### PR TITLE
Enhancement/wait for taskdef on worker

### DIFF
--- a/sdk-java/build.gradle
+++ b/sdk-java/build.gradle
@@ -89,6 +89,7 @@ dependencies {
 
     // Utils
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.awaitility:awaitility:4.2.0'
 
     // OAuth
     implementation 'com.nimbusds:oauth2-oidc-sdk:10.9.2'

--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -5,7 +5,7 @@ import io.littlehorse.sdk.common.proto.TaskDefId;
 import io.littlehorse.sdk.worker.LHTaskWorker;
 import io.littlehorse.test.exception.LHTestExceptionUtil;
 import io.littlehorse.test.exception.LHTestInitializationException;
-import io.littlehorse.test.internal.StandaloneTestBootstrapper;
+import io.littlehorse.test.internal.ExternalTestBootstrapper;
 import io.littlehorse.test.internal.TestContext;
 import java.io.IOException;
 import java.time.Duration;
@@ -28,7 +28,7 @@ public class LHExtension implements BeforeAllCallback, TestInstancePostProcessor
         Awaitility.setDefaultTimeout(Duration.of(1000, ChronoUnit.MILLIS));
         getStore(context)
                 .getOrComputeIfAbsent(
-                        LH_TEST_CONTEXT, s -> new TestContext(new StandaloneTestBootstrapper()), TestContext.class);
+                        LH_TEST_CONTEXT, s -> new TestContext(new ExternalTestBootstrapper()), TestContext.class);
     }
 
     private ExtensionContext.Store getStore(ExtensionContext context) {

--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -5,7 +5,7 @@ import io.littlehorse.sdk.common.proto.TaskDefId;
 import io.littlehorse.sdk.worker.LHTaskWorker;
 import io.littlehorse.test.exception.LHTestExceptionUtil;
 import io.littlehorse.test.exception.LHTestInitializationException;
-import io.littlehorse.test.internal.ExternalTestBootstrapper;
+import io.littlehorse.test.internal.StandaloneTestBootstrapper;
 import io.littlehorse.test.internal.TestContext;
 import java.io.IOException;
 import java.time.Duration;
@@ -28,7 +28,7 @@ public class LHExtension implements BeforeAllCallback, TestInstancePostProcessor
         Awaitility.setDefaultTimeout(Duration.of(1000, ChronoUnit.MILLIS));
         getStore(context)
                 .getOrComputeIfAbsent(
-                        LH_TEST_CONTEXT, s -> new TestContext(new ExternalTestBootstrapper()), TestContext.class);
+                        LH_TEST_CONTEXT, s -> new TestContext(new StandaloneTestBootstrapper()), TestContext.class);
     }
 
     private ExtensionContext.Store getStore(ExtensionContext context) {

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -33,7 +33,7 @@ import org.awaitility.Awaitility;
 
 public class TestContext {
 
-    private final LHConfig LHConfig;
+    private final LHConfig config;
     private final LittleHorseBlockingStub lhClient;
 
     private final Map<String, ExternalEventDef> externalEventDefMap = new HashMap<>();
@@ -45,7 +45,7 @@ public class TestContext {
     private final Lock wfSpecStoreLock;
 
     public TestContext(TestBootstrapper bootstrapper) {
-        this.LHConfig = bootstrapper.getWorkerConfig();
+        this.config = bootstrapper.getWorkerConfig();
         this.lhClient = bootstrapper.getLhClient();
         this.wfSpecStoreLock = new ReentrantLock();
     }
@@ -55,7 +55,7 @@ public class TestContext {
         List<LHTaskMethod> annotatedMethods =
                 ReflectionUtil.findAnnotatedMethods(testInstance.getClass(), LHTaskMethod.class);
         for (LHTaskMethod annotatedMethod : annotatedMethods) {
-            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), LHConfig));
+            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), config));
         }
         return workers;
     }
@@ -128,7 +128,7 @@ public class TestContext {
 
     private void injectLhConfig(Object testInstance) {
         new FieldDependencyInjector(
-                () -> LHConfig, testInstance, field -> field.getType().isAssignableFrom(LHConfig.getClass()))
+                        () -> config, testInstance, field -> field.getType().isAssignableFrom(config.getClass()))
                 .inject();
     }
 
