### PR TITLE
Minor Fixes

### DIFF
--- a/sdk-go/common/lh_variables.go
+++ b/sdk-go/common/lh_variables.go
@@ -43,21 +43,21 @@ func StrToVarVal(input string, varType model.VariableType) (*model.VariableValue
 		// GoLang has this weird thing with scope of variables in switch...
 		var tmp int64
 		tmp, err = strconv.ParseInt(input, 10, 64)
-		if err != nil {
+		if err == nil {
 			out.Value = &model.VariableValue_Int{Int: tmp}
 		}
 
 	case model.VariableType_BOOL:
 		var tmp bool
 		tmp, err = strconv.ParseBool(input)
-		if err != nil {
+		if err == nil {
 			out.Value = &model.VariableValue_Bool{Bool: tmp}
 		}
 
 	case model.VariableType_DOUBLE:
 		var tmp float64
 		tmp, err = strconv.ParseFloat(input, 64)
-		if err != nil {
+		if err == nil {
 			out.Value = &model.VariableValue_Double{Double: tmp}
 		}
 

--- a/sdk-go/common/lh_variables_test.go
+++ b/sdk-go/common/lh_variables_test.go
@@ -1,0 +1,7 @@
+package common_test
+
+import "testing"
+
+func TestStrToVarValWithStr(t *testing.T) {
+	
+}

--- a/sdk-go/common/lh_variables_test.go
+++ b/sdk-go/common/lh_variables_test.go
@@ -1,7 +1,28 @@
 package common_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/common"
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/common/model"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestStrToVarValWithStr(t *testing.T) {
-	
+	result, err := common.StrToVarVal("1234", model.VariableType_INT)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1234), result.GetInt())
+
+	result, err = common.StrToVarVal("1234", model.VariableType_STR)
+	assert.Nil(t, err)
+	assert.Equal(t, "1234", result.GetStr())
+
+	_, err = common.StrToVarVal("not-an-int", model.VariableType_INT)
+	assert.NotNil(t, err)
+
+	result, _ = common.StrToVarVal("true", model.VariableType_BOOL)
+	assert.True(t, result.GetBool())
+
+	result, _ = common.StrToVarVal("false", model.VariableType_BOOL)
+	assert.False(t, result.GetBool())
 }

--- a/sdk-python/littlehorse/worker.py
+++ b/sdk-python/littlehorse/worker.py
@@ -278,20 +278,22 @@ class LHConnection:
             args.append(context)
 
         try:
-            output = to_variable_value(await self._task._callable(*args))
-            status = TaskStatus.TASK_SUCCESS
+            raw_output = await self._task._callable(*args)
+            try:
+                output = to_variable_value(raw_output)
+                status = TaskStatus.TASK_SUCCESS
+            except TypeError:
+                output = None
+                stacktrace = traceback.format_exc()
+                logging.error(stacktrace)
+                context.log(stacktrace)
+                status = TaskStatus.TASK_OUTPUT_SERIALIZING_ERROR
         except LHTaskException:
             output = None
             stacktrace = traceback.format_exc()
             logging.error(stacktrace)
             context.log(stacktrace)
             status = TaskStatus.TASK_EXCEPTION
-        except TypeError:
-            output = None
-            stacktrace = traceback.format_exc()
-            logging.error(stacktrace)
-            context.log(stacktrace)
-            status = TaskStatus.TASK_OUTPUT_SERIALIZING_ERROR
         except BaseException:
             output = None
             stacktrace = traceback.format_exc()


### PR DESCRIPTION
1. `lhctl` was failing to pick up INT and DOUBLE input variables
2. Python SDK was not discriminating between errors with serialization and task execution