### PR TITLE
Enable idempotency to PutTaskDefRequest

### DIFF
--- a/examples/basic/src/main/java/io/littlehorse/examples/BasicExample.java
+++ b/examples/basic/src/main/java/io/littlehorse/examples/BasicExample.java
@@ -10,17 +10,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /*
  * This is a simple example, which does two things:
  * 1. Declare an "input-name" variable of type String
  * 2. Pass that variable into the execution of the "greet" task.
  */
 public class BasicExample {
-
-    private static final Logger log = LoggerFactory.getLogger(BasicExample.class);
 
     public static Workflow getWorkflow() {
         return new WorkflowImpl(
@@ -65,33 +60,11 @@ public class BasicExample {
         // New worker
         LHTaskWorker worker = getTaskWorker(config);
 
-        // Register task if it does not exist
-        if (worker.doesTaskDefExist()) {
-            log.debug(
-                "Task {} already exists, skipping creation",
-                worker.getTaskDefName()
-            );
-        } else {
-            log.debug(
-                "Task {} does not exist, registering it",
-                worker.getTaskDefName()
-            );
-            worker.registerTaskDef();
-        }
+        // Register task
+        worker.registerTaskDef();
 
-        // Register a workflow if it does not exist
-        if (workflow.doesWfSpecExist(config.getBlockingStub())) {
-            log.debug(
-                "Workflow {} already exists, skipping creation",
-                workflow.getName()
-            );
-        } else {
-            log.debug(
-                "Workflow {} does not exist, registering it",
-                workflow.getName()
-            );
-            workflow.registerWfSpec(config.getBlockingStub());
-        }
+        // Register a workflow
+        workflow.registerWfSpec(config.getBlockingStub());
 
         // Run the worker
         worker.start();

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTaskDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTaskDefRequestModel.java
@@ -9,6 +9,7 @@ import io.littlehorse.common.model.getable.global.wfspec.variable.VariableDefMod
 import io.littlehorse.common.model.getable.objectId.TaskDefIdModel;
 import io.littlehorse.common.model.metadatacommand.MetadataSubCommand;
 import io.littlehorse.common.util.LHUtil;
+import io.littlehorse.common.util.TaskDefUtil;
 import io.littlehorse.sdk.common.proto.PutTaskDefRequest;
 import io.littlehorse.sdk.common.proto.TaskDef;
 import io.littlehorse.sdk.common.proto.VariableDef;
@@ -65,13 +66,17 @@ public class PutTaskDefRequestModel extends MetadataSubCommand<PutTaskDefRequest
             throw new LHApiException(Status.INVALID_ARGUMENT, "TaskDefName must be a valid hostname");
         }
 
-        TaskDefModel oldVersion = metadataManager.get(new TaskDefIdModel(name));
-        if (oldVersion != null) {
-            throw new LHApiException(Status.ALREADY_EXISTS, "TaskDef already exists and is immutable.");
-        }
         TaskDefModel spec = new TaskDefModel();
         spec.setId(new TaskDefIdModel(name));
         spec.inputVars = inputVars;
+
+        TaskDefModel oldVersion = metadataManager.get(new TaskDefIdModel(name));
+        if (oldVersion != null) {
+            if (TaskDefUtil.equals(spec, oldVersion))
+                return oldVersion.toProto().build();
+            throw new LHApiException(Status.ALREADY_EXISTS, "TaskDef already exists and is immutable.");
+        }
+
         metadataManager.put(spec);
 
         return spec.toProto().build();

--- a/server/src/main/java/io/littlehorse/common/util/TaskDefUtil.java
+++ b/server/src/main/java/io/littlehorse/common/util/TaskDefUtil.java
@@ -1,0 +1,26 @@
+package io.littlehorse.common.util;
+
+import com.google.protobuf.Timestamp;
+import io.littlehorse.common.model.getable.global.taskdef.TaskDefModel;
+import io.littlehorse.sdk.common.proto.TaskDef;
+import java.util.Arrays;
+import java.util.Date;
+
+public class TaskDefUtil {
+    private TaskDefUtil() {}
+
+    public static boolean equals(TaskDefModel left, TaskDefModel right) {
+        TaskDef.Builder copy = left.toProto();
+        TaskDef.Builder toCopy = right.toProto();
+
+        Timestamp date = LHUtil.fromDate(new Date());
+        sanitize(copy, date);
+        sanitize(toCopy, date);
+
+        return Arrays.equals(copy.build().toByteArray(), toCopy.build().toByteArray());
+    }
+
+    private static void sanitize(TaskDef.Builder task, Timestamp time) {
+        task.setCreatedAt(time);
+    }
+}

--- a/server/src/test/java/e2e/TaskDefIdempotencyTest.java
+++ b/server/src/test/java/e2e/TaskDefIdempotencyTest.java
@@ -1,0 +1,61 @@
+package e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.grpc.StatusRuntimeException;
+import io.littlehorse.common.model.getable.global.taskdef.TaskDefModel;
+import io.littlehorse.common.util.TaskDefUtil;
+import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
+import io.littlehorse.sdk.common.proto.TaskDef;
+import io.littlehorse.sdk.wfsdk.internal.taskdefutil.TaskDefBuilder;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.test.LHTest;
+import org.junit.jupiter.api.Test;
+
+@LHTest
+public class TaskDefIdempotencyTest {
+
+    private LittleHorseBlockingStub client;
+
+    @Test
+    void shouldBeIdempotent() {
+        TaskDefBuilder task = new TaskDefBuilder(new TaskWorker(), "greet");
+        TaskDefBuilder taskCopy = new TaskDefBuilder(new TaskWorker(), "greet");
+        TaskDef original = client.putTaskDef(task.toPutTaskDefRequest());
+        TaskDef copy = client.putTaskDef(taskCopy.toPutTaskDefRequest());
+        assertThat(TaskDefUtil.equals(TaskDefModel.fromProto(original, null), TaskDefModel.fromProto(copy, null)))
+                .isTrue();
+    }
+
+    @Test
+    void shouldThrowAlreadyExistWhenTaskDefDifferent() {
+        TaskDefBuilder task = new TaskDefBuilder(new TaskWorker(), "greet-with-update");
+        client.putTaskDef(task.toPutTaskDefRequest());
+
+        TaskDefBuilder taskUpdated = new TaskDefBuilder(new TaskWorkerUpdated(), "greet-with-update");
+
+        assertThatThrownBy(() -> client.putTaskDef(taskUpdated.toPutTaskDefRequest()))
+                .isInstanceOf(StatusRuntimeException.class)
+                .hasMessage("ALREADY_EXISTS: TaskDef already exists and is immutable.");
+    }
+}
+
+class TaskWorker {
+    @LHTaskMethod("greet")
+    public String greeting(String name) {
+        return "hello there, " + name;
+    }
+
+    @LHTaskMethod("greet-with-update")
+    public String greetingUpdated(String name) {
+        return "hello there, " + name;
+    }
+}
+
+class TaskWorkerUpdated {
+    @LHTaskMethod("greet-with-update")
+    public String greetingUpdated(String name, String lastName) {
+        return "hello there, " + name;
+    }
+}

--- a/server/src/test/java/io/littlehorse/common/util/TaskDefUtilTest.java
+++ b/server/src/test/java/io/littlehorse/common/util/TaskDefUtilTest.java
@@ -1,0 +1,46 @@
+package io.littlehorse.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.littlehorse.common.model.getable.global.taskdef.TaskDefModel;
+import io.littlehorse.sdk.common.proto.TaskDef;
+import io.littlehorse.sdk.common.proto.TaskDefId;
+import io.littlehorse.sdk.common.proto.VariableDef;
+import io.littlehorse.sdk.common.proto.VariableType;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+public class TaskDefUtilTest {
+    @Test
+    void testshouldBeTrueWhenTwoTaskDefAreEqual() {
+        TaskDefId.Builder taskId = TaskDefId.newBuilder().setName("task-name");
+        VariableDef.Builder variable =
+                VariableDef.newBuilder().setName("variable").setType(VariableType.STR);
+        TaskDef.Builder originalDef =
+                TaskDef.newBuilder().setId(taskId).addInputVars(variable).setCreatedAt(LHUtil.fromDate(new Date()));
+        TaskDef.Builder copyDef = TaskDef.newBuilder().setId(taskId).addInputVars(variable);
+
+        TaskDefModel original = TaskDefModel.fromProto(originalDef.build(), null);
+        TaskDefModel copy = TaskDefModel.fromProto(copyDef.build(), null);
+
+        assertThat(TaskDefUtil.equals(original, copy)).isTrue();
+    }
+
+    @Test
+    void testshouldBeFalseWhenTwoTaskDefAreDifferent() {
+        TaskDefId.Builder taskId = TaskDefId.newBuilder().setName("task-name");
+        VariableDef.Builder variable =
+                VariableDef.newBuilder().setName("variable").setType(VariableType.STR);
+        TaskDef.Builder originalDef =
+                TaskDef.newBuilder().setId(taskId).addInputVars(variable).setCreatedAt(LHUtil.fromDate(new Date()));
+        VariableDef.Builder newVariable =
+                VariableDef.newBuilder().setName("new-variable").setType(VariableType.BOOL);
+        TaskDef.Builder copyDef =
+                TaskDef.newBuilder().setId(taskId).addInputVars(variable).addInputVars(newVariable);
+
+        TaskDefModel original = TaskDefModel.fromProto(originalDef.build(), null);
+        TaskDefModel copy = TaskDefModel.fromProto(copyDef.build(), null);
+
+        assertThat(TaskDefUtil.equals(original, copy)).isFalse();
+    }
+}


### PR DESCRIPTION
Enable idempotency on PutTaskDefRequest

### Includes
- [x] `TaskDefUtil.equals` tests
- [x] E2E tests