### PR TITLE
--quick option for local docker build

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -79,10 +79,16 @@ Upgrade to a new version:
 
 ## Building the Docker Image
 
-You can build the `littlehorse` docker image by running:
+You can build the `littlehorse-server` and `littlehorse-standalone` docker images by running:
 
 ```
 ./local-dev/build.sh
+```
+
+To build the `littlehorse-server` image for local development utilizing the local gradle cache, you can run:
+
+```
+./local-dev/build.sh --quick
 ```
 
 Run server with docker (default config `local-dev/server-1.config`):

--- a/local-dev/build.sh
+++ b/local-dev/build.sh
@@ -9,8 +9,6 @@ CONTEXT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 cd "$CONTEXT_DIR"
 
-CONTAINER=lh-quickbuilder
-
 if [ "$1" == "--quick" ]; then
     # The quick build compiles the jar using gradle on the host machine, which
     # enables usage of the gradle cache. This is much faster than building from

--- a/local-dev/build.sh
+++ b/local-dev/build.sh
@@ -9,10 +9,28 @@ CONTEXT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 
 cd "$CONTEXT_DIR"
 
-echo "Building server"
-docker build --file ${LH_SERVER_WORK_DIR}/Dockerfile \
-    --tag littlehorse/littlehorse-server:latest ${CONTEXT_DIR}
+CONTAINER=lh-quickbuilder
 
-echo "Building standalone"
-docker build --file ${LH_STANDALONE_WORK_DIR}/Dockerfile \
-    --tag littlehorse/littlehorse-standalone:latest ${CONTEXT_DIR}
+if [ "$1" == "--quick" ]; then
+    # The quick build compiles the jar using gradle on the host machine, which
+    # enables usage of the gradle cache. This is much faster than building from
+    # scratch in a fresh container, and is suitable for local development.
+    echo "Building server image using host machine's gradle cache"
+    cd ${CONTEXT_DIR}
+    gradle server:shadowJar -x test
+
+    docker build -f ${SCRIPT_DIR}/util/Dockerfile.server-quick \
+        --tag littlehorse/littlehorse-server:latest ${CONTEXT_DIR}
+else
+    # Build from scratch using the same Dockerfiles used in our CI/CD
+    # pipeline. Also, we build the standalone image as well.
+    echo "Building server and standalone images from scratch inside Docker environment"
+
+    echo "Building server"
+    docker build --file ${LH_SERVER_WORK_DIR}/Dockerfile \
+        --tag littlehorse/littlehorse-server:latest ${CONTEXT_DIR}
+
+    echo "Building standalone"
+    docker build --file ${LH_STANDALONE_WORK_DIR}/Dockerfile \
+        --tag littlehorse/littlehorse-standalone:latest ${CONTEXT_DIR}
+fi

--- a/local-dev/util/Dockerfile.server-quick
+++ b/local-dev/util/Dockerfile.server-quick
@@ -1,0 +1,9 @@
+FROM amazoncorretto:17
+
+WORKDIR /lh
+
+COPY ./docker/server/docker-entrypoint.sh /lh
+COPY ./docker/server/log4j2.properties /lh
+COPY ./server/build/libs/server-*-all.jar /lh/server.jar
+ENTRYPOINT ["/lh/docker-entrypoint.sh"]
+CMD ["server"]


### PR DESCRIPTION
Adds a --quick option to local-dev/build.sh which uses local gradle cache to build.