### PR TITLE
Optimization 2/incremental combine tags cache getable

### DIFF
--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/lifecycle/AEImproperTaskNode.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/lifecycle/AEImproperTaskNode.java
@@ -115,7 +115,7 @@ public class AEImproperTaskNode extends Test {
 
         WfRunPb wfRun = client.getWfRun(failWfRun);
         if (wfRun.getStatus() != LHStatusPb.ERROR) {
-            throw new RuntimeException("Wf " + failWfRun + " hould have failed!");
+            throw new RuntimeException("Wf " + failWfRun + " should have failed!");
         }
         NodeRunPb nodeRun = client.getNodeRun(failWfRun, 0, 2);
         FailurePb failure = nodeRun.getFailures(0);

--- a/server/src/main/java/io/littlehorse/common/LHDAO.java
+++ b/server/src/main/java/io/littlehorse/common/LHDAO.java
@@ -130,7 +130,7 @@ public interface LHDAO extends LHGlobalMetaStores {
      * Clear any dirty cache if necessary, BUT also mark any wfRun's that were
      * in processing as ERROR and note an error message.
      */
-    public void abortChangesAndMarkWfRunFailed(String message);
+    void abortChangesAndMarkWfRunFailed(Throwable failure, String wfRunId);
 
     /*
      * Commit changes to the backing store.

--- a/server/src/main/java/io/littlehorse/common/model/command/subcommandresponse/DeleteObjectReply.java
+++ b/server/src/main/java/io/littlehorse/common/model/command/subcommandresponse/DeleteObjectReply.java
@@ -3,8 +3,16 @@ package io.littlehorse.common.model.command.subcommandresponse;
 import com.google.protobuf.Message;
 import io.littlehorse.common.model.command.AbstractResponse;
 import io.littlehorse.sdk.common.proto.DeleteObjectReplyPb;
+import io.littlehorse.sdk.common.proto.LHResponseCodePb;
 
 public class DeleteObjectReply extends AbstractResponse<DeleteObjectReplyPb> {
+
+    public DeleteObjectReply() {}
+
+    public DeleteObjectReply(LHResponseCodePb code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 
     public Class<DeleteObjectReplyPb> getProtoBaseClass() {
         return DeleteObjectReplyPb.class;

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -196,7 +196,7 @@ import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
 import io.littlehorse.server.streamsimpl.taskqueue.PollTaskRequestObserver;
 import io.littlehorse.server.streamsimpl.taskqueue.TaskQueueManager;
 import io.littlehorse.server.streamsimpl.util.GETStreamObserver;
-import io.littlehorse.server.streamsimpl.util.GETStreamObserverPepe;
+import io.littlehorse.server.streamsimpl.util.GETStreamObserverNew;
 import io.littlehorse.server.streamsimpl.util.POSTStreamObserver;
 import java.io.File;
 import java.io.IOException;
@@ -566,7 +566,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getWfRun(WfRunIdPb req, StreamObserver<GetWfRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverNew<>(
             ctx,
             WfRun.class,
             GetWfRunReplyPb.class,
@@ -584,7 +584,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getNodeRun(NodeRunIdPb req, StreamObserver<GetNodeRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverNew<>(
             ctx,
             NodeRun.class,
             GetNodeRunReplyPb.class,
@@ -608,7 +608,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getTaskRun(TaskRunIdPb req, StreamObserver<GetTaskRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverNew<>(
             ctx,
             TaskRun.class,
             GetTaskRunReplyPb.class,
@@ -630,7 +630,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
         UserTaskRunIdPb req,
         StreamObserver<GetUserTaskRunReplyPb> ctx
     ) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverNew<>(
             ctx,
             UserTaskRun.class,
             GetUserTaskRunReplyPb.class,

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -608,7 +608,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getTaskRun(TaskRunIdPb req, StreamObserver<GetTaskRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserver<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
             ctx,
             TaskRun.class,
             GetTaskRunReplyPb.class,

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -196,6 +196,7 @@ import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
 import io.littlehorse.server.streamsimpl.taskqueue.PollTaskRequestObserver;
 import io.littlehorse.server.streamsimpl.taskqueue.TaskQueueManager;
 import io.littlehorse.server.streamsimpl.util.GETStreamObserver;
+import io.littlehorse.server.streamsimpl.util.GETStreamObserverPepe;
 import io.littlehorse.server.streamsimpl.util.POSTStreamObserver;
 import java.io.File;
 import java.io.IOException;
@@ -583,7 +584,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getNodeRun(NodeRunIdPb req, StreamObserver<GetNodeRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserver<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
             ctx,
             NodeRun.class,
             GetNodeRunReplyPb.class,

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -566,7 +566,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
 
     @Override
     public void getWfRun(WfRunIdPb req, StreamObserver<GetWfRunReplyPb> ctx) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserver<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
             ctx,
             WfRun.class,
             GetWfRunReplyPb.class,

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -630,7 +630,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
         UserTaskRunIdPb req,
         StreamObserver<GetUserTaskRunReplyPb> ctx
     ) {
-        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserver<>(
+        StreamObserver<CentralStoreQueryReplyPb> observer = new GETStreamObserverPepe<>(
             ctx,
             UserTaskRun.class,
             GetUserTaskRunReplyPb.class,

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/CommandProcessor.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/CommandProcessor.java
@@ -100,7 +100,8 @@ public class CommandProcessor
             if (command.hasResponse() && command.getCommandId() != null) {
                 server.sendErrorToClient(command.getCommandId(), exn);
             }
-            dao.abortChangesAndMarkWfRunFailed(exn.getMessage());
+            // Note that command id's are wfRunId's too.
+            dao.abortChangesAndMarkWfRunFailed(exn, command.getPartitionKey());
             // Should we have a DLQ? I don't think that makes sense...the internals
             // of a database like Postgres don't have a DLQ for their WAL. However,
             // we should add metrics. If we get here, then A Very Bad Thing has

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -179,10 +179,10 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
                 getable.getStoreKey()
         );
 
-        StoredGetable<U, T> bufferedResult = uncommittedChanges.get(getable.getStoreKey());
+        StoredGetable<U, T> uncommittedEntity = uncommittedChanges.get(getable.getStoreKey());
 
-        if (bufferedResult != null) {
-            if (bufferedResult.getStoredObject() != getable) {
+        if (uncommittedEntity != null) {
+            if (uncommittedEntity.getStoredObject() != getable) {
                 throw new IllegalStateException(
                         "Appears that Getable " +
                                 getable.getObjectId() +

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -535,7 +535,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         }
 
         // By this point it's guaranteed that a wfRun exists
-        storageManager.deletep(wfRunId, WfRun.class);
+        storageManager.delete(wfRunId, WfRun.class);
 
         deleteAllChildren(wfRun);
 
@@ -628,7 +628,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<NodeRun> next = iter.next();
-                storageManager.deletep(next.getKey(), NodeRun.class);
+                storageManager.delete(next.getKey(), NodeRun.class);
             }
         }
 
@@ -640,7 +640,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<Variable> next = iter.next();
-                storageManager.delete(next.getKey(), Variable.class);
+                storageManager.deleteGetable(next.getKey(), Variable.class);
             }
         }
 
@@ -652,7 +652,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<UserTaskRun> next = iter.next();
-                storageManager.deletep(next.getKey(), UserTaskRun.class);
+                storageManager.delete(next.getKey(), UserTaskRun.class);
             }
         }
 
@@ -664,7 +664,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<TaskRun> next = iter.next();
-                storageManager.deletep(next.getKey(), TaskRun.class);
+                storageManager.delete(next.getKey(), TaskRun.class);
             }
         }
 
@@ -676,7 +676,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<ExternalEvent> next = iter.next();
-                storageManager.delete(next.getKey(), ExternalEvent.class);
+                storageManager.deleteGetable(next.getKey(), ExternalEvent.class);
             }
         }
     }
@@ -937,7 +937,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         if (val != null) {
             storageManager.store(val);
         } else {
-            storageManager.delete(key, cls);
+            storageManager.deleteGetable(key, cls);
         }
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -75,7 +75,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
     private Map<String, WfSpec> wfSpecPuts;
     private Map<String, TaskDef> taskDefPuts;
     private Map<String, StoredGetable<TaskRunPb, TaskRun>> taskRunPuts;
-    private Map<String, UserTaskRun> userTaskRunPuts;
+    private Map<String, StoredGetable<UserTaskRunPb, UserTaskRun>> userTaskRunPuts;
     private Map<String, UserTaskDef> userTaskDefPuts;
     private Map<String, ExternalEventDef> extEvtDefPuts;
     private Map<String, ScheduledTask> scheduledTaskPuts;
@@ -255,21 +255,13 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
 
     @Override
     public void putUserTaskRun(UserTaskRun utr) {
-        userTaskRunPuts.put(utr.getStoreKey(), utr);
+        put(utr, userTaskRunPuts, UserTaskRun.class);
     }
 
     @Override
     public UserTaskRun getUserTaskRun(UserTaskRunId userTaskRunId) {
         String key = userTaskRunId.getStoreKey();
-        if (userTaskRunPuts.containsKey(key)) {
-            return userTaskRunPuts.get(key);
-        }
-        UserTaskRun out = localStore.get(key, UserTaskRun.class);
-        if (out != null) {
-            userTaskRunPuts.put(key, out);
-            out.setDao(this);
-        }
-        return out;
+        return get(key, userTaskRunPuts, UserTaskRun.class);
     }
 
     @Override
@@ -719,7 +711,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         ) {
             while (iter.hasNext()) {
                 LHIterKeyValue<UserTaskRun> next = iter.next();
-                getableStorageManager.delete(next.getKey(), UserTaskRun.class);
+                getableStorageManager.pepeDelete(next.getKey(), UserTaskRun.class);
             }
         }
 
@@ -785,8 +777,8 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         for (Map.Entry<String, StoredGetable<TaskRunPb, TaskRun>> e : taskRunPuts.entrySet()) {
             pepeSaveOrDeleteGETableFlush(e.getKey(), e.getValue(), TaskRun.class);
         }
-        for (Map.Entry<String, UserTaskRun> e : userTaskRunPuts.entrySet()) {
-            saveOrDeleteGETableFlush(e.getKey(), e.getValue(), UserTaskRun.class);
+        for (Map.Entry<String, StoredGetable<UserTaskRunPb, UserTaskRun>> e : userTaskRunPuts.entrySet()) {
+            pepeSaveOrDeleteGETableFlush(e.getKey(), e.getValue(), UserTaskRun.class);
         }
         // Turns out that we have to save the WfRun's before we save the Variable.
         for (Map.Entry<String, Variable> e : variablePuts.entrySet()) {

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -1038,6 +1038,7 @@ public class KafkaStreamsLHDAOImpl implements LHDAO {
         taskRunPuts.clear();
         userTaskDefPuts.clear();
         extEvtDefPuts.clear();
+        userTaskRunPuts.clear();
         taskWorkerGroupPuts.clear();
         taskMetricPuts = new HashMap<>();
         wfMetricPuts = new HashMap<>();

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
@@ -8,25 +8,28 @@ import io.littlehorse.server.streamsimpl.storeinternals.index.CachedTag;
 import io.littlehorse.server.streamsimpl.storeinternals.index.Tag;
 import io.littlehorse.server.streamsimpl.storeinternals.index.TagsCache;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
-
-import java.util.List;
 
 @Slf4j
 public class GetableStorageManager {
 
-    private LHStoreWrapper localStore;
+    private final Map<String, StoredGetable<? extends Message, ? extends Getable<?>>> uncommittedChanges;
 
-    private TagStorageManager tagStorageManager;
+    private final LHStoreWrapper localStore;
+
+    private final TagStorageManager tagStorageManager;
 
     public GetableStorageManager(
         LHStoreWrapper localStore,
-        LHConfig config,
         TagStorageManager tagStorageManager
     ) {
         this.localStore = localStore;
         this.tagStorageManager = tagStorageManager;
+        this.uncommittedChanges = new HashMap<>();
     }
 
     public GetableStorageManager(
@@ -34,7 +37,121 @@ public class GetableStorageManager {
         LHConfig config,
         ProcessorContext<String, CommandProcessorOutput> context
     ) {
-        this(localStore, config, new TagStorageManager(localStore, context, config));
+        this(localStore, new TagStorageManager(localStore, context, config));
+    }
+
+    @SuppressWarnings("unchecked")
+    public <U extends Message, T extends Getable<U>> T get(
+        String key,
+        Class<T> clazz
+    ) {
+        if (uncommittedChanges.containsKey(key)) {
+            StoredGetable<U, T> storedGetable = (StoredGetable<U, T>) uncommittedChanges.get(key);
+            return storedGetable.getStoredObject();
+        }
+
+        StoredGetable<U, T> storedGetable = localStore.getPepe(key, clazz);
+
+        if (storedGetable != null) {
+            uncommittedChanges.put(key, storedGetable);
+            return storedGetable.getStoredObject();
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <U extends Message, T extends Getable<U>> void put(
+        T getable,
+        Class<T> clazz
+    ) throws IllegalStateException {
+        log.trace("Putting {} with key {}", getable.getClass(), getable.getStoreKey());
+
+        StoredGetable<U, T> uncommittedEntity = (StoredGetable<U, T>) uncommittedChanges.get(getable.getStoreKey());
+
+        if (uncommittedEntity != null) {
+            if (uncommittedEntity.getStoredObject() != getable) {
+                throw new IllegalStateException(
+                    "Appears that Getable " +
+                    getable.getObjectId() +
+                    " was re-instantiated"
+                );
+            }
+            return;
+        }
+
+        StoredGetable<U, T> previousValue = localStore.getPepe(getable.getStoreKey(), clazz);
+
+        final StoredGetable<U, T> toPut = previousValue != null
+            ? new StoredGetable<>(
+                previousValue.getIndexCache(),
+                getable,
+                previousValue.getObjectType()
+            )
+            : new StoredGetable<>(
+                new TagsCache(),
+                getable,
+                Getable.getTypeEnum(clazz)
+            );
+
+        uncommittedChanges.put(getable.getStoreKey(), toPut);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <U extends Message, T extends Getable<U>> void deletep(
+        String key,
+        Class<T> clazz
+    ) throws IllegalStateException {
+        log.trace("Deleting {} with key {}", clazz, key);
+
+        StoredGetable<U, T> entity = localStore.getPepe(key, clazz);
+
+        if (entity != null) {
+            StoredGetable<U, T> toDelete = new StoredGetable<>(
+                entity.getIndexCache(),
+                null,
+                entity.getObjectType()
+            );
+            uncommittedChanges.put(key, toDelete);
+        }
+    }
+
+    public void commit() {
+        for (Map.Entry<String, StoredGetable<? extends Message, ? extends Getable<?>>> entry : uncommittedChanges.entrySet()) {
+            StoredGetable<? extends Message, ? extends Getable<?>> storedGetable = entry.getValue();
+            if (storedGetable.getStoredObject() != null) {
+                pepeStore(storedGetable);
+            } else {
+                pepeDelete(entry.getKey(), storedGetable);
+            }
+        }
+        uncommittedChanges.clear();
+    }
+
+    private <U extends Message, T extends Getable<U>> void pepeStore(
+        StoredGetable<U, T> getable
+    ) {
+        TagsCache previousTags = getable.getIndexCache();
+        List<Tag> newTags = getable.getStoredObject().getIndexEntries();
+        List<CachedTag> newCachedTags = newTags
+            .stream()
+            .map(tag -> new CachedTag(tag.getStoreKey(), tag.isRemote()))
+            .toList();
+        StoredGetable<U, T> entityToStore = new StoredGetable<>(
+            new TagsCache(newCachedTags),
+            getable.getStoredObject(),
+            getable.getObjectType()
+        );
+        localStore.pepePut(entityToStore);
+        tagStorageManager.pepeStore(newTags, previousTags);
+    }
+
+    private <U extends Message, T extends Getable<U>> void pepeDelete(
+        String key,
+        StoredGetable<U, T> getable
+    ) {
+        localStore.delete(key, getable.getStoredClass());
+        tagStorageManager.pepeStore(List.of(), getable.getIndexCache());
     }
 
     @SuppressWarnings("unchecked")
@@ -45,33 +162,6 @@ public class GetableStorageManager {
             getable.getStoreKey(),
             (Class<? extends Getable<?>>) getable.getClass()
         );
-    }
-    public <U extends Message, T extends Getable<U>> void pepeStore(StoredGetable<U, T> getable) {
-        TagsCache previousTags = getable.getIndexCache();
-        List<Tag> newTags = getable.getStoredObject().getIndexEntries();
-        List<CachedTag> newCachedTags = newTags
-                .stream()
-                .map(tag -> new CachedTag(tag.getStoreKey(), tag.isRemote()))
-                .toList();
-        StoredGetable<U, T> entityToStore = new StoredGetable<>(new TagsCache(newCachedTags), getable.getStoredObject(), getable.getObjectType());
-        localStore.pepePut(entityToStore);
-        tagStorageManager.pepeStore(newTags, previousTags);
-    }
-
-    public <U extends Message, T extends Getable<U>> void pepeDelete(
-        String storeKey,
-        Class<T> getableClass
-    ) {
-        StoredGetable<U, T> getable = localStore.getPepe(storeKey, getableClass);
-        if (getable == null) {
-            log.debug(
-                    "Tried to delete a thing that didn't exist! Likely because it " +
-                            "was created and deleted in the same Command Event."
-            );
-            return;
-        }
-        localStore.delete(getable.getStoredObject());
-        tagStorageManager.pepeStore(List.of(), getable.getIndexCache());
     }
 
     public <U extends Message, T extends Getable<U>> void delete(

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
@@ -116,6 +116,19 @@ public class GetableStorageManager {
         }
     }
 
+    public <U extends Message, T extends Getable<U>> void abortAndUpdate(T getable) {
+        uncommittedChanges.clear();
+        StoredGetable<U, T> storedGetable = localStore.getStoredGetable(getable.getStoreKey(), getable.getClass());
+        if (storedGetable != null) {
+            StoredGetable<U, T> toUpdate = new StoredGetable<>(
+                    storedGetable.getIndexCache(),
+                    getable,
+                    storedGetable.getObjectType()
+            );
+            insertIntoStore(toUpdate);
+        }
+    }
+
     public void commit() {
         for (Map.Entry<String, StoredGetable<? extends Message, ? extends Getable<?>>> entry : uncommittedChanges.entrySet()) {
             StoredGetable<? extends Message, ? extends Getable<?>> storedGetable = entry.getValue();

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
@@ -8,9 +8,8 @@ import io.littlehorse.common.model.Storeable;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.LHKeyValueIterator;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
-import java.util.stream.Stream;
-
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
@@ -9,7 +9,6 @@ import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.LHKeyValueIterator;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -46,7 +45,7 @@ public class LHROStoreWrapper {
         this.config = config;
     }
 
-    public <U extends Message, T extends Getable<U>> StoredGetable<U, T> getPepe(
+    public <U extends Message, T extends Getable<U>> StoredGetable<U, T> getStoredGetable(
             String objectId,
             Class<T> cls
     ) {
@@ -64,6 +63,12 @@ public class LHROStoreWrapper {
         }
     }
 
+    /**
+     * @deprecated
+     * Should not use this method because it's not using the StoredGetable class. This method will
+     * be removed once all entities are migrated to use the StoredGetable class.
+     */
+    @Deprecated(forRemoval = true)
     public <U extends Message, T extends Storeable<U>> T get(
         String objectId,
         Class<T> cls

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHROStoreWrapper.java
@@ -2,12 +2,15 @@ package io.littlehorse.server.streamsimpl.storeinternals;
 
 import com.google.protobuf.Message;
 import io.littlehorse.common.LHConfig;
+import io.littlehorse.common.model.Getable;
 import io.littlehorse.common.model.LHSerializable;
 import io.littlehorse.common.model.Storeable;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.LHKeyValueIterator;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
 import java.util.stream.Stream;
+
+import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
@@ -42,6 +45,24 @@ public class LHROStoreWrapper {
     ) {
         this.store = store;
         this.config = config;
+    }
+
+    public <U extends Message, T extends Getable<U>> StoredGetable<U, T> getPepe(
+            String objectId,
+            Class<T> cls
+    ) {
+        Bytes raw = store.get(StoreUtils.getFullStoreKey(objectId, cls));
+        if (raw == null) {
+            return null;
+        }
+        try {
+            return (StoredGetable<U, T>) LHSerializable.fromBytes(raw.get(), StoredGetable.class, config);
+        } catch (LHSerdeError exn) {
+            log.error(exn.getMessage(), exn);
+            throw new RuntimeException(
+                    "Not possible to have this happen, indicates corrupted store."
+            );
+        }
     }
 
     public <U extends Message, T extends Storeable<U>> T get(

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -35,12 +35,12 @@ public class LHStoreWrapper extends LHROStoreWrapper {
         put(storeKey, thing);
     }
 
-    public void pepePut(StoredGetable<?, ?> thing) {
+    public void put(StoredGetable<?, ?> thing) {
         String storeKey = StoreUtils.getFullStoreKey(thing.getStoredObject());
         put(storeKey, thing);
     }
 
-    public void put(String storeKey, Storeable<?> thing) {
+    private void put(String storeKey, Storeable<?> thing) {
         totalPuts++;
         log.trace("Putting {}", storeKey);
         store.put(storeKey, new Bytes(thing.toBytes(config)));

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -9,6 +9,7 @@ import io.littlehorse.common.proto.CommandPb.CommandCase;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.server.streamsimpl.storeinternals.index.TagsCache;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoreUtils;
+import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -31,6 +32,11 @@ public class LHStoreWrapper extends LHROStoreWrapper {
 
     public void put(Storeable<?> thing) {
         String storeKey = StoreUtils.getFullStoreKey(thing);
+        put(storeKey, thing);
+    }
+
+    public void pepePut(StoredGetable<?, ?> thing) {
+        String storeKey = StoreUtils.getFullStoreKey(thing.getStoredObject());
         put(storeKey, thing);
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
@@ -45,6 +45,24 @@ public class TagStorageManager {
         tagsCache.setTags(cachedTags);
         localStore.putTagsCache(getableId, getableCls, tagsCache);
     }
+    public void pepeStore(
+        Collection<Tag> tags,
+        TagsCache preExistingTags
+    ) {
+        List<String> existingTagIds = preExistingTags.getTagIds();
+        List<CachedTag> cachedTags = tags
+                .stream()
+                .map(tag -> {
+                    CachedTag cachedTag = new CachedTag();
+                    cachedTag.setId(tag.getStoreKey());
+                    cachedTag.setRemote(tag.isRemote());
+                    return cachedTag;
+                })
+                .toList();
+        this.storeLocalOrRemoteTag(tags, existingTagIds);
+        this.removeOldTags(tags, preExistingTags.getTags());
+        preExistingTags.setTags(cachedTags);
+    }
 
     private void removeOldTags(Collection<Tag> newTags, List<CachedTag> cachedTags) {
         List<String> newTagIds = newTags.stream().map(Tag::getStoreKey).toList();

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
@@ -46,22 +46,12 @@ public class TagStorageManager {
         localStore.putTagsCache(getableId, getableCls, tagsCache);
     }
     public void pepeStore(
-        Collection<Tag> tags,
+        Collection<Tag> newTags,
         TagsCache preExistingTags
     ) {
         List<String> existingTagIds = preExistingTags.getTagIds();
-        List<CachedTag> cachedTags = tags
-                .stream()
-                .map(tag -> {
-                    CachedTag cachedTag = new CachedTag();
-                    cachedTag.setId(tag.getStoreKey());
-                    cachedTag.setRemote(tag.isRemote());
-                    return cachedTag;
-                })
-                .toList();
-        this.storeLocalOrRemoteTag(tags, existingTagIds);
-        this.removeOldTags(tags, preExistingTags.getTags());
-        preExistingTags.setTags(cachedTags);
+        this.storeLocalOrRemoteTag(newTags, existingTagIds);
+        this.removeOldTags(newTags, preExistingTags.getTags());
     }
 
     private void removeOldTags(Collection<Tag> newTags, List<CachedTag> cachedTags) {

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
@@ -45,10 +45,8 @@ public class TagStorageManager {
         tagsCache.setTags(cachedTags);
         localStore.putTagsCache(getableId, getableCls, tagsCache);
     }
-    public void pepeStore(
-        Collection<Tag> newTags,
-        TagsCache preExistingTags
-    ) {
+
+    public void pepeStore(Collection<Tag> newTags, TagsCache preExistingTags) {
         List<String> existingTagIds = preExistingTags.getTagIds();
         this.storeLocalOrRemoteTag(newTags, existingTagIds);
         this.removeOldTags(newTags, preExistingTags.getTags());

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManager.java
@@ -23,7 +23,13 @@ public class TagStorageManager {
     private ProcessorContext<String, CommandProcessorOutput> context;
     private LHConfig lhConfig;
 
-    public void store(
+    /**
+     * @deprecated
+     * Should not use this method because it's making an extra get and put to the database in order to get the tag cache.
+     * This method will be removed once all entities are migrated to use the StoredGetable class.
+     */
+    @Deprecated(forRemoval = true)
+    public void storeUsingCache(
         Collection<Tag> tags,
         String getableId,
         Class<? extends Getable<?>> getableCls
@@ -46,7 +52,7 @@ public class TagStorageManager {
         localStore.putTagsCache(getableId, getableCls, tagsCache);
     }
 
-    public void pepeStore(Collection<Tag> newTags, TagsCache preExistingTags) {
+    public void store(Collection<Tag> newTags, TagsCache preExistingTags) {
         List<String> existingTagIds = preExistingTags.getTagIds();
         this.storeLocalOrRemoteTag(newTags, existingTagIds);
         this.removeOldTags(newTags, preExistingTags.getTags());
@@ -61,6 +67,12 @@ public class TagStorageManager {
         tagsIdsToRemove.forEach(this::removeTag);
     }
 
+    /**
+     * @deprecated
+     * Do not use this method outside the TagStorageManager class. This method will become private once
+     * all entities are migrated to use the StoredGetable class.
+     */
+    @Deprecated
     public void removeTag(CachedTag cachedTag) {
         if (cachedTag.isRemote()) {
             String attributeString = extractAttributeStringFromStoreKey(

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/index/CachedTag.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/index/CachedTag.java
@@ -14,6 +14,13 @@ public class CachedTag extends LHSerializable<TagsCachePb.CachedTagPb> {
     private String id;
     private boolean isRemote;
 
+    public CachedTag() {}
+
+    public CachedTag(String id, boolean isRemote) {
+        this.id = id;
+        this.isRemote = isRemote;
+    }
+
     @Override
     public TagsCachePb.CachedTagPb.Builder toProto() {
         return TagsCachePb.CachedTagPb.newBuilder().setId(id).setIsRemote(isRemote);

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/index/TagsCache.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/index/TagsCache.java
@@ -15,6 +15,12 @@ public class TagsCache extends LHSerializable<TagsCachePb> {
 
     public List<CachedTag> tags = new ArrayList<>();
 
+    public TagsCache() {}
+
+    public TagsCache(List<CachedTag> tags) {
+        this.tags = tags;
+    }
+
     public Class<TagsCachePb> getProtoBaseClass() {
         return TagsCachePb.class;
     }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/utils/StoredGetable.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/utils/StoredGetable.java
@@ -1,0 +1,76 @@
+package io.littlehorse.server.streamsimpl.storeinternals.utils;
+
+import com.google.protobuf.Message;
+import io.littlehorse.common.model.Getable;
+import io.littlehorse.common.model.LHSerializable;
+import io.littlehorse.common.model.ObjectId;
+import io.littlehorse.common.model.Storeable;
+import io.littlehorse.common.proto.GetableClassEnumPb;
+import io.littlehorse.common.proto.StoredGetablePb;
+import io.littlehorse.sdk.common.exception.LHSerdeError;
+import io.littlehorse.server.streamsimpl.storeinternals.index.TagsCache;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Setter
+public class StoredGetable<U extends Message, T extends Getable<U>>
+        extends Storeable<StoredGetablePb> {
+
+    private TagsCache indexCache;
+    private T storedObject;
+    private GetableClassEnumPb objectType;
+
+    public StoredGetable(TagsCache indexCache, T storedObject, GetableClassEnumPb objectType) {
+        this.indexCache = indexCache;
+        this.storedObject = storedObject;
+        this.objectType = objectType;
+    }
+
+    public StoredGetable() {}
+
+    @Override
+    public Class<StoredGetablePb> getProtoBaseClass() {
+        return StoredGetablePb.class;
+    }
+
+    @Override
+    public void initFrom(Message proto) {
+        StoredGetablePb p = (StoredGetablePb) proto;
+        indexCache = LHSerializable.fromProto(p.getIndexCache(), TagsCache.class);
+        objectType = p.getType();
+        try {
+            storedObject = LHSerializable.fromBytes(
+                    p.getGetablePayload().toByteArray(),
+                    getStoredClass(),
+                    null);
+        } catch (LHSerdeError exception) {
+            log.error("Failed loading from store: {}", exception.getMessage(), exception);
+        }
+    }
+
+    @Override
+    public StoredGetablePb.Builder toProto() {
+        return StoredGetablePb
+                .newBuilder()
+                .setType(objectType)
+                .setIndexCache(indexCache.toProto())
+                .setGetablePayload(storedObject.toProto().build().toByteString());
+    }
+
+    @Override
+    public String getStoreKey() {
+        return StoredGetable.getStoreKey(storedObject.getObjectId());
+    }
+
+    public static String getStoreKey(ObjectId<?, ?, ?> id) {
+        return id.getType().getNumber() + "/" + id.getStoreKey();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Class<T> getStoredClass() {
+        return (Class<T>) Getable.getCls(objectType);
+    }
+}

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/utils/StoredGetable.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/utils/StoredGetable.java
@@ -17,13 +17,17 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Setter
 public class StoredGetable<U extends Message, T extends Getable<U>>
-        extends Storeable<StoredGetablePb> {
+    extends Storeable<StoredGetablePb> {
 
     private TagsCache indexCache;
     private T storedObject;
     private GetableClassEnumPb objectType;
 
-    public StoredGetable(TagsCache indexCache, T storedObject, GetableClassEnumPb objectType) {
+    public StoredGetable(
+        TagsCache indexCache,
+        T storedObject,
+        GetableClassEnumPb objectType
+    ) {
         this.indexCache = indexCache;
         this.storedObject = storedObject;
         this.objectType = objectType;
@@ -42,22 +46,28 @@ public class StoredGetable<U extends Message, T extends Getable<U>>
         indexCache = LHSerializable.fromProto(p.getIndexCache(), TagsCache.class);
         objectType = p.getType();
         try {
-            storedObject = LHSerializable.fromBytes(
+            storedObject =
+                LHSerializable.fromBytes(
                     p.getGetablePayload().toByteArray(),
                     getStoredClass(),
-                    null);
+                    null
+                );
         } catch (LHSerdeError exception) {
-            log.error("Failed loading from store: {}", exception.getMessage(), exception);
+            log.error(
+                "Failed loading from store: {}",
+                exception.getMessage(),
+                exception
+            );
         }
     }
 
     @Override
     public StoredGetablePb.Builder toProto() {
         return StoredGetablePb
-                .newBuilder()
-                .setType(objectType)
-                .setIndexCache(indexCache.toProto())
-                .setGetablePayload(storedObject.toProto().build().toByteString());
+            .newBuilder()
+            .setType(objectType)
+            .setIndexCache(indexCache.toProto())
+            .setGetablePayload(storedObject.toProto().build().toByteString());
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserver.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserver.java
@@ -9,6 +9,12 @@ import io.littlehorse.common.proto.CentralStoreQueryReplyPb;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.sdk.common.proto.LHResponseCodePb;
 
+/**
+ * @deprecated
+ * Should not use this class because it's not using the StoredGetable class. This class will
+ * be removed once all entities are migrated to use the StoredGetable class.
+ */
+@Deprecated(forRemoval = true)
 public class GETStreamObserver<
     U extends Message, T extends Storeable<U>, V extends Message
 >

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverNew.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverNew.java
@@ -10,7 +10,7 @@ import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.sdk.common.proto.LHResponseCodePb;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
 
-public class GETStreamObserverPepe<U extends Message, T extends Getable<U>, V extends Message>
+public class GETStreamObserverNew<U extends Message, T extends Getable<U>, V extends Message>
         implements StreamObserver<CentralStoreQueryReplyPb> {
 
     private StreamObserver<V> ctx;
@@ -19,7 +19,7 @@ public class GETStreamObserverPepe<U extends Message, T extends Getable<U>, V ex
 
     private IntermediateGETResp<U, T, V> out;
 
-    public GETStreamObserverPepe(
+    public GETStreamObserverNew(
         StreamObserver<V> responseObserver,
         Class<T> getableCls,
         Class<V> responseCls,

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverPepe.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverPepe.java
@@ -1,0 +1,71 @@
+package io.littlehorse.server.streamsimpl.util;
+
+import com.google.protobuf.Message;
+import io.grpc.stub.StreamObserver;
+import io.littlehorse.common.LHConfig;
+import io.littlehorse.common.model.Getable;
+import io.littlehorse.common.model.LHSerializable;
+import io.littlehorse.common.proto.CentralStoreQueryReplyPb;
+import io.littlehorse.sdk.common.exception.LHSerdeError;
+import io.littlehorse.sdk.common.proto.LHResponseCodePb;
+import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
+
+public class GETStreamObserverPepe<
+    U extends Message, T extends Getable<U>, V extends Message
+>
+    implements StreamObserver<CentralStoreQueryReplyPb> {
+
+    private StreamObserver<V> ctx;
+    private LHConfig config;
+    private Class<T> getableCls;
+
+    private IntermediateGETResp<U, T, V> out;
+
+    public GETStreamObserverPepe(
+        StreamObserver<V> responseObserver,
+        Class<T> getableCls,
+        Class<V> responseCls,
+        LHConfig config
+    ) {
+        this.ctx = responseObserver;
+        this.getableCls = getableCls;
+        this.config = config;
+
+        this.out = new IntermediateGETResp<U, T, V>(responseCls);
+    }
+
+    public void onError(Throwable t) {
+        Throwable cause = t.getCause() != null ? t.getCause() : t;
+
+        out.code = LHResponseCodePb.CONNECTION_ERROR;
+        out.message = "Failed connecting to backend: " + cause.getMessage();
+        ctx.onNext(out.toProto());
+        ctx.onCompleted();
+    }
+
+    public void onCompleted() {}
+
+    public void onNext(CentralStoreQueryReplyPb reply) {
+        // TODO
+        if (reply.hasResult()) {
+            out.code = LHResponseCodePb.OK;
+            try {
+                out.result = ((StoredGetable<U, T>) LHSerializable.fromBytes(
+                        reply.getResult().toByteArray(),
+                        StoredGetable.class,
+                        config
+                    )).getStoredObject();
+            } catch (LHSerdeError exn) {
+                out.code = LHResponseCodePb.CONNECTION_ERROR;
+                out.message =
+                    "Impossible: got unreadable response from backend: " +
+                    exn.getMessage();
+            }
+        } else {
+            out.code = LHResponseCodePb.NOT_FOUND_ERROR;
+        }
+
+        ctx.onNext(out.toProto());
+        ctx.onCompleted();
+    }
+}

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverPepe.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/util/GETStreamObserverPepe.java
@@ -10,10 +10,8 @@ import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.sdk.common.proto.LHResponseCodePb;
 import io.littlehorse.server.streamsimpl.storeinternals.utils.StoredGetable;
 
-public class GETStreamObserverPepe<
-    U extends Message, T extends Getable<U>, V extends Message
->
-    implements StreamObserver<CentralStoreQueryReplyPb> {
+public class GETStreamObserverPepe<U extends Message, T extends Getable<U>, V extends Message>
+        implements StreamObserver<CentralStoreQueryReplyPb> {
 
     private StreamObserver<V> ctx;
     private LHConfig config;
@@ -46,15 +44,15 @@ public class GETStreamObserverPepe<
     public void onCompleted() {}
 
     public void onNext(CentralStoreQueryReplyPb reply) {
-        // TODO
         if (reply.hasResult()) {
             out.code = LHResponseCodePb.OK;
             try {
-                out.result = ((StoredGetable<U, T>) LHSerializable.fromBytes(
+                StoredGetable<U, T> entity = (StoredGetable<U, T>) LHSerializable.fromBytes(
                         reply.getResult().toByteArray(),
                         StoredGetable.class,
                         config
-                    )).getStoredObject();
+                );
+                out.result = entity.getStoredObject();
             } catch (LHSerdeError exn) {
                 out.code = LHResponseCodePb.CONNECTION_ERROR;
                 out.message =

--- a/server/src/test/java/io/littlehorse/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManagerTest.java
+++ b/server/src/test/java/io/littlehorse/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManagerTest.java
@@ -115,7 +115,7 @@ public class GetableStorageManagerTest {
             .map(s -> localStoreWrapper.get(s, Tag.class))
             .collect(Collectors.groupingBy(Objects::nonNull));
 
-        geTableStorageManager.delete(wfRun);
+        geTableStorageManager.deleteGetable(wfRun);
         Assertions
             .assertThat(localStoreWrapper.get(wfRun.getStoreKey(), WfRun.class))
             .isNull();

--- a/server/src/test/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManagerTest.java
+++ b/server/src/test/java/io/littlehorse/server/streamsimpl/storeinternals/TagStorageManagerTest.java
@@ -70,7 +70,7 @@ public class TagStorageManagerTest {
 
     @Test
     void saveTagsWithNewTagsCache() {
-        tagStorageManager.store(tags, "123456", WfRun.class);
+        tagStorageManager.storeUsingCache(tags, "123456", WfRun.class);
         Tag tagResult1 = localStore.get(tag1.getStoreKey(), Tag.class);
         Tag tagResult2 = localStore.get(tag2.getStoreKey(), Tag.class);
         TagsCache tagsCache = localStore.getTagsCache("123456", WfRun.class);
@@ -97,7 +97,7 @@ public class TagStorageManagerTest {
         tagsCache.setTags(List.of(cachedTag));
         localStore.putTagsCache(wfRunId, WfRun.class, tagsCache);
 
-        tagStorageManager.store(tags, wfRunId, WfRun.class);
+        tagStorageManager.storeUsingCache(tags, wfRunId, WfRun.class);
         TagsCache tagsCacheResult = localStore.getTagsCache(wfRunId, WfRun.class);
         Assertions
             .assertThat(localStore.get(tag2.getStoreKey(), Tag.class))
@@ -117,7 +117,7 @@ public class TagStorageManagerTest {
         String expectedPartitionKey = "3/__wfSpecName_test-name";
         tag1.setTagType(TagStorageTypePb.REMOTE);
         tags = List.of(tag1, tag2);
-        tagStorageManager.store(tags, "test-wfrun-id", WfRun.class);
+        tagStorageManager.storeUsingCache(tags, "test-wfrun-id", WfRun.class);
         List<? extends Record<? extends String, ? extends CommandProcessorOutput>> outputs = mockProcessorContext
             .forwarded()
             .stream()
@@ -157,7 +157,7 @@ public class TagStorageManagerTest {
         tagsCache.setTags(List.of(cachedTag1, cachedTag2));
         localStore.putTagsCache(wfRunId, WfRun.class, tagsCache);
 
-        tagStorageManager.store(tags, wfRunId, WfRun.class);
+        tagStorageManager.storeUsingCache(tags, wfRunId, WfRun.class);
         List<? extends Record<? extends String, ? extends CommandProcessorOutput>> outputs = mockProcessorContext
             .forwarded()
             .stream()


### PR DESCRIPTION
In this first optimization PR we wanted to achieve two things:

1. Store the entities together with the tags cache to reduce 1 get and 1 put every time we inserted/updated something
2. Reduce the complexity of the KafkaStreamsLHDAOImpl by moving the "ORM"/"Transactional" logic into the GetableStorageManager

At first we tried to do this optimization/refactor in a big bang way but we encountered a lot of compilation errors and around 30+ files with changes. So we decided to do it incrementally by first introducing it to the "Run" entities. This PR introduces the optimization to the NodeRun, TaskRun, UserTaskRun, WfRun, and TaskWorkerGroup.