### PR TITLE
Go SDK Variable Type Fix

### DIFF
--- a/sdk-go/common/lh_variables.go
+++ b/sdk-go/common/lh_variables.go
@@ -74,28 +74,71 @@ func StrToVarVal(input string, varType model.VariableType) (*model.VariableValue
 	return out, nil
 }
 
-func GetVarType(thing interface{}) model.VariableType {
+func VarValToVarType(varVal *model.VariableValue) *model.VariableType {
+	if varVal.GetValue() == nil {
+		return nil
+	}
+	switch varVal.GetValue().(type) {
+	case *model.VariableValue_Bool:
+		result := model.VariableType_BOOL
+		return &result
+	case *model.VariableValue_Bytes:
+		result := model.VariableType_BYTES
+		return &result
+	case *model.VariableValue_Double:
+		result := model.VariableType_DOUBLE
+		return &result
+	case *model.VariableValue_Int:
+		result := model.VariableType_INT
+		return &result
+	case *model.VariableValue_JsonArr:
+		result := model.VariableType_JSON_ARR
+		return &result
+	case *model.VariableValue_JsonObj:
+		result := model.VariableType_JSON_OBJ
+		return &result
+	case *model.VariableValue_Str:
+	}
+	result := model.VariableType_STR
+	return &result
+}
+
+func GetVarType(thing interface{}) *model.VariableType {
+	if thing == nil {
+		return nil
+	}
 	switch e := thing.(type) {
 	case model.VariableType:
-		return e
-	case int, int32, int64:
-		return model.VariableType_INT
-	case float32, float64:
-		return model.VariableType_DOUBLE
-	case string:
-		return model.VariableType_STR
-	case bool:
-		return model.VariableType_BOOL
-	case []byte:
-		return model.VariableType_BYTES
+		return &e
+	case model.VariableValue:
+		return VarValToVarType(&e)
+	case *model.VariableValue:
+		return VarValToVarType(e)
+	case int, int32, int64, *int, *int32, *int64:
+		result := model.VariableType_INT
+		return &result
+	case float32, float64, *float32, *float64:
+		result := model.VariableType_DOUBLE
+		return &result
+	case string, *string:
+		result := model.VariableType_STR
+		return &result
+	case bool, *bool:
+		result := model.VariableType_BOOL
+		return &result
+	case []byte, *[]byte:
+		result := model.VariableType_BYTES
+		return &result
 	default:
 		// This is risky, for now we assume that all objects can be serialized
 		// to JSON.
 		isAList := reflect.TypeOf(e).Kind() == reflect.Slice
 		if isAList {
-			return model.VariableType_JSON_ARR
+			result := model.VariableType_JSON_ARR
+			return &result
 		} else {
-			return model.VariableType_JSON_OBJ
+			result := model.VariableType_JSON_OBJ
+			return &result
 		}
 	}
 }

--- a/sdk-go/wflib/wf_lib_internal.go
+++ b/sdk-go/wflib/wf_lib_internal.go
@@ -529,7 +529,7 @@ func (t *WorkflowThread) addVariable(
 		if err != nil {
 			log.Fatal(err)
 		}
-		if common.GetVarType(defaultVarVal.GetValue()) != varType {
+		if *common.GetVarType(defaultVarVal) != varType {
 			log.Fatal("provided default value for variable " + name + " didn't match type " + varType.String())
 		}
 		varDef.DefaultValue = defaultVarVal

--- a/sdk-go/wflib/wf_lib_internal_test.go
+++ b/sdk-go/wflib/wf_lib_internal_test.go
@@ -3,6 +3,7 @@ package wflib_test
 import (
 	"testing"
 
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/common"
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/common/model"
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/wflib"
 	"github.com/stretchr/testify/assert"
@@ -373,4 +374,45 @@ func TestCatchAnyFailure(t *testing.T) {
 	_, ok := putWf.ThreadSpecs[handler.HandlerSpecName]
 	assert.True(t, ok)
 	assert.Nil(t, handler.GetFailureToCatch())
+}
+
+type someObject struct {
+	Foo int32
+	Bar string
+}
+
+func TestVarValToVarType(t *testing.T) {
+	// Int
+	varVal, err := common.InterfaceToVarVal(123)
+	assert.Nil(t, err)
+	varType := common.VarValToVarType(varVal)
+	assert.Equal(t, *varType, model.VariableType_INT)
+
+	// Str
+	varVal, err = common.InterfaceToVarVal("hello there")
+	assert.Nil(t, err)
+	varType = common.VarValToVarType(varVal)
+	assert.Equal(t, *varType, model.VariableType_STR)
+
+	// Str pointer
+	mystr := "hello there"
+	varVal, err = common.InterfaceToVarVal(&mystr)
+	assert.Nil(t, err)
+	varType = common.VarValToVarType(varVal)
+	assert.Equal(t, *varType, model.VariableType_STR)
+	assert.Equal(t, varVal.GetStr(), mystr)
+
+	// struct/JSON_OBJ
+	varVal, err = common.InterfaceToVarVal(someObject{
+		Foo: 137,
+		Bar: "meaningoflife",
+	})
+	assert.Nil(t, err)
+	varType = common.VarValToVarType(varVal)
+	assert.Equal(t, *varType, model.VariableType_JSON_OBJ)
+
+	// Nil varval
+	varVal = &model.VariableValue{}
+	varType = common.VarValToVarType(varVal)
+	assert.Nil(t, varType)
 }


### PR DESCRIPTION
Previously, the common.GetVarType() function did not work when a VariableValue was passed in. This was due to improper inspection of the Go Protobuf Oneof, which has been fixed and tested in this PR.