@@ -192,5 +192,9 @@ public class TestContext {
 
     public LittleHorseBlockingStub getLhClient() {
         return lhClient;
+    }
+
+    public LHConfig getConfig() {
+        return config;
     }
 }

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -33,7 +33,7 @@ import org.awaitility.Awaitility;
 
 public class TestContext {
 
-    private final LHConfig config;
+    private final LHConfig LHConfig;
     private final LittleHorseBlockingStub lhClient;
 
     private final Map<String, ExternalEventDef> externalEventDefMap = new HashMap<>();
@@ -45,7 +45,7 @@ public class TestContext {
     private final Lock wfSpecStoreLock;
 
     public TestContext(TestBootstrapper bootstrapper) {
-        this.config = bootstrapper.getWorkerConfig();
+        this.LHConfig = bootstrapper.getWorkerConfig();
         this.lhClient = bootstrapper.getLhClient();
         this.wfSpecStoreLock = new ReentrantLock();
     }
@@ -55,7 +55,7 @@ public class TestContext {
         List<LHTaskMethod> annotatedMethods =
                 ReflectionUtil.findAnnotatedMethods(testInstance.getClass(), LHTaskMethod.class);
         for (LHTaskMethod annotatedMethod : annotatedMethods) {
-            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), config));
+            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), LHConfig));
         }
         return workers;
     }
@@ -128,7 +128,7 @@ public class TestContext {
 
     private void injectLhConfig(Object testInstance) {
         new FieldDependencyInjector(
-                        () -> config, testInstance, field -> field.getType().isAssignableFrom(config.getClass()))
+                        () -> LHConfig, testInstance, field -> field.getType().isAssignableFrom(LHConfig.getClass()))
                 .inject();
     }
 
@@ -194,7 +194,7 @@ public class TestContext {
         return lhClient;
     }
 
-    public LHConfig getConfig() {
-        return config;
+    public LHConfig getLHConfig() {
+        return LHConfig;
     }
 }

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -33,7 +33,7 @@ import org.awaitility.Awaitility;
 
 public class TestContext {
 
-    private final LHConfig LHConfig;
+    private final LHConfig config;
     private final LittleHorseBlockingStub lhClient;
 
     private final Map<String, ExternalEventDef> externalEventDefMap = new HashMap<>();
@@ -45,7 +45,7 @@ public class TestContext {
     private final Lock wfSpecStoreLock;
 
     public TestContext(TestBootstrapper bootstrapper) {
-        this.LHConfig = bootstrapper.getWorkerConfig();
+        this.config = bootstrapper.getWorkerConfig();
         this.lhClient = bootstrapper.getLhClient();
         this.wfSpecStoreLock = new ReentrantLock();
     }
@@ -55,7 +55,7 @@ public class TestContext {
         List<LHTaskMethod> annotatedMethods =
                 ReflectionUtil.findAnnotatedMethods(testInstance.getClass(), LHTaskMethod.class);
         for (LHTaskMethod annotatedMethod : annotatedMethods) {
-            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), LHConfig));
+            workers.add(new LHTaskWorker(testInstance, annotatedMethod.value(), config));
         }
         return workers;
     }
@@ -128,7 +128,7 @@ public class TestContext {
 
     private void injectLhConfig(Object testInstance) {
         new FieldDependencyInjector(
-                        () -> LHConfig, testInstance, field -> field.getType().isAssignableFrom(LHConfig.getClass()))
+                        () -> config, testInstance, field -> field.getType().isAssignableFrom(config.getClass()))
                 .inject();
     }
 
@@ -194,7 +194,7 @@ public class TestContext {
         return lhClient;
     }
 
-    public LHConfig getLHConfig() {
-        return LHConfig;
+    public LHConfig getConfig() {
+        return config;
     }
 }

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -107,6 +107,7 @@ public class TestContext {
         List<DiscoveredWorkflowDefinition> discoveredWorkflowDefinitions = workflowDefinitionDiscover.scan();
         injectWorkflowDefinitions(testInstance, discoveredWorkflowDefinitions);
         injectLhClient(testInstance);
+        injectLhConfig(testInstance);
     }
 
     private void injectWorkflowDefinitions(
@@ -122,6 +123,12 @@ public class TestContext {
     private void injectLhClient(Object testInstance) {
         new FieldDependencyInjector(
                         () -> lhClient, testInstance, field -> field.getType().isAssignableFrom(lhClient.getClass()))
+                .inject();
+    }
+
+    private void injectLhConfig(Object testInstance) {
+        new FieldDependencyInjector(
+                () -> LHConfig, testInstance, field -> field.getType().isAssignableFrom(LHConfig.getClass()))
                 .inject();
     }
 


### PR DESCRIPTION
> Metadata is strongly consistent on the write path, but it is eventually consistent on the read path as it must propagate from the leader for the metadata topology to the global store on each of the Core SubTopology instances. This means that if you do a putTaskDef() and then LHTaskWorker#start() in quick succession, the Task Worker can crash with a TaskDef NOT_FOUND error.
> 
> This is not dangerous, since we still have consistent write processing and eventual consistency for reads.
> 
> To make this less of a pain in the butt, this commit makes the Java Task Worker wait (at most two seconds) until the TaskDef has propagated to the instances. It also adds an e2e test to verify this behavior. Before the modifications to LHTaskWorker.java, I verified that the e2e test failed."
[enhancement/wait-for-taskdef-on-worker ea13a352] ENHANCEMENT: Allows Task Worker to Wait for TaskDef
