### PR TITLE
Trace RocksDB Puts/Gets/Deletes

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -993,6 +993,8 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         taskWorkerGroupPuts.clear();
         taskMetricPuts = new HashMap<>();
         wfMetricPuts = new HashMap<>();
+
+        localStore.clearCommandMetrics(getCommand());
     }
 
     public void forwardAndClearMetricsUpdatesUntil() {


### PR DESCRIPTION
This PR adds traces that tell how many puts/gets/deletes there were when processing a single Command. This will be used to quantify the impact of the subsequent PR that moves the TagCache and Getable into the same RocksDB entry.

Note that as of now, when running the `example-hundred-tasks`, the completion of the TaskRun results in:

```
REPORT_TASK_RUN: 5 gets, 16 puts, 2 deletes
```