### PR TITLE
Separate metadata processor

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHConfig.java
@@ -141,6 +141,14 @@ public class LHConfig extends ConfigBase {
         return clusterId + "-core-cmd";
     }
 
+    public String getPepeCmdTopicName() {
+        return getPepeCmdTopicName(getLHClusterId());
+    }
+
+    public static String getPepeCmdTopicName(String clusterId) {
+        return clusterId + "-pepe-cmd";
+    }
+
     public String getRepartitionTopicName() {
         return getRepartitionTopicName(getLHClusterId());
     }
@@ -273,6 +281,17 @@ public class LHConfig extends ConfigBase {
                 replicationFactor
             )
                 .configs(globalMetaCLConfig)
+        );
+
+        // TODO: define the appropriate configuration for this topic -> For sure it shouldn't have compaction
+        out.add(
+            new NewTopic(
+                getPepeCmdTopicName(clusterId),
+                // This topic is input to a global store. Therefore, it doesn't
+                // make sense to have any more than just one partition.
+                1,
+                replicationFactor
+            )
         );
 
         return out;

--- a/server/src/main/java/io/littlehorse/common/LHConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHConfig.java
@@ -283,12 +283,11 @@ public class LHConfig extends ConfigBase {
                 .configs(globalMetaCLConfig)
         );
 
-        // TODO: define the appropriate configuration for this topic -> For sure it shouldn't have compaction
         out.add(
             new NewTopic(
                 getMetadataCmdTopicName(clusterId),
-                // This topic is input to a global store. Therefore, it doesn't
-                // make sense to have any more than just one partition.
+                // All metadata have the same key, thus having more than one partition is
+                // unnecessary.
                 1,
                 replicationFactor
             )

--- a/server/src/main/java/io/littlehorse/common/LHConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHConfig.java
@@ -141,12 +141,12 @@ public class LHConfig extends ConfigBase {
         return clusterId + "-core-cmd";
     }
 
-    public String getPepeCmdTopicName() {
-        return getPepeCmdTopicName(getLHClusterId());
+    public String getMetadataCmdTopicName() {
+        return getMetadataCmdTopicName(getLHClusterId());
     }
 
-    public static String getPepeCmdTopicName(String clusterId) {
-        return clusterId + "-pepe-cmd";
+    public static String getMetadataCmdTopicName(String clusterId) {
+        return clusterId + "-metadata-cmd";
     }
 
     public String getRepartitionTopicName() {
@@ -286,7 +286,7 @@ public class LHConfig extends ConfigBase {
         // TODO: define the appropriate configuration for this topic -> For sure it shouldn't have compaction
         out.add(
             new NewTopic(
-                getPepeCmdTopicName(clusterId),
+                getMetadataCmdTopicName(clusterId),
                 // This topic is input to a global store. Therefore, it doesn't
                 // make sense to have any more than just one partition.
                 1,

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -197,7 +197,6 @@ import io.littlehorse.server.streamsimpl.util.GETStreamObserver;
 import io.littlehorse.server.streamsimpl.util.GETStreamObserverNew;
 import io.littlehorse.server.streamsimpl.util.HealthService;
 import io.littlehorse.server.streamsimpl.util.POSTStreamObserver;
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
@@ -207,7 +206,6 @@ import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.Topology;
 
 @Slf4j
 public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
@@ -282,7 +280,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
             config
         );
         internalComms.getStoreBytesAsync(
-            ServerTopology.PEPE_STORE,
+            ServerTopology.METADATA_STORE,
             StoreUtils.getFullStoreKey(
                 new WfSpecId(req.getName(), req.getVersion()),
                 WfSpec.class
@@ -307,7 +305,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
             StoreUtils.getFullPrefixByName(req.getName(), WfSpec.class),
             LHConstants.META_PARTITION_KEY,
             observer,
-            ServerTopology.PEPE_STORE
+            ServerTopology.METADATA_STORE
         );
     }
 
@@ -329,7 +327,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
             StoreUtils.getFullPrefixByName(req.getName(), UserTaskDef.class),
             LHConstants.META_PARTITION_KEY,
             observer,
-            ServerTopology.PEPE_STORE
+            ServerTopology.METADATA_STORE
         );
     }
 
@@ -346,7 +344,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
         );
 
         internalComms.getStoreBytesAsync(
-            ServerTopology.PEPE_STORE,
+            ServerTopology.METADATA_STORE,
             StoreUtils.getFullStoreKey(
                 new UserTaskDefId(req.getName(), req.getVersion()),
                 UserTaskDef.class
@@ -366,7 +364,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
         );
 
         internalComms.getStoreBytesAsync(
-            ServerTopology.PEPE_STORE,
+            ServerTopology.METADATA_STORE,
             StoreUtils.getFullStoreKey(new TaskDefId(req.getName()), TaskDef.class),
             LHConstants.META_PARTITION_KEY,
             observer
@@ -386,7 +384,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
         );
 
         internalComms.getStoreBytesAsync(
-            ServerTopology.PEPE_STORE,
+            ServerTopology.METADATA_STORE,
             StoreUtils.getFullStoreKey(
                 new ExternalEventDefId(req.getName()),
                 ExternalEventDef.class
@@ -1062,7 +1060,7 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
             subCmdCls == DeleteWfSpec.class ||
             subCmdCls == DeleteUserTaskDef.class
         ) {
-            topicName = config.getPepeCmdTopicName();
+            topicName = config.getMetadataCmdTopicName();
         } else {
             topicName = config.getCoreCmdTopicName();
         }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/ServerTopology.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/ServerTopology.java
@@ -101,7 +101,7 @@ public class ServerTopology {
 
         topo.addProcessor(
             PEPE_PROCESSOR,
-            () -> new CommandProcessor(config, server, wfSpecCache, PEPE_STORE),
+            () -> new CommandProcessor(config, server, wfSpecCache, PEPE_STORE, true),
             PEPE_SOURCE
         );
 
@@ -123,9 +123,8 @@ public class ServerTopology {
 
         topo.addProcessor(
             CORE_PROCESSOR,
-            () -> {
-                return new CommandProcessor(config, server, wfSpecCache, CORE_STORE);
-            },
+            () ->
+                new CommandProcessor(config, server, wfSpecCache, CORE_STORE, false),
             CORE_SOURCE
         );
 

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/coreprocessors/KafkaStreamsLHDAOImpl.java
@@ -1,7 +1,5 @@
 package io.littlehorse.server.streamsimpl.coreprocessors;
 
-import static io.littlehorse.server.streamsimpl.ServerTopology.PEPE_STORE;
-
 import com.google.protobuf.Message;
 import io.littlehorse.common.LHConfig;
 import io.littlehorse.common.LHConstants;

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -136,4 +136,8 @@ public class LHStoreWrapper extends LHROStoreWrapper {
         totalPuts = 0;
         totalDeletes = 0;
     }
+
+    public String getName() {
+        return store.name();
+    }
 }

--- a/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
+++ b/server/src/main/java/io/littlehorse/server/streamsimpl/storeinternals/LHStoreWrapper.java
@@ -136,8 +136,4 @@ public class LHStoreWrapper extends LHROStoreWrapper {
         totalPuts = 0;
         totalDeletes = 0;
     }
-
-    public String getName() {
-        return store.name();
-    }
 }


### PR DESCRIPTION
Separates metadata into its own processor. The separation is meant to be done incrementally, right now it was implemented with the fewest code changes possible. In a future commit we will be refactoring the code so that Metadata and Run processors do not share the same DAO and CommandProcessor classes.

**Note:** Search is not working. Everything else is, at least everything that is covered by e2e tests. 