### PR TITLE
MINOR: Remove Dangling Exit Node

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
@@ -83,7 +83,10 @@ final class WorkflowThreadImpl implements WorkflowThread {
         func.threadFunction(this);
 
         // Now add an exit node.
-        addNode("exit", NodeCase.EXIT, ExitNode.newBuilder().build());
+        Node node = spec.getNodesOrThrow(lastNodeName);
+        if (node.getNodeCase() != NodeCase.EXIT) {
+            addNode("exit", NodeCase.EXIT, ExitNode.newBuilder().build());
+        }
         isActive = false;
     }
 
@@ -691,7 +694,7 @@ final class WorkflowThreadImpl implements WorkflowThread {
         checkIfIsActive();
         String nextNodeName = getNodeName(name, type);
         if (lastNodeName == null) {
-            throw new RuntimeException("Not possible to have null last node here");
+            throw new IllegalStateException("Not possible to have null last node here");
         }
 
         Node.Builder feederNode = spec.getNodesOrThrow(lastNodeName).toBuilder();


### PR DESCRIPTION
Fixes issue in Java SDK where we add an unneeded exit node if the user calls `WorkflowThread#fail()` as the last invocation in the workflow thread building function. No impact on actual workflow execution; just makes the dashboard look confusing.