### PR TITLE
minor changes to make red hat's java plugin happier

### DIFF
--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AIConditionalsLessThan.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AIConditionalsLessThan.java
@@ -64,7 +64,7 @@ public class AIConditionalsLessThan extends WorkflowLogicTest {
         Object rhs,
         boolean shouldEqual
     ) throws TestFailure, InterruptedException, LHApiError {
-        InputObj input = new InputObj(lhs, rhs);
+        AIInputObj input = new AIInputObj(lhs, rhs);
 
         if (shouldEqual) {
             return runWithInputsAndCheckPath(client, input, true, true);

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AJConditionalsLessThanEq.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AJConditionalsLessThanEq.java
@@ -64,7 +64,7 @@ public class AJConditionalsLessThanEq extends WorkflowLogicTest {
         Object rhs,
         boolean shouldEqual
     ) throws TestFailure, InterruptedException, LHApiError {
-        InputObj input = new InputObj(lhs, rhs);
+        AJInputObj input = new AJInputObj(lhs, rhs);
 
         if (shouldEqual) {
             return runWithInputsAndCheckPath(client, input, true, true);

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AKConditionalsGreaterThan.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AKConditionalsGreaterThan.java
@@ -64,7 +64,7 @@ public class AKConditionalsGreaterThan extends WorkflowLogicTest {
         Object rhs,
         boolean shouldEqual
     ) throws TestFailure, InterruptedException, LHApiError {
-        InputObj input = new InputObj(lhs, rhs);
+        AKInputObj input = new AKInputObj(lhs, rhs);
 
         if (shouldEqual) {
             return runWithInputsAndCheckPath(client, input, true, true);

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AMConditionalsIn.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/AMConditionalsIn.java
@@ -75,7 +75,7 @@ public class AMConditionalsIn extends WorkflowLogicTest {
         Object rhs,
         boolean shouldEqual
     ) throws TestFailure, InterruptedException, LHApiError {
-        InputObj input = new InputObj(lhs, rhs);
+        AMInputObj input = new AMInputObj(lhs, rhs);
 
         if (shouldEqual) {
             return runWithInputsAndCheckPath(client, input, true, true);

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/GetableStorageManager.java
@@ -17,7 +17,7 @@ import org.apache.kafka.streams.processor.api.ProcessorContext;
 @Slf4j
 public class GetableStorageManager {
 
-    private final Map<String, StoredGetable<? extends Message, ? extends Getable<?>>> uncommittedChanges;
+    private final Map<String, StoredGetable<?, ?>> uncommittedChanges;
 
     private final LHStoreWrapper localStore;
 
@@ -108,7 +108,6 @@ public class GetableStorageManager {
         uncommittedChanges.put(getable.getStoreKey(), toPut);
     }
 
-    @SuppressWarnings("unchecked")
     public <U extends Message, T extends Getable<U>> void delete(
         String key,
         Class<T> clazz
@@ -129,7 +128,9 @@ public class GetableStorageManager {
 
     public <U extends Message, T extends Getable<U>> void abortAndUpdate(T getable) {
         uncommittedChanges.clear();
-        StoredGetable<U, T> storedGetable = localStore.getStoredGetable(
+
+        @SuppressWarnings("unchecked")
+        StoredGetable<U, T> storedGetable = (StoredGetable<U, T>) localStore.getStoredGetable(
             getable.getStoreKey(),
             getable.getClass()
         );
@@ -144,7 +145,7 @@ public class GetableStorageManager {
     }
 
     public void commit() {
-        for (Map.Entry<String, StoredGetable<? extends Message, ? extends Getable<?>>> entry : uncommittedChanges.entrySet()) {
+        for (Map.Entry<String, StoredGetable<?, ?>> entry : uncommittedChanges.entrySet()) {
             StoredGetable<? extends Message, ? extends Getable<?>> storedGetable = entry.getValue();
             if (storedGetable.getStoredObject() != null) {
                 insertIntoStore(storedGetable);
@@ -156,7 +157,7 @@ public class GetableStorageManager {
     }
 
     private <U extends Message, T extends Getable<U>> void insertIntoStore(
-        StoredGetable<U, T> getable
+        StoredGetable<?, ?> getable
     ) {
         TagsCache previousTags = getable.getIndexCache();
         List<Tag> newTags = getable.getStoredObject().getIndexEntries();
@@ -164,7 +165,9 @@ public class GetableStorageManager {
             .stream()
             .map(tag -> new CachedTag(tag.getStoreKey(), tag.isRemote()))
             .toList();
-        StoredGetable<U, T> entityToStore = new StoredGetable<>(
+
+        @SuppressWarnings("unchecked")
+        StoredGetable<U, T> entityToStore = (StoredGetable<U, T>) new StoredGetable<>(
             new TagsCache(newCachedTags),
             getable.getStoredObject(),
             getable.getObjectType()
@@ -175,7 +178,7 @@ public class GetableStorageManager {
 
     private <U extends Message, T extends Getable<U>> void deleteFromStore(
         String key,
-        StoredGetable<U, T> getable
+        StoredGetable<?, ?> getable
     ) {
         localStore.delete(key, getable.getStoredClass());
         tagStorageManager.store(List.of(), getable.getIndexCache());


### PR DESCRIPTION
It appears that IntelliJ and VSCode use different java linters. This fixes some errors and warnings that were present (and quite annoying) in the VSCode one.