### PR TITLE
MINOR: allows hyphens in listener name

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHConfig.java
@@ -447,7 +447,7 @@ public class LHConfig extends ConfigBase {
 
         if (
             !rawAuthProtocolMap.matches(
-                "([a-zA-Z0-9_]+:(" + regexAllAuthProtocols + ")+,?)+"
+                "([a-zA-Z0-9_-]+:(" + regexAllAuthProtocols + ")+,?)+"
             )
         ) {
             throw new LHMisconfigurationException(
@@ -487,7 +487,9 @@ public class LHConfig extends ConfigBase {
             .collect(Collectors.joining("|"));
 
         if (
-            !rawProtocolMap.matches("([a-zA-Z0-9_]+:(" + regexAllProtocols + ")+,?)+")
+            !rawProtocolMap.matches(
+                "([a-zA-Z0-9_-]+:(" + regexAllProtocols + ")+,?)+"
+            )
         ) {
             throw new LHMisconfigurationException(
                 "Invalid configuration: " + LHConfig.LISTENERS_PROTOCOL_MAP_KEY
@@ -586,7 +588,7 @@ public class LHConfig extends ConfigBase {
         );
 
         if (
-            !rawListenersConfig.matches("([a-zA-Z0-9_]+://[a-zA-Z0-9.\\-]+:\\d+,?)+")
+            !rawListenersConfig.matches("([a-zA-Z0-9_-]+://[a-zA-Z0-9.\\-]+:\\d+,?)+")
         ) {
             throw new LHMisconfigurationException(
                 "Invalid configuration: " + LHConfig.ADVERTISED_LISTENERS_KEY


### PR DESCRIPTION
allows hyphens in listener name on Protocol Map, authorization map, and advertised listeners map.