### PR TITLE
Enhancement/mvp 176 migrate to new search mechanism

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/GetableSearchImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/GetableSearchImpl.java
@@ -36,13 +36,20 @@ public class GetableSearchImpl implements GetableSearch {
             );
             out.setType(InternalScanPb.ScanBoundaryCase.TAG_SCAN);
         } else {
-            throw new LHValidationError("Scan boundary not supported yet");
+            out.setBoundedObjectIdScan(
+                (InternalScanPb.BoundedObjectIdScanPb) searchScanBoundary.buildScanProto()
+            );
+            out.setType(InternalScanPb.ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN);
+            out.setResultType(ScanResultTypePb.OBJECT);
+            out.setStoreName(ServerTopology.CORE_REPARTITION_STORE);
+            out.setPartitionKey(searchScanBoundary.getSearchAttributeString());
         }
+
         if (tagStorageType == TagStorageTypePb.REMOTE) {
             out.setStoreName(ServerTopology.CORE_REPARTITION_STORE);
             out.setResultType(ScanResultTypePb.OBJECT_ID);
             out.setPartitionKey(searchScanBoundary.getSearchAttributeString());
-        } else {
+        } else if (tagStorageType == TagStorageTypePb.LOCAL) {
             out.storeName = ServerTopology.CORE_STORE;
             out.resultType = ScanResultTypePb.OBJECT_ID;
         }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/ObjectIdScanBoundaryStrategy.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/ObjectIdScanBoundaryStrategy.java
@@ -1,0 +1,40 @@
+package io.littlehorse.server.streamsimpl.lhinternalscan;
+
+import com.google.protobuf.Message;
+import io.littlehorse.common.proto.InternalScanPb;
+
+public class ObjectIdScanBoundaryStrategy implements SearchScanBoundaryStrategy {
+
+    private String startKey;
+    private String endKey;
+
+    private String objectId;
+
+    public ObjectIdScanBoundaryStrategy(String objectId) {
+        this(objectId, objectId + "/", objectId + "/~");
+    }
+
+    public ObjectIdScanBoundaryStrategy(
+        String objectId,
+        String startKey,
+        String endKey
+    ) {
+        this.startKey = startKey;
+        this.endKey = endKey;
+        this.objectId = objectId;
+    }
+
+    @Override
+    public Message buildScanProto() {
+        return InternalScanPb.BoundedObjectIdScanPb
+            .newBuilder()
+            .setStartObjectId(startKey)
+            .setEndObjectId(endKey)
+            .build();
+    }
+
+    @Override
+    public String getSearchAttributeString() {
+        return objectId;
+    }
+}

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/PublicScanRequest.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/PublicScanRequest.java
@@ -40,25 +40,17 @@ public abstract class PublicScanRequest<
         return limit;
     }
 
