### PR TITLE
Fix python task worker error handling logs:

### DIFF
--- a/sdk-python/littlehorse/worker.py
+++ b/sdk-python/littlehorse/worker.py
@@ -275,19 +275,19 @@ class LHConnection:
         try:
             output = to_variable_value(await self._task._callable(*args))
             status = TaskStatus.TASK_SUCCESS
-        except LHTaskException as le:
+        except LHTaskException:
             output = None
             stacktrace = traceback.format_exc()
             logging.error(stacktrace)
             context.log(stacktrace)
             status = TaskStatus.TASK_EXCEPTION
-        except TypeError as te:
+        except TypeError:
             output = None
             stacktrace = traceback.format_exc()
             logging.error(stacktrace)
             context.log(stacktrace)
             status = TaskStatus.TASK_OUTPUT_SERIALIZING_ERROR
-        except BaseException as be:
+        except BaseException:
             output = None
             stacktrace = traceback.format_exc()
             logging.error(stacktrace)

--- a/sdk-python/littlehorse/worker.py
+++ b/sdk-python/littlehorse/worker.py
@@ -5,6 +5,7 @@ import functools
 from inspect import Parameter, signature, iscoroutinefunction
 import logging
 import signal
+import traceback
 from typing import Any, AsyncIterator, Callable, Optional
 from littlehorse.config import LHConfig
 from littlehorse.exceptions import (
@@ -276,15 +277,21 @@ class LHConnection:
             status = TaskStatus.TASK_SUCCESS
         except LHTaskException as le:
             output = None
-            context.log(le)
+            stacktrace = traceback.format_exc()
+            logging.error(stacktrace)
+            context.log(stacktrace)
             status = TaskStatus.TASK_EXCEPTION
         except TypeError as te:
             output = None
-            context.log(te)
+            stacktrace = traceback.format_exc()
+            logging.error(stacktrace)
+            context.log(stacktrace)
             status = TaskStatus.TASK_OUTPUT_SERIALIZING_ERROR
         except BaseException as be:
             output = None
-            context.log(be)
+            stacktrace = traceback.format_exc()
+            logging.error(stacktrace)
+            context.log(stacktrace)
             status = TaskStatus.TASK_FAILED
 
         self._schedule_task_semaphore.release()

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/TaskNodeReferenceModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/TaskNodeReferenceModel.java
@@ -5,7 +5,6 @@ import io.littlehorse.common.LHConstants;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.dao.CoreProcessorDAO;
 import io.littlehorse.common.model.getable.core.noderun.NodeRunModel;
-import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.model.getable.core.wfrun.failure.FailureModel;
 import io.littlehorse.common.model.getable.objectId.NodeRunIdModel;
 import io.littlehorse.common.model.getable.objectId.WfSpecIdModel;
@@ -55,10 +54,6 @@ public class TaskNodeReferenceModel extends TaskRunSubSource<TaskNodeReference> 
         FailureModel failure;
         if (!lastFailure.containsException()) {
             String message = getMessageFor(lastFailure.getStatus());
-            VariableValueModel stderr = lastFailure.getLogOutput();
-            if (stderr != null && stderr.getVal() != null) {
-                message += ": " + stderr.getVal().toString();
-            }
             if (lastFailure.getError() == null) { // check for compatibility
                 failure = new FailureModel(message, getFailureCodeFor(lastFailure.getStatus()));
             } else {


### PR DESCRIPTION
- now print stacktrace in console logs rather than swallow it
- log the stacktrace back to LH Server so it is reported with the WfRun.