### PR TITLE
Two fixes to test harness:

### DIFF
--- a/lh-test/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/lh-test/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -1,6 +1,7 @@
 package io.littlehorse.test.internal;
 
 import io.grpc.StatusRuntimeException;
+import io.grpc.Status.Code;
 import io.littlehorse.sdk.common.config.LHConfig;
 import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
@@ -81,8 +82,15 @@ public class TestContext {
             PutExternalEventDefRequest putExternalEventDefRequest = PutExternalEventDefRequest.newBuilder()
                     .setName(externalEventDef.getName())
                     .build();
-            ExternalEventDef externalEventDefResult = lhClient.putExternalEventDef(putExternalEventDefRequest);
-            externalEventDefMap.put(externalEventDefResult.getName(), externalEventDefResult);
+
+            try {
+                ExternalEventDef externalEventDefResult = lhClient.putExternalEventDef(putExternalEventDefRequest);
+                externalEventDefMap.put(externalEventDefResult.getName(), externalEventDefResult);
+            } catch (StatusRuntimeException exn) {
+                if (exn.getStatus().getCode() != Code.ALREADY_EXISTS) {
+                    throw exn;
+                }
+            }
         }
     }
 

--- a/lh-test/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/lh-test/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -1,7 +1,7 @@
 package io.littlehorse.test.internal;
 
-import io.grpc.StatusRuntimeException;
 import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
 import io.littlehorse.sdk.common.config.LHConfig;
 import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;

--- a/server/src/test/java/e2e/WaitForThreadsTest.java
+++ b/server/src/test/java/e2e/WaitForThreadsTest.java
@@ -162,7 +162,7 @@ public class WaitForThreadsTest {
 
     @LHWorkflow("wait-for-threads-with-exception-handler")
     public Workflow buildWaitForThreadsWithExceptionHandlerWorkflow() {
-        return new WorkflowImpl("parallel-approval", thread -> {
+        return new WorkflowImpl("wait-for-threads-with-exception-handler", thread -> {
             // Initialize variables.
             WfRunVariable person1Approved = thread.addVariable("person-1-approved", VariableType.BOOL);
             WfRunVariable person2Approved = thread.addVariable("person-2-approved", VariableType.BOOL);
@@ -216,7 +216,7 @@ public class WaitForThreadsTest {
 
     @LHWorkflow("wait-for-threads-without-exception-handler")
     public Workflow buildWaitForThreadsWithoutExceptionHandlerWorkflow() {
-        return new WorkflowImpl("parallel-approval", thread -> {
+        return new WorkflowImpl("wait-for-threads-without-exception-handler", thread -> {
             // Initialize variables.
             WfRunVariable person1Approved = thread.addVariable("person-1-approved", VariableType.BOOL);
             WfRunVariable person2Approved = thread.addVariable("person-2-approved", VariableType.BOOL);


### PR DESCRIPTION
- dont reuse same workflow name parallel-approval
- Ignore already exist errors on external event def's which makes ExternalBootstrapper work better