### PR TITLE
fixes BackendInternalComms#getObject()

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -183,6 +183,7 @@ public class BackendInternalComms implements Closeable {
                             .getObject(GetObjectRequest.newBuilder()
                                     .setObjectType(objectId.getType())
                                     .setObjectId(objectId.toString())
+                                    .setPartition(metadata.partition())
                                     .build())
                             .getResponse()
                             .toByteArray(),


### PR DESCRIPTION
We didn't set the partition on the request, so proto made it default to 0. Some learnings:

* We need to start running e2e-tests in a distributed environment (not just one server)
* I ran them with a 3-node cluster on my local box. Flakiness increases quite a bit, but eventually it passed. Specifically, metadata propagation takes longer and is harder to verify.