### PR TITLE
Minor:

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/command/Command.java
+++ b/server/src/main/java/io/littlehorse/common/model/command/Command.java
@@ -73,13 +73,11 @@ public class Command extends LHSerializable<CommandPb> {
     public Command() {}
 
     public Command(SubCommand<?> cmd) {
-        this.commandId = LHUtil.generateGuid();
         this.time = new Date();
         this.setSubCommand(cmd);
     }
 
     public Command(SubCommand<?> cmd, Date time) {
-        this.commandId = LHUtil.generateGuid();
         this.time = time;
         this.setSubCommand(cmd);
     }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -43,7 +43,6 @@ public class LHStoreWrapper extends LHROStoreWrapper {
 
     private void put(String storeKey, Storeable<?> thing) {
         totalPuts++;
-        log.trace("Putting {}", storeKey);
         store.put(storeKey, new Bytes(thing.toBytes(config)));
     }
 
@@ -73,14 +72,12 @@ public class LHStoreWrapper extends LHROStoreWrapper {
     }
 
     public void delete(String fullStoreKey) {
-        log.trace("Deleting {}", fullStoreKey);
         totalDeletes++;
         store.delete(fullStoreKey);
     }
 
     public Bytes getRaw(String rawKey) {
         totalGets++;
-        log.warn("Getting: {}", rawKey);
         return store.get(rawKey);
     }
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -1,5 +1,6 @@
 package io.littlehorse.server.streamsimpl.storeinternals;
 
+import com.google.protobuf.Message;
 import io.littlehorse.common.LHConfig;
 import io.littlehorse.common.model.Getable;
 import io.littlehorse.common.model.LHSerializable;
@@ -63,6 +64,14 @@ public class LHStoreWrapper extends LHROStoreWrapper {
         delete(fullStoreKey);
     }
 
+    @Override
+    public <
+        U extends Message, T extends Getable<U>
+    > StoredGetable<U, T> getStoredGetable(String objectId, Class<T> cls) {
+        totalGets++;
+        return super.getStoredGetable(objectId, cls);
+    }
+
     public void delete(String fullStoreKey) {
         log.trace("Deleting {}", fullStoreKey);
         totalDeletes++;
@@ -71,6 +80,7 @@ public class LHStoreWrapper extends LHROStoreWrapper {
 
     public Bytes getRaw(String rawKey) {
         totalGets++;
+        log.warn("Getting: {}", rawKey);
         return store.get(rawKey);
     }
 


### PR DESCRIPTION
- fix the counting of number of rocksdb gets in each Command.
- no longer put a commandId onthe Timer Command's which don't have a response observer. This reduces load on the AsyncWaiters.