### PR TITLE
MINOR: updates lhctl version.

### DIFF
--- a/lhctl/cmd/version.go
+++ b/lhctl/cmd/version.go
@@ -14,7 +14,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print Client and Server Version Information.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("lhctl version: 0.7.0-alpha.4")
+		fmt.Println("lhctl version: 0.7.0")
 
 		resp, err := getGlobalClient(cmd).GetServerVersion(requestContext(), &emptypb.Empty{})
 		if err != nil {

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -809,7 +809,6 @@ public class KafkaStreamsServerImpl extends LittleHorseImplBase {
                 .setMajorVersion(0)
                 .setMinorVersion(7)
                 .setMajorVersion(0)
-                .setPreReleaseIdentifier("alpha.4")
                 .build());
         ctx.onCompleted();
     }


### PR DESCRIPTION
Updates lhctl version to 0.7.0 in preparation for the release. TODO: this needs to be automated in our release script.