### PR TITLE
Variable Search Improvement

### DIFF
--- a/examples/variables/src/main/java/io/littlehorse/examples/VariablesExample.java
+++ b/examples/variables/src/main/java/io/littlehorse/examples/VariablesExample.java
@@ -4,6 +4,7 @@ import static io.littlehorse.sdk.common.proto.IndexType.LOCAL_INDEX;
 import static io.littlehorse.sdk.common.proto.IndexType.REMOTE_INDEX;
 
 import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.proto.IndexType;
 import io.littlehorse.sdk.common.proto.LHPublicApiGrpc;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
 import io.littlehorse.sdk.common.proto.VariableType;
@@ -36,20 +37,25 @@ public class VariablesExample {
                 WfRunVariable inputText = thread
                     .addVariable("input-text", VariableType.STR)
                     .withIndex(LOCAL_INDEX);
-                WfRunVariable addLength = thread.addVariable(
+
+                    WfRunVariable addLength = thread.addVariable(
                     "add-length",
                     VariableType.BOOL
-                );
+                ).withIndex(IndexType.LOCAL_INDEX);
+
                 WfRunVariable userId = thread
                     .addVariable("user-id", VariableType.INT)
                     .withIndex(REMOTE_INDEX);
-                WfRunVariable sentimentScore = thread
+
+                    WfRunVariable sentimentScore = thread
                     .addVariable("sentiment-score", VariableType.DOUBLE)
                     .withIndex(LOCAL_INDEX);
-                WfRunVariable processedResult = thread
+
+                    WfRunVariable processedResult = thread
                     .addVariable("processed-result", VariableType.JSON_OBJ)
                     .withJsonIndex("$.sentimentScore", REMOTE_INDEX);
-                NodeOutput sentimentAnalysisOutput = thread.execute(
+
+                    NodeOutput sentimentAnalysisOutput = thread.execute(
                     "sentiment-analysis",
                     inputText
                 );

--- a/examples/variables/src/main/java/io/littlehorse/examples/VariablesExample.java
+++ b/examples/variables/src/main/java/io/littlehorse/examples/VariablesExample.java
@@ -38,7 +38,7 @@ public class VariablesExample {
                     .addVariable("input-text", VariableType.STR)
                     .withIndex(LOCAL_INDEX);
 
-                    WfRunVariable addLength = thread.addVariable(
+                WfRunVariable addLength = thread.addVariable(
                     "add-length",
                     VariableType.BOOL
                 ).withIndex(IndexType.LOCAL_INDEX);
@@ -47,15 +47,15 @@ public class VariablesExample {
                     .addVariable("user-id", VariableType.INT)
                     .withIndex(REMOTE_INDEX);
 
-                    WfRunVariable sentimentScore = thread
+                WfRunVariable sentimentScore = thread
                     .addVariable("sentiment-score", VariableType.DOUBLE)
                     .withIndex(LOCAL_INDEX);
 
-                    WfRunVariable processedResult = thread
+                WfRunVariable processedResult = thread
                     .addVariable("processed-result", VariableType.JSON_OBJ)
                     .withJsonIndex("$.sentimentScore", REMOTE_INDEX);
 
-                    NodeOutput sentimentAnalysisOutput = thread.execute(
+                NodeOutput sentimentAnalysisOutput = thread.execute(
                     "sentiment-analysis",
                     inputText
                 );

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/Workflow.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/Workflow.java
@@ -117,7 +117,6 @@ public abstract class Workflow {
      *
      * @param client is an LHClient.
      * @return true if the workflow spec is registered or false otherwise
-     * @throws LHApiError if the call fails.
      */
     public boolean doesWfSpecExist(LHPublicApiBlockingStub client) {
         try {
@@ -139,7 +138,6 @@ public abstract class Workflow {
      * @param client is an LHClient.
      * @param version workflow version
      * @return true if the workflow spec is registered for this version or false otherwise
-     * @throws LHApiError
      */
     public boolean doesWfSpecExist(LHPublicApiBlockingStub client, Integer version) {
         if (version == null) return doesWfSpecExist(client);
@@ -162,7 +160,6 @@ public abstract class Workflow {
      * Workflow::registerWfSpec() is the same as client.putWfSpec(workflow.compileWorkflow()).
      *
      * @param client is an LHClient.
-     * @throws LHApiError if the call fails.
      */
     public void registerWfSpec(LHPublicApiBlockingStub client) {
         log.info("Creating wfSpec:\n {}", LHLibUtil.protoToJson(client.putWfSpec(compileWorkflow())));

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/LHTaskWorker.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/LHTaskWorker.java
@@ -85,7 +85,6 @@ public class LHTaskWorker implements Closeable {
      * Checks if the TaskDef exists
      *
      * @return true if the task is registered or false otherwise
-     * @throws LHApiError if the call fails.
      */
     public boolean doesTaskDefExist() {
         try {
@@ -103,7 +102,6 @@ public class LHTaskWorker implements Closeable {
      * Deploys the TaskDef object to the LH Server. This is a convenience method, generally not
      * recommended for production (in production you should manually use the PutTaskDef).
      *
-     * @throws LHApiError if the call fails.
      */
     public void registerTaskDef() {
         registerTaskDef(false);
@@ -180,9 +178,7 @@ public class LHTaskWorker implements Closeable {
     /**
      * Starts polling for and executing tasks.
      *
-     * @throws LHApiError if the schema from the TaskDef configured in the configProps is
-     *     incompatible with the method signature from the provided executable Java object, or if
-     *     the Worker cannot connect to the LH Server.
+     * @throws IOException if unexpected error occurs opening connections.
      */
     public void start() throws IOException {
         if (!doesTaskDefExist()) {

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.LHServerConfig;
@@ -469,6 +470,8 @@ public class KafkaStreamsServerImpl extends LHPublicApiImplBase {
             }
             ctx.onNext((RP) out.toProto().build());
             ctx.onCompleted();
+        } catch (StatusRuntimeException exn) {
+            ctx.onError(exn);
         } catch (Exception exn) {
             log.error("Failed handling a search", exn);
             ctx.onError(LHUtil.toGrpcError(exn));


### PR DESCRIPTION
Returns a proper grpc response to client when the request specifies a variable that doesn't exist, doesn't have an index, or has a different type than requested in Search Variable rpc.