### PR TITLE
PutUserTaskDefRequest idempotency

### DIFF
--- a/examples/user-tasks/src/main/java/io/littlehorse/examples/UserTasksExample.java
+++ b/examples/user-tasks/src/main/java/io/littlehorse/examples/UserTasksExample.java
@@ -16,12 +16,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UserTasksExample {
-
-    private static final Logger log = LoggerFactory.getLogger(UserTasksExample.class);
 
     private static final String WF_NAME = "it-request";
     public static final String EMAIL_TASK_NAME = "send-email";
@@ -158,45 +154,20 @@ public class UserTasksExample {
         // New worker
         LHTaskWorker worker = getTaskWorker(config);
 
-        // Register task if it does not exist
-        if (worker.doesTaskDefExist()) {
-            log.warn(
-                "Task {} already exists, skipping creation",
-                worker.getTaskDefName()
-            );
-        } else {
-            log.debug(
-                "Task {} does not exist, registering it",
-                worker.getTaskDefName()
-            );
-            worker.registerTaskDef();
-        }
-
         // Create the User Task Def
         UserTaskSchema requestForm = new UserTaskSchema(
             new ItemRequestForm(),
             IT_REQUEST_FORM
         );
         client.putUserTaskDef(requestForm.compile());
+
         UserTaskSchema approvalForm = new UserTaskSchema(
             new ApprovalForm(),
             APPROVAL_FORM
         );
         client.putUserTaskDef(approvalForm.compile());
 
-        // Register a workflow if it does not exist
-        if (workflow.doesWfSpecExist(client)) {
-            log.warn(
-                "Workflow {} already exists, skipping creation",
-                workflow.getName()
-            );
-        } else {
-            log.debug(
-                "Workflow {} does not exist, registering it",
-                workflow.getName()
-            );
-            workflow.registerWfSpec(client);
-        }
+        workflow.registerWfSpec(client);
 
         // Run the worker
         worker.start();

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutUserTaskDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutUserTaskDefRequestModel.java
@@ -10,6 +10,7 @@ import io.littlehorse.common.model.getable.global.wfspec.node.subnode.usertasks.
 import io.littlehorse.common.model.getable.objectId.UserTaskDefIdModel;
 import io.littlehorse.common.model.metadatacommand.MetadataSubCommand;
 import io.littlehorse.common.util.LHUtil;
+import io.littlehorse.common.util.UserTaskUtil;
 import io.littlehorse.sdk.common.proto.PutUserTaskDefRequest;
 import io.littlehorse.sdk.common.proto.UserTaskDef;
 import io.littlehorse.sdk.common.proto.UserTaskField;
@@ -77,7 +78,10 @@ public class PutUserTaskDefRequestModel extends MetadataSubCommand<PutUserTaskDe
         spec.createdAt = new Date();
 
         UserTaskDefModel oldVersion = metadataManager.lastFromPrefix(UserTaskDefIdModel.getPrefix(name));
+
         if (oldVersion != null) {
+            if (UserTaskUtil.equals(spec, oldVersion))
+                return oldVersion.toProto().build();
             spec.version = oldVersion.version + 1;
         } else {
             spec.version = 0;

--- a/server/src/main/java/io/littlehorse/common/util/UserTaskUtil.java
+++ b/server/src/main/java/io/littlehorse/common/util/UserTaskUtil.java
@@ -1,0 +1,28 @@
+package io.littlehorse.common.util;
+
+import com.google.protobuf.Timestamp;
+import io.littlehorse.common.model.getable.global.wfspec.node.subnode.usertasks.UserTaskDefModel;
+import io.littlehorse.sdk.common.proto.UserTaskDef;
+import java.util.Arrays;
+import java.util.Date;
+
+public class UserTaskUtil {
+    private UserTaskUtil() {}
+
+    private static Integer baseVersion = 0;
+
+    public static boolean equals(UserTaskDefModel left, UserTaskDefModel right) {
+        UserTaskDef.Builder copy = left.toProto();
+        UserTaskDef.Builder toCopy = right.toProto();
+
+        Timestamp date = LHUtil.fromDate(new Date());
+        sanitize(copy, date);
+        sanitize(toCopy, date);
+
+        return Arrays.equals(copy.build().toByteArray(), toCopy.build().toByteArray());
+    }
+
+    private static void sanitize(UserTaskDef.Builder task, Timestamp time) {
+        task.setCreatedAt(time).setVersion(baseVersion);
+    }
+}

--- a/server/src/test/java/e2e/UserTaskIdempotencyTest.java
+++ b/server/src/test/java/e2e/UserTaskIdempotencyTest.java
@@ -1,0 +1,58 @@
+package e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.UserTaskDef;
+import io.littlehorse.sdk.usertask.UserTaskSchema;
+import io.littlehorse.sdk.usertask.annotations.UserTaskField;
+import io.littlehorse.test.LHTest;
+import org.junit.jupiter.api.Test;
+
+@LHTest
+public class UserTaskIdempotencyTest {
+
+    private LittleHorseBlockingStub client;
+
+    @Test
+    void shouldBeIdempotent() {
+        String taskName = "sample-task";
+
+        UserTaskSchema schema = new UserTaskSchema(new SampleForm(), taskName);
+
+        UserTaskDef original = client.putUserTaskDef(schema.compile());
+        UserTaskDef copy = client.putUserTaskDef(schema.compile());
+
+        assertThat(original.getVersion()).isEqualTo(0);
+        assertThat(copy.getVersion()).isEqualTo(original.getVersion());
+    }
+
+    @Test
+    void shouldCreateNewVersion() {
+        String taskName = "sample-task";
+
+        UserTaskSchema schema = new UserTaskSchema(new SampleForm(), taskName);
+
+        UserTaskDef original = client.putUserTaskDef(schema.compile());
+
+        UserTaskSchema newSchema = new UserTaskSchema(new SampleFormUpdated(), taskName);
+        UserTaskDef copy = client.putUserTaskDef(newSchema.compile());
+
+        assertThat(original.getVersion()).isEqualTo(0);
+        assertThat(copy.getVersion()).isEqualTo(original.getVersion() + 1);
+    }
+}
+
+class SampleForm {
+
+    @UserTaskField(displayName = "Approved?", description = "Reply 'true' if this is an acceptable request.")
+    public boolean isApproved;
+}
+
+class SampleFormUpdated {
+    @UserTaskField(displayName = "Approved?", description = "Reply 'true' if this is an acceptable request.")
+    public boolean isApproved;
+
+    @UserTaskField(displayName = "Approved By?", description = "Put your name")
+    public String approvedBy;
+}

--- a/server/src/test/java/e2e/UserTaskIdempotencyTest.java
+++ b/server/src/test/java/e2e/UserTaskIdempotencyTest.java
@@ -29,7 +29,7 @@ public class UserTaskIdempotencyTest {
 
     @Test
     void shouldCreateNewVersion() {
-        String taskName = "sample-task";
+        String taskName = "updated-task";
 
         UserTaskSchema schema = new UserTaskSchema(new SampleForm(), taskName);
 

--- a/server/src/test/java/io/littlehorse/common/util/UserTaskUtilTest.java
+++ b/server/src/test/java/io/littlehorse/common/util/UserTaskUtilTest.java
@@ -1,0 +1,55 @@
+package io.littlehorse.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.littlehorse.common.model.getable.global.wfspec.node.subnode.usertasks.UserTaskDefModel;
+import io.littlehorse.sdk.common.proto.UserTaskDef;
+import io.littlehorse.sdk.common.proto.UserTaskField;
+import org.junit.jupiter.api.Test;
+
+public class UserTaskUtilTest {
+    @Test
+    void testshouldBeTrueWhenTwoUserTaskModelsAreEqual() {
+        UserTaskField.Builder field =
+                UserTaskField.newBuilder().setName("field").setDescription("description");
+        String name = "user-task";
+        UserTaskDef originalTask = UserTaskDef.newBuilder()
+                .addFields(field)
+                .setName(name)
+                .setVersion(1)
+                .build();
+        UserTaskDef copyTask = UserTaskDef.newBuilder()
+                .addFields(field)
+                .setName(name)
+                .setVersion(0)
+                .build();
+        UserTaskDefModel original = UserTaskDefModel.fromProto(originalTask, UserTaskDefModel.class, null);
+        UserTaskDefModel copy = UserTaskDefModel.fromProto(copyTask, UserTaskDefModel.class, null);
+
+        assertThat(UserTaskUtil.equals(original, copy)).isTrue();
+    }
+
+    @Test
+    void testshouldBeFalseWhenTwoUserTaskModelsAreDifferent() {
+        UserTaskField.Builder field =
+                UserTaskField.newBuilder().setName("field").setDescription("description");
+        String name = "user-task";
+        UserTaskDef originalTask = UserTaskDef.newBuilder()
+                .addFields(field)
+                .setName(name)
+                .setVersion(1)
+                .build();
+        UserTaskField.Builder newField =
+                UserTaskField.newBuilder().setName("new-field").setDescription("new-description");
+        UserTaskDef copyTask = UserTaskDef.newBuilder()
+                .addFields(field)
+                .addFields(newField)
+                .setName(name)
+                .setVersion(0)
+                .build();
+        UserTaskDefModel original = UserTaskDefModel.fromProto(originalTask, UserTaskDefModel.class, null);
+        UserTaskDefModel copy = UserTaskDefModel.fromProto(copyTask, UserTaskDefModel.class, null);
+
+        assertThat(UserTaskUtil.equals(original, copy)).isFalse();
+    }
+}


### PR DESCRIPTION
Adds idempotency to UserTask.

It will accept and compare a new userTask request to the previous version stored and verify equality using `UserTaksUtil.equals` static method.

If equals returns true, then no new version will be created and the current spec will be returned.
If equals returns false, then a new version will be created

It includes utils tests and e2e tests and updates `examples/user-task` to remove no longer required existence checks.