### PR TITLE
Properly utilizes the Rack ID configuration in the LH Server Config:

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.5.2
 group=io.littlehorse
-kafkaVersion=3.5.0
+kafkaVersion=3.6.0
 lombokVersion=1.18.28
 grpcVersion=1.56.1
 junitVersion=5.9.2


### PR DESCRIPTION
- Standby tasks, global consumer, and restoring active tasks now fetch from followers
- Processing Active Tasks still fetch from the leader to ensure lowest latency possible
- Enable rack-aware task assignment for standby replicas

Streams config cleanup:
- Remove ill-advised fetch.max.wait.ms=20 config, which incurred unnecessary load on brokers and also extra network traffic.
- Increase request timeout to 60 seconds
- Increase transaction timeout to 60 seconds
- Ensure that all request timeouts (consumer, producer, admin client) use the same config