-    @Deprecated
-    protected abstract InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError;
-
     public InternalScan getInternalSearch(LHGlobalMetaStores stores)
         throws LHValidationError {
         SearchScanBoundaryStrategy searchScanBoundaryStrategy = getScanBoundary(
             getSearchAttributeString()
         );
-        if (searchScanBoundaryStrategy != null) {
-            getableSearch =
-                new GetableSearchImpl(getObjectType(), searchScanBoundaryStrategy);
-        }
-        InternalScan out;
-        if (getableSearch == null) {
-            out = startInternalSearch(stores);
-        } else {
-            out = getableSearch.buildInternalScan(stores, indexTypeForSearch());
-        }
+        getableSearch =
+            new GetableSearchImpl(getObjectType(), searchScanBoundaryStrategy);
+        InternalScan out = getableSearch.buildInternalScan(
+            stores,
+            indexTypeForSearch(stores)
+        );
         if (out.limit == 0) out.limit = getLimit();
         out.bookmark = bookmark;
         out.objectType = getObjectType();
@@ -97,7 +89,8 @@ public abstract class PublicScanRequest<
      * @throws LHValidationError if there are validation errors in the input.
      */
 
-    public abstract TagStorageTypePb indexTypeForSearch() throws LHValidationError;
+    public abstract TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError;
 
     /**
      * Validate input parameters for the search operation
@@ -107,5 +100,5 @@ public abstract class PublicScanRequest<
 
     public abstract SearchScanBoundaryStrategy getScanBoundary(
         String searchAttributeString
-    );
+    ) throws LHValidationError;
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListExternalEvents.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListExternalEvents.java
@@ -4,15 +4,11 @@ import com.google.protobuf.Message;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.wfrun.ExternalEvent;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.sdk.common.proto.ExternalEventPb;
 import io.littlehorse.sdk.common.proto.ListExternalEventsPb;
 import io.littlehorse.sdk.common.proto.ListExternalEventsReplyPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
@@ -41,12 +37,9 @@ public class ListExternalEvents
         return GetableClassEnumPb.EXTERNAL_EVENT;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        return null;
-    }
-
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return TagStorageTypePb.LOCAL;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListExternalEvents.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListExternalEvents.java
@@ -14,6 +14,7 @@ import io.littlehorse.sdk.common.proto.ListExternalEventsPb;
 import io.littlehorse.sdk.common.proto.ListExternalEventsReplyPb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.ListExternalEventsReply;
@@ -41,23 +42,12 @@ public class ListExternalEvents
     }
 
     public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        InternalScan out = new InternalScan();
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT;
-        out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-        out.partitionKey = wfRunId;
-        out.boundedObjectIdScan =
-            BoundedObjectIdScanPb
-                .newBuilder()
-                .setStartObjectId(wfRunId + "/")
-                .setEndObjectId(wfRunId + "/~")
-                .build();
-        return out;
+        return null;
     }
 
     @Override
     public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+        return TagStorageTypePb.LOCAL;
     }
 
     @Override
@@ -65,6 +55,6 @@ public class ListExternalEvents
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        return new ObjectIdScanBoundaryStrategy(wfRunId);
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListNodeRuns.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListNodeRuns.java
@@ -14,6 +14,7 @@ import io.littlehorse.sdk.common.proto.ListNodeRunsReplyPb;
 import io.littlehorse.sdk.common.proto.NodeRunPb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.ListNodeRunsReply;
@@ -41,23 +42,12 @@ public class ListNodeRuns
     }
 
     public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        InternalScan out = new InternalScan();
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT;
-        out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-        out.partitionKey = wfRunId;
-        out.boundedObjectIdScan =
-            BoundedObjectIdScanPb
-                .newBuilder()
-                .setStartObjectId(wfRunId + "/")
-                .setEndObjectId(wfRunId + "/~")
-                .build();
-        return out;
+        return null;
     }
 
     @Override
     public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+        return TagStorageTypePb.LOCAL;
     }
 
     @Override
@@ -65,6 +55,6 @@ public class ListNodeRuns
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        return new ObjectIdScanBoundaryStrategy(wfRunId);
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListNodeRuns.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListNodeRuns.java
@@ -4,15 +4,11 @@ import com.google.protobuf.Message;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.wfrun.NodeRun;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.sdk.common.proto.ListNodeRunsPb;
 import io.littlehorse.sdk.common.proto.ListNodeRunsReplyPb;
 import io.littlehorse.sdk.common.proto.NodeRunPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
@@ -41,12 +37,9 @@ public class ListNodeRuns
         return GetableClassEnumPb.NODE_RUN;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        return null;
-    }
-
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return TagStorageTypePb.LOCAL;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListTaskMetrics.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListTaskMetrics.java
@@ -4,9 +4,6 @@ import com.google.protobuf.Message;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.metrics.TaskDefMetrics;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.common.util.LHUtil;
@@ -14,7 +11,6 @@ import io.littlehorse.sdk.common.proto.ListTaskMetricsPb;
 import io.littlehorse.sdk.common.proto.ListTaskMetricsReplyPb;
 import io.littlehorse.sdk.common.proto.MetricsWindowLengthPb;
 import io.littlehorse.sdk.common.proto.TaskDefMetricsPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
@@ -58,12 +54,9 @@ public class ListTaskMetrics
         return GetableClassEnumPb.TASK_DEF_METRICS;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        return null;
-    }
-
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return TagStorageTypePb.LOCAL;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListVariables.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListVariables.java
@@ -4,15 +4,11 @@ import com.google.protobuf.Message;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.wfrun.Variable;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.sdk.common.proto.ListVariablesPb;
 import io.littlehorse.sdk.common.proto.ListVariablesReplyPb;
 import io.littlehorse.sdk.common.proto.VariablePb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
@@ -41,12 +37,9 @@ public class ListVariables
         return GetableClassEnumPb.VARIABLE;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        return null;
-    }
-
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return TagStorageTypePb.LOCAL;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListVariables.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListVariables.java
@@ -14,6 +14,7 @@ import io.littlehorse.sdk.common.proto.ListVariablesReplyPb;
 import io.littlehorse.sdk.common.proto.VariablePb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.ListVariablesReply;
@@ -41,22 +42,12 @@ public class ListVariables
     }
 
     public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        InternalScan out = new InternalScan();
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT;
-        out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-        out.partitionKey = wfRunId;
-        out.boundedObjectIdScan =
-            BoundedObjectIdScanPb
-                .newBuilder()
-                .setStartObjectId(wfRunId + "/")
-                .build();
-        return out;
+        return null;
     }
 
     @Override
     public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+        return TagStorageTypePb.LOCAL;
     }
 
     @Override
@@ -64,6 +55,6 @@ public class ListVariables
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        return new ObjectIdScanBoundaryStrategy(wfRunId);
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListWfMetrics.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListWfMetrics.java
@@ -4,9 +4,6 @@ import com.google.protobuf.Message;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.metrics.WfSpecMetrics;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.common.util.LHUtil;
@@ -14,7 +11,6 @@ import io.littlehorse.sdk.common.proto.ListWfMetricsPb;
 import io.littlehorse.sdk.common.proto.ListWfMetricsReplyPb;
 import io.littlehorse.sdk.common.proto.MetricsWindowLengthPb;
 import io.littlehorse.sdk.common.proto.WfSpecMetricsPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
@@ -61,12 +57,9 @@ public class ListWfMetrics
         return GetableClassEnumPb.WF_SPEC_METRICS;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        return null;
-    }
-
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return null;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListWfMetrics.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/ListWfMetrics.java
@@ -16,6 +16,7 @@ import io.littlehorse.sdk.common.proto.MetricsWindowLengthPb;
 import io.littlehorse.sdk.common.proto.WfSpecMetricsPb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.ListWfMetricsReply;
@@ -53,6 +54,7 @@ public class ListWfMetrics
         windowLength = p.getWindowLength();
         wfSpecName = p.getWfSpecName();
         wfSpecVersion = p.getWfSpecVersion();
+        limit = numWindows;
     }
 
     public GetableClassEnumPb getObjectType() {
@@ -60,17 +62,19 @@ public class ListWfMetrics
     }
 
     public InternalScan startInternalSearch(LHGlobalMetaStores stores) {
-        InternalScan out = new InternalScan();
-        out.storeName = ServerTopology.CORE_REPARTITION_STORE;
-        out.resultType = ScanResultTypePb.OBJECT;
-        out.limit = numWindows;
-        out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
+        return null;
+    }
 
-        // TODO: Need to make WfSpecName a required field. When client wants to
-        // search for all WfSpecs, then they need to provide a reserved WfSpec name
-        // such as '__LH_ALL'
-        out.partitionKey = wfSpecName;
+    @Override
+    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+        return null;
+    }
 
+    @Override
+    public void validate() throws LHValidationError {}
+
+    @Override
+    public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
         String endKey = WfSpecMetrics.getObjectId(
             windowLength,
             lastWindowStart,
@@ -86,26 +90,6 @@ public class ListWfMetrics
             wfSpecName,
             wfSpecVersion
         );
-        out.boundedObjectIdScan =
-            BoundedObjectIdScanPb
-                .newBuilder()
-                .setStartObjectId(startKey)
-                .setEndObjectId(endKey)
-                .build();
-
-        return out;
-    }
-
-    @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
-    }
-
-    @Override
-    public void validate() throws LHValidationError {}
-
-    @Override
-    public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        return new ObjectIdScanBoundaryStrategy(wfSpecName, startKey, endKey);
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchExternalEvent.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchExternalEvent.java
@@ -7,20 +7,17 @@ import io.littlehorse.common.model.objectId.ExternalEventId;
 import io.littlehorse.common.model.wfrun.ExternalEvent;
 import io.littlehorse.common.proto.BookmarkPb;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb;
-import io.littlehorse.common.proto.InternalScanPb.BoundedObjectIdScanPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
 import io.littlehorse.sdk.common.proto.ExternalEventIdPb;
 import io.littlehorse.sdk.common.proto.SearchExternalEventPb;
 import io.littlehorse.sdk.common.proto.SearchExternalEventPb.ExtEvtCriteriaCase;
 import io.littlehorse.sdk.common.proto.SearchExternalEventReplyPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
+import io.littlehorse.server.streamsimpl.lhinternalscan.TagScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.SearchExternalEventReply;
 import io.littlehorse.server.streamsimpl.storeinternals.GetableIndex;
 import io.littlehorse.server.streamsimpl.storeinternals.index.Attribute;
@@ -108,62 +105,6 @@ public class SearchExternalEvent
         return out;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        InternalScan out = new InternalScan();
-
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT_ID;
-        if (type == ExtEvtCriteriaCase.WF_RUN_ID) {
-            out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-            out.partitionKey = wfRunId;
-            out.boundedObjectIdScan =
-                BoundedObjectIdScanPb
-                    .newBuilder()
-                    .setStartObjectId(wfRunId + "/")
-                    .build();
-        } else if (
-            type.equals(ExtEvtCriteriaCase.EXTERNAL_EVENT_DEF_NAME_AND_STATUS)
-        ) {
-            out.setType(ScanBoundaryCase.TAG_SCAN);
-            InternalScanPb.TagScanPb.Builder tagScanBuilder = InternalScanPb.TagScanPb.newBuilder();
-            tagScanBuilder.setKeyPrefix(getSearchAttributeString());
-            out.setTagScan(tagScanBuilder.build());
-            List<String> searchAttributes = getSearchAttributes()
-                .stream()
-                .map(Attribute::getEscapedKey)
-                .toList();
-            List<GetableIndex<? extends Getable<?>>> indexConfigurations = new ExternalEvent()
-                .getIndexConfigurations();
-            GetableIndex<? extends Getable<?>> getableIndex = indexConfigurations
-                .stream()
-                .filter(getableIndexConfiguration -> {
-                    return getableIndexConfiguration.searchAttributesMatch(
-                        searchAttributes
-                    );
-                })
-                .findFirst()
-                .orElse(null);
-            if (getableIndex != null) {
-                if (
-                    getableIndex.getTagStorageTypePb().get() == TagStorageTypePb.LOCAL
-                ) {
-                    out.setStoreName(ServerTopology.CORE_STORE);
-                    out.setResultType(ScanResultTypePb.OBJECT_ID);
-                } else {
-                    out.setStoreName(ServerTopology.CORE_REPARTITION_STORE);
-                    out.setResultType(ScanResultTypePb.OBJECT_ID);
-                    out.setPartitionKey(getSearchAttributeString());
-                }
-            }
-        } else {
-            throw new IllegalArgumentException(
-                "%s type is not supported yet".formatted(type)
-            );
-        }
-        return out;
-    }
-
     public List<Attribute> getSearchAttributes() {
         return isClaimed
             .map(claimed ->
@@ -176,8 +117,28 @@ public class SearchExternalEvent
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
+        List<String> searchAttributes = getSearchAttributes()
+            .stream()
+            .map(Attribute::getEscapedKey)
+            .toList();
+        List<GetableIndex<? extends Getable<?>>> indexConfigurations = new ExternalEvent()
+            .getIndexConfigurations();
+        GetableIndex<? extends Getable<?>> getableIndex = indexConfigurations
+            .stream()
+            .filter(getableIndexConfiguration -> {
+                return getableIndexConfiguration.searchAttributesMatch(
+                    searchAttributes
+                );
+            })
+            .findFirst()
+            .orElse(null);
+        if (getableIndex != null) {
+            return getableIndex.getTagStorageTypePb().get();
+        } else {
+            return TagStorageTypePb.LOCAL;
+        }
     }
 
     @Override
@@ -185,6 +146,20 @@ public class SearchExternalEvent
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        if (type == ExtEvtCriteriaCase.WF_RUN_ID) {
+            return new ObjectIdScanBoundaryStrategy(wfRunId);
+        } else if (
+            type.equals(ExtEvtCriteriaCase.EXTERNAL_EVENT_DEF_NAME_AND_STATUS)
+        ) {
+            return new TagScanBoundaryStrategy(
+                searchAttributeString,
+                Optional.empty(),
+                Optional.empty()
+            );
+        } else {
+            throw new IllegalArgumentException(
+                "%s type is not supported yet".formatted(type)
+            );
+        }
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchExternalEvent.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchExternalEvent.java
@@ -34,7 +34,7 @@ public class SearchExternalEvent
     public ExtEvtCriteriaCase type;
     public String wfRunId;
     private String externalEventDefName;
-    private Optional<Boolean> isClaimed;
+    private Optional<Boolean> isClaimed = Optional.empty();
 
     public GetableClassEnumPb getObjectType() {
         return GetableClassEnumPb.EXTERNAL_EVENT;

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchNodeRun.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchNodeRun.java
@@ -94,7 +94,7 @@ public class SearchNodeRun
         if (type == NoderunCriteriaCase.WF_RUN_ID) {
             return new ObjectIdScanBoundaryStrategy(wfRunId);
         } else {
-            throw new LHValidationError("Yikes, unimplemented type: " + type);
+            throw new LHValidationError("Unimplemented type: " + type);
         }
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchTaskRun.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchTaskRun.java
@@ -1,28 +1,28 @@
 package io.littlehorse.server.streamsimpl.lhinternalscan.publicrequests;
 
 import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
 import io.littlehorse.common.exceptions.LHValidationError;
 import io.littlehorse.common.model.objectId.TaskRunId;
 import io.littlehorse.common.proto.BookmarkPb;
 import io.littlehorse.common.proto.GetableClassEnumPb;
-import io.littlehorse.common.proto.InternalScanPb.ScanBoundaryCase;
-import io.littlehorse.common.proto.InternalScanPb.TagScanPb;
-import io.littlehorse.common.proto.ScanResultTypePb;
 import io.littlehorse.common.proto.TagStorageTypePb;
 import io.littlehorse.common.util.LHGlobalMetaStores;
+import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.SearchTaskRunPb;
 import io.littlehorse.sdk.common.proto.SearchTaskRunPb.ByTaskDefPb;
 import io.littlehorse.sdk.common.proto.SearchTaskRunPb.StatusAndTaskDefPb;
 import io.littlehorse.sdk.common.proto.SearchTaskRunPb.TaskRunCriteriaCase;
 import io.littlehorse.sdk.common.proto.SearchTaskRunReplyPb;
 import io.littlehorse.sdk.common.proto.TaskRunIdPb;
-import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
+import io.littlehorse.server.streamsimpl.lhinternalscan.TagScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.SearchTaskRunReply;
 import io.littlehorse.server.streamsimpl.storeinternals.index.Attribute;
 import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -96,50 +96,30 @@ public class SearchTaskRun
         return out;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        InternalScan out = new InternalScan();
-        out.setResultType(ScanResultTypePb.OBJECT_ID);
-        out.setObjectType(getObjectType());
-
+    private Timestamp getEarliestStart() {
         if (type == TaskRunCriteriaCase.TASK_DEF) {
-            out.storeName = ServerTopology.CORE_STORE;
-            out.type = ScanBoundaryCase.TAG_SCAN;
-
-            // partiiton key should be null, since it's a LOCAL search.
-            TagScanPb.Builder scanBuilder = TagScanPb
-                .newBuilder()
-                .setKeyPrefix(getSearchAttributeString());
-
             if (taskDef.hasEarliestStart()) {
-                scanBuilder.setEarliestCreateTime(taskDef.getEarliestStart());
+                return taskDef.getEarliestStart();
             }
-            if (taskDef.hasLatestStart()) {
-                scanBuilder.setLatestCreateTime(taskDef.getLatestStart());
-            }
-            out.setTagScan(scanBuilder.build());
         } else if (type == TaskRunCriteriaCase.STATUS_AND_TASK_DEF) {
-            out.storeName = ServerTopology.CORE_STORE;
-            out.type = ScanBoundaryCase.TAG_SCAN;
-
-            TagScanPb.Builder scanBuilder = TagScanPb
-                .newBuilder()
-                .setKeyPrefix(getSearchAttributeString());
-
             if (statusAndTaskDef.hasEarliestStart()) {
-                scanBuilder.setEarliestCreateTime(
-                    statusAndTaskDef.getEarliestStart()
-                );
+                return statusAndTaskDef.getEarliestStart();
             }
-            if (statusAndTaskDef.hasLatestStart()) {
-                scanBuilder.setLatestCreateTime(statusAndTaskDef.getLatestStart());
-            }
-
-            out.setTagScan(scanBuilder.build());
-        } else {
-            throw new LHValidationError("Unimplemented search type: " + type);
         }
-        return out;
+        return null;
+    }
+
+    private Timestamp getLatestStart() {
+        if (type == TaskRunCriteriaCase.TASK_DEF) {
+            if (taskDef.hasLatestStart()) {
+                return taskDef.getLatestStart();
+            }
+        } else if (type == TaskRunCriteriaCase.STATUS_AND_TASK_DEF) {
+            if (statusAndTaskDef.hasLatestStart()) {
+                return statusAndTaskDef.getLatestStart();
+            }
+        }
+        return null;
     }
 
     @Override
@@ -157,15 +137,28 @@ public class SearchTaskRun
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
+        return TagStorageTypePb.LOCAL;
     }
 
     @Override
     public void validate() throws LHValidationError {}
 
     @Override
-    public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+    public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString)
+        throws LHValidationError {
+        if (
+            type == TaskRunCriteriaCase.TASK_DEF ||
+            type == TaskRunCriteriaCase.STATUS_AND_TASK_DEF
+        ) {
+            return new TagScanBoundaryStrategy(
+                searchAttributeString,
+                Optional.ofNullable(LHUtil.fromProtoTs(getEarliestStart())),
+                Optional.ofNullable(LHUtil.fromProtoTs(getLatestStart()))
+            );
+        } else {
+            throw new LHValidationError("Unimplemented search type: " + type);
+        }
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchUserTaskRun.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchUserTaskRun.java
@@ -132,12 +132,6 @@ public class SearchUserTaskRun
         }
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        // Replaced by GetableSearchStrategy
-        return null;
-    }
-
     private Optional<TagStorageTypePb> tagStorageTypePbByStatus() {
         return Optional
             .ofNullable(status)
@@ -177,7 +171,8 @@ public class SearchUserTaskRun
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         TagStorageTypePb tagStorageTypePb = tagStorageTypePbByUserId()
             .orElseGet(() -> tagStorageTypePbByStatus().orElse(null));
         if (tagStorageTypePb == null) {

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchVariable.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchVariable.java
@@ -23,8 +23,10 @@ import io.littlehorse.sdk.common.proto.VariableIdPb;
 import io.littlehorse.sdk.common.proto.VariableValuePb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
+import io.littlehorse.server.streamsimpl.lhinternalscan.TagScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.SearchVariableReply;
 import io.littlehorse.server.streamsimpl.storeinternals.GetableIndex;
 import io.littlehorse.server.streamsimpl.storeinternals.index.Attribute;
@@ -100,67 +102,6 @@ public class SearchVariable
         return out;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        InternalScan out = new InternalScan();
-
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT_ID;
-
-        if (type == VariableCriteriaCase.WF_RUN_ID) {
-            out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-            out.partitionKey = wfRunId;
-            out.boundedObjectIdScan =
-                BoundedObjectIdScanPb
-                    .newBuilder()
-                    .setStartObjectId(wfRunId + "/")
-                    .setEndObjectId(wfRunId + "/~")
-                    .build();
-        } else if (type == VariableCriteriaCase.VALUE) {
-            out.type = ScanBoundaryCase.TAG_SCAN;
-
-            // This may change depending on the type of the tag. For example,
-            // sparse strings (such as emails) may be REMOTE_HASH_UNCOUNTED; whereas
-            // hot boolean variables may be LOCAL_UNCOUNTED
-            out.partitionKey = null;
-
-            if (value.hasWfSpecVersion()) {
-                wfSpecVersion = value.getWfSpecVersion();
-                WfSpec spec = stores.getWfSpec(value.getWfSpecName(), wfSpecVersion);
-                if (spec == null) {
-                    throw new LHValidationError(
-                        null,
-                        "Couldn't find specified wfSpec"
-                    );
-                }
-            } else {
-                WfSpec spec = stores.getWfSpec(value.getWfSpecName(), null);
-                if (spec == null) {
-                    throw new LHValidationError(
-                        null,
-                        "Search refers to missing WfSpec"
-                    );
-                } else {
-                    wfSpecVersion = spec.version;
-                }
-            }
-            out.tagScan =
-                TagScanPb
-                    .newBuilder()
-                    .setKeyPrefix(getSearchAttributeString())
-                    .build();
-            TagStorageTypePb tagStorageTypePb = getStorageTypeFromVariableIndexConfiguration()
-                .orElse(null);
-            if (tagStorageTypePb != null) {
-                setSearchTypeFromTagStorageType(tagStorageTypePb, out, wfSpecVersion);
-            } else {
-                setSearchTypeFromWfSpec(out, wfSpecVersion, stores);
-            }
-        }
-
-        return out;
-    }
-
     private Optional<TagStorageTypePb> getStorageTypeFromVariableIndexConfiguration() {
         return new Variable()
             .getIndexConfigurations()
@@ -177,14 +118,10 @@ public class SearchVariable
             .findFirst();
     }
 
-    private void setSearchTypeFromWfSpec(
-        InternalScan out,
-        int wfSpecVersion,
-        LHGlobalMetaStores stores
-    ) throws LHValidationError {
+    private TagStorageTypePb indexTypeForSearchFromWfSpec(LHGlobalMetaStores stores) {
         WfSpec spec = stores.getWfSpec(value.getWfSpecName(), null);
 
-        TagStorageTypePb tagStorageTypePb = spec
+        return spec
             .getThreadSpecs()
             .entrySet()
             .stream()
@@ -198,26 +135,6 @@ public class SearchVariable
             .map(VariableDef::getTagStorageTypePb)
             .findFirst()
             .orElse(null);
-        if (tagStorageTypePb != null) {
-            setSearchTypeFromTagStorageType(tagStorageTypePb, out, wfSpecVersion);
-        }
-    }
-
-    private void setSearchTypeFromTagStorageType(
-        TagStorageTypePb tagStorageTypePb,
-        InternalScan out,
-        int wfSpecVersion
-    ) throws LHValidationError {
-        if (tagStorageTypePb == TagStorageTypePb.LOCAL) {
-            // Local Tag Scan (All Partitions Tag Scan)
-            out.setStoreName(ServerTopology.CORE_STORE);
-            out.setResultType(ScanResultTypePb.OBJECT_ID);
-        } else {
-            // Remote Tag Scan (Specific Partition Tag Scan)
-            out.setStoreName(ServerTopology.CORE_REPARTITION_STORE);
-            out.setResultType(ScanResultTypePb.OBJECT_ID);
-            out.setPartitionKey(getSearchAttributeString());
-        }
     }
 
     public List<Attribute> getSearchAttributes() throws LHValidationError {
@@ -229,8 +146,10 @@ public class SearchVariable
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
-        return null;
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
+        return getStorageTypeFromVariableIndexConfiguration()
+            .orElse(indexTypeForSearchFromWfSpec(stores));
     }
 
     @Override
@@ -238,6 +157,15 @@ public class SearchVariable
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
+        if (type == VariableCriteriaCase.WF_RUN_ID) {
+            return new ObjectIdScanBoundaryStrategy(wfRunId);
+        } else if (type == VariableCriteriaCase.VALUE) {
+            return new TagScanBoundaryStrategy(
+                searchAttributeString,
+                Optional.empty(),
+                Optional.empty()
+            );
+        }
         return null;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchWfRun.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchWfRun.java
@@ -104,11 +104,6 @@ public class SearchWfRun
         return out;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        return null;
-    }
-
     private List<WfrunCriteriaCase> supportedCriteriaCases() {
         return List.of(
             WfrunCriteriaCase.STATUS_AND_SPEC,
@@ -154,7 +149,8 @@ public class SearchWfRun
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         List<String> searchAttributeKeys = getSearchAttributes()
             .stream()
             .map(Attribute::getEscapedKey)

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchWfSpec.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/lhinternalscan/publicrequests/SearchWfSpec.java
@@ -19,11 +19,14 @@ import io.littlehorse.sdk.common.proto.SearchWfSpecReplyPb;
 import io.littlehorse.sdk.common.proto.WfSpecIdPb;
 import io.littlehorse.server.streamsimpl.ServerTopology;
 import io.littlehorse.server.streamsimpl.lhinternalscan.InternalScan;
+import io.littlehorse.server.streamsimpl.lhinternalscan.ObjectIdScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streamsimpl.lhinternalscan.SearchScanBoundaryStrategy;
+import io.littlehorse.server.streamsimpl.lhinternalscan.TagScanBoundaryStrategy;
 import io.littlehorse.server.streamsimpl.lhinternalscan.publicsearchreplies.SearchWfSpecReply;
 import io.littlehorse.server.streamsimpl.storeinternals.index.Attribute;
 import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -104,54 +107,14 @@ public class SearchWfSpec
         return out;
     }
 
-    public InternalScan startInternalSearch(LHGlobalMetaStores stores)
-        throws LHValidationError {
-        InternalScan out = new InternalScan();
-        out.storeName = ServerTopology.CORE_STORE;
-        out.resultType = ScanResultTypePb.OBJECT_ID;
-        out.type = ScanBoundaryCase.BOUNDED_OBJECT_ID_SCAN;
-        out.partitionKey = LHConstants.META_PARTITION_KEY;
-
-        if (name != null && !name.equals("")) {
-            // exact match on name
-            out.boundedObjectIdScan =
-                BoundedObjectIdScanPb
-                    .newBuilder()
-                    .setStartObjectId(name + "/")
-                    .setEndObjectId(name + "/~")
-                    .build();
-        } else if (prefix != null && !prefix.equals("")) {
-            // Prefix scan on name
-            out.boundedObjectIdScan =
-                BoundedObjectIdScanPb
-                    .newBuilder()
-                    .setStartObjectId(prefix)
-                    .setEndObjectId(prefix + "~")
-                    .build();
-        } else if (!Strings.isNullOrEmpty(taskDefName)) {
-            out.partitionKey = null;
-            out.type = ScanBoundaryCase.TAG_SCAN;
-            out.tagScan =
-                InternalScanPb.TagScanPb
-                    .newBuilder()
-                    .setKeyPrefix(getSearchAttributeString())
-                    .build();
-        } else {
-            // that means we want to search all wfSpecs
-            out.boundedObjectIdScan =
-                BoundedObjectIdScanPb.newBuilder().setStartObjectId("").build();
-        }
-
-        return out;
-    }
-
     @Override
-    public List<Attribute> getSearchAttributes() throws LHValidationError {
+    public List<Attribute> getSearchAttributes() {
         return List.of(new Attribute("taskDef", taskDefName));
     }
 
     @Override
-    public TagStorageTypePb indexTypeForSearch() throws LHValidationError {
+    public TagStorageTypePb indexTypeForSearch(LHGlobalMetaStores stores)
+        throws LHValidationError {
         return null;
     }
 
@@ -160,6 +123,30 @@ public class SearchWfSpec
 
     @Override
     public SearchScanBoundaryStrategy getScanBoundary(String searchAttributeString) {
-        return null;
+        if (name != null && !name.equals("")) {
+            return new ObjectIdScanBoundaryStrategy(
+                LHConstants.META_PARTITION_KEY,
+                name + "/",
+                name + "/~"
+            );
+        } else if (prefix != null && !prefix.equals("")) {
+            return new ObjectIdScanBoundaryStrategy(
+                LHConstants.META_PARTITION_KEY,
+                name + "/",
+                name + "/~"
+            );
+        } else if (!Strings.isNullOrEmpty(taskDefName)) {
+            return new TagScanBoundaryStrategy(
+                searchAttributeString,
+                Optional.empty(),
+                Optional.empty()
+            );
+        } else {
+            return new ObjectIdScanBoundaryStrategy(
+                LHConstants.META_PARTITION_KEY,
+                "",
+                "~"
+            );
+        }
     }
 }


### PR DESCRIPTION
Another step in order to improve Search mechanism.

PublicScanRequest types usually do this logic on tag scan:

- Find if the search should be Local or Remote
- Set storage name (Core or repartition)
- Build attributes from proto Search class
- Create tag prefix from attributes
- handle bookmark and timestamps.

step 3 and 4 were addressed by this [PR](https://github.com/littlehorse-enterprises/littlehorse/pull/10)

The intention for this PR is reduce the logic that we have in `PublicScanRequest` types. This PR only refactors for Search User Task Run and WfRun. next PR will refactor other types of searches. 