### PR TITLE
Builds and pushes lh-standalone image for x86 and ARM platforms and fixes dashboard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,9 @@ jobs:
           npm install pnpm --global
           pnpm install
           pnpm build
-#      - name: Tests
+      - name: Build server
+        run: ./gradlew server:shadowJar -x test
+#      - name: Tests server
 #        run: ./gradlew server:test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*" # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+
 jobs:
   publish-sdk-java:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,10 +71,6 @@ jobs:
           npm install pnpm --global
           pnpm install
           pnpm build
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
       - name: Build server
         run: ./gradlew server:shadowJar -x test
 #      - name: Tests server

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           push: true
           tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest"
-#          platforms: "linux/amd64,linux/arm64"
+          platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,10 @@ jobs:
           npm install pnpm --global
           pnpm install
           pnpm build
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.2
       - name: Build server
         run: ./gradlew server:shadowJar -x test
 #      - name: Tests server

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,9 +108,7 @@ jobs:
           push: false
           tags: latest
           labels: latest
-          platforms:
-            - linux/amd64
-            - linux/arm64
+          platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Push Standalone Image to Amazon ECR
@@ -120,7 +118,7 @@ jobs:
           ECR_REPOSITORY: lh-standalone
           IMAGE_TAG: latest
         run: |
-          docker buildx build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,9 +105,8 @@ jobs:
       - name: Build and push docker
         uses: docker/build-push-action@v5
         with:
-          push: false
-          tags: latest
-          labels: latest
+          push: true
+          tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest"
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,15 +91,15 @@ jobs:
         with:
           mask-password: "true"
           registry-type: public
-#      - name: Push Server Image to Amazon ECR
-#        env:
-#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-#          ECR_REGISTRY_ALIAS: littlehorse
-#          ECR_REPOSITORY: lh-server
-#          IMAGE_TAG: ${{ github.ref_name }}
-#        run: |
-#          docker build -f docker/server/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+      - name: Push Server Image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          ECR_REGISTRY_ALIAS: littlehorse
+          ECR_REPOSITORY: lh-server
+          IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          docker build -f docker/server/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
       - name: Push Standalone Image to Amazon ECR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,8 +71,8 @@ jobs:
           npm install pnpm --global
           pnpm install
           pnpm build
-      - name: Tests
-        run: ./gradlew server:test
+#      - name: Tests
+#        run: ./gradlew server:test
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -109,7 +109,7 @@ jobs:
           ECR_REPOSITORY: lh-standalone
           IMAGE_TAG: ${{ github.ref_name }}
         run: |
-          docker buildx build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 8.2
+          gradle-version: wrapper
       - name: Build server
         run: ./gradlew server:shadowJar -x test
 #      - name: Tests server

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest"
+          tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest,${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:pepe"
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,59 +2,59 @@ name: publish
 run-name: Publish
 on:
   push:
-    branches:
-      - "enhancement/publish-docker-image-arm64"
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*" # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
 jobs:
-#  publish-sdk-java:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#      - name: Setup Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: "corretto"
-#          java-version: "11"
-#      - name: Tests
-#        run: ./gradlew sdk-java:test
-#      - name: Import GPG key
-#        uses: crazy-max/ghaction-import-gpg@v5
-#        with:
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-#      - name: Generate KeyRing
-#        run: |
-#          gpg --keyring secring.gpg --export-secret-keys --passphrase ${{ secrets.GPG_PASSPHRASE }} --batch --yes --pinentry-mode=loopback > ~/.gnupg/secring.gpg
-#          ls ~/.gnupg/
-#      - name: Publish
-#        run: |
-#          ./gradlew sdk-java:publish -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg -Psigning.password=${{ secrets.GPG_PASSPHRASE }} -Psigning.keyId=${{ vars.GPG_KEY_ID }} -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }}
-#          echo Login at https://s01.oss.sonatype.org/
-#  publish-sdk-python:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#      - name: Set up Python
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: "3.9"
-#      - name: Install Dependencies
-#        run: |
-#          python -m pip install --upgrade pip setuptools wheel
-#          pip install poetry
-#      - name: Tests
-#        working-directory: ./sdk-python
-#        run: |
-#          poetry install
-#          poetry run python -m unittest -v
-#          poetry build
-#      - name: Publish Package
-#        uses: pypa/gh-action-pypi-publish@v1.8.10
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_API_TOKEN }}
-#          packages-dir: ./sdk-python/dist/
+  publish-sdk-java:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "11"
+      - name: Tests
+        run: ./gradlew sdk-java:test
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Generate KeyRing
+        run: |
+          gpg --keyring secring.gpg --export-secret-keys --passphrase ${{ secrets.GPG_PASSPHRASE }} --batch --yes --pinentry-mode=loopback > ~/.gnupg/secring.gpg
+          ls ~/.gnupg/
+      - name: Publish
+        run: |
+          ./gradlew sdk-java:publish -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg -Psigning.password=${{ secrets.GPG_PASSPHRASE }} -Psigning.keyId=${{ vars.GPG_KEY_ID }} -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }}
+          echo Login at https://s01.oss.sonatype.org/
+  publish-sdk-python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install poetry
+      - name: Tests
+        working-directory: ./sdk-python
+        run: |
+          poetry install
+          poetry run python -m unittest -v
+          poetry build
+      - name: Publish Package
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: ./sdk-python/dist/
   publish-docker-image:
     runs-on: ubuntu-latest
     steps:
@@ -100,37 +100,37 @@ jobs:
         run: |
           docker build -f docker/server/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
       - name: Push Standalone Image to Amazon ECR
         uses: docker/build-push-action@v5
         with:
-          push: false
+          push: true
           tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:latest,${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:${{ github.ref_name }}"
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile
           context: ./
-#      - name: Push lhctl CLI Image to Amazon ECR
-#        env:
-#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-#          ECR_REGISTRY_ALIAS: littlehorse
-#          ECR_REPOSITORY: lhctl
-#          IMAGE_TAG: ${{ github.ref_name }}
-#        run: |
-#          docker build -f docker/lhctl/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-#      - name: Push Dashboard Image to Amazon ECR
-#        env:
-#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-#          ECR_REGISTRY_ALIAS: littlehorse
-#          ECR_REPOSITORY: lh-dashboard
-#          IMAGE_TAG: ${{ github.ref_name }}
-#        run: |
-#          docker build -f docker/dashboard/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+      - name: Push lhctl CLI Image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          ECR_REGISTRY_ALIAS: littlehorse
+          ECR_REPOSITORY: lhctl
+          IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          docker build -f docker/lhctl/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+      - name: Push Dashboard Image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          ECR_REGISTRY_ALIAS: littlehorse
+          ECR_REPOSITORY: lh-dashboard
+          IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          docker build -f docker/dashboard/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,10 +71,8 @@ jobs:
           npm install pnpm --global
           pnpm install
           pnpm build
-      - name: Build server
-        run: ./gradlew server:shadowJar -x test
-#      - name: Tests server
-#        run: ./gradlew server:test
+      - name: Build & Test Server
+        run: ./gradlew server:test server:shadowJar
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -100,31 +98,20 @@ jobs:
 #          ECR_REPOSITORY: lh-server
 #          IMAGE_TAG: ${{ github.ref_name }}
 #        run: |
-#          docker buildx build -f docker/server/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+#          docker build -f docker/server/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
 #          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-      - name: Build and push docker
+      - name: Push Standalone Image to Amazon ECR
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest,${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:pepe"
+          tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:latest,${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:${{ github.ref_name }}"
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile
           context: ./
-#      - name: Push Standalone Image to Amazon ECR
-#        env:
-#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-#          ECR_REGISTRY_ALIAS: littlehorse
-#          ECR_REPOSITORY: lh-standalone
-#          IMAGE_TAG: latest
-#        run: |
-#          docker build -f docker/standalone/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #      - name: Push lhctl CLI Image to Amazon ECR
 #        env:
 #          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,15 +111,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile
-      - name: Push Standalone Image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          ECR_REGISTRY_ALIAS: littlehorse
-          ECR_REPOSITORY: lh-standalone
-          IMAGE_TAG: latest
-        run: |
-          docker build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#      - name: Push Standalone Image to Amazon ECR
+#        env:
+#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+#          ECR_REGISTRY_ALIAS: littlehorse
+#          ECR_REPOSITORY: lh-standalone
+#          IMAGE_TAG: latest
+#        run: |
+#          docker build -f docker/standalone/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #      - name: Push lhctl CLI Image to Amazon ECR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,6 +111,7 @@ jobs:
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          file: ./docker/standalone/Dockerfile
       - name: Push Standalone Image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           ECR_REGISTRY_ALIAS: littlehorse
           ECR_REPOSITORY: lh-standalone
-          IMAGE_TAG: ${{ github.ref_name }}
+          IMAGE_TAG: latest
         run: |
           docker build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           push: true
           tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-proof-of-concept:latest"
-          platforms: "linux/amd64,linux/arm64"
+#          platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,17 @@ jobs:
 #          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+      - name: Build and push docker
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          tags: latest
+          labels: latest
+          platforms:
+            - linux/amd64
+            - linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Push Standalone Image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
@@ -109,7 +120,7 @@ jobs:
           ECR_REPOSITORY: lh-standalone
           IMAGE_TAG: latest
         run: |
-          docker build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker buildx build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
 #          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,60 +2,59 @@ name: publish
 run-name: Publish
 on:
   push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*" # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-
+    branches:
+      - "enhancement/publish-docker-image-arm64"
 jobs:
-  publish-sdk-java:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "11"
-      - name: Tests
-        run: ./gradlew sdk-java:test
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Generate KeyRing
-        run: |
-          gpg --keyring secring.gpg --export-secret-keys --passphrase ${{ secrets.GPG_PASSPHRASE }} --batch --yes --pinentry-mode=loopback > ~/.gnupg/secring.gpg
-          ls ~/.gnupg/
-      - name: Publish
-        run: |
-          ./gradlew sdk-java:publish -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg -Psigning.password=${{ secrets.GPG_PASSPHRASE }} -Psigning.keyId=${{ vars.GPG_KEY_ID }} -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }}
-          echo Login at https://s01.oss.sonatype.org/
-  publish-sdk-python:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install poetry
-      - name: Tests
-        working-directory: ./sdk-python
-        run: |
-          poetry install
-          poetry run python -m unittest -v
-          poetry build
-      - name: Publish Package
-        uses: pypa/gh-action-pypi-publish@v1.8.10
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: ./sdk-python/dist/
+#  publish-sdk-java:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - name: Setup Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: "corretto"
+#          java-version: "11"
+#      - name: Tests
+#        run: ./gradlew sdk-java:test
+#      - name: Import GPG key
+#        uses: crazy-max/ghaction-import-gpg@v5
+#        with:
+#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+#          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+#      - name: Generate KeyRing
+#        run: |
+#          gpg --keyring secring.gpg --export-secret-keys --passphrase ${{ secrets.GPG_PASSPHRASE }} --batch --yes --pinentry-mode=loopback > ~/.gnupg/secring.gpg
+#          ls ~/.gnupg/
+#      - name: Publish
+#        run: |
+#          ./gradlew sdk-java:publish -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg -Psigning.password=${{ secrets.GPG_PASSPHRASE }} -Psigning.keyId=${{ vars.GPG_KEY_ID }} -PossrhUsername=${{ secrets.OSSRH_USERNAME }} -PossrhPassword=${{ secrets.OSSRH_PASSWORD }}
+#          echo Login at https://s01.oss.sonatype.org/
+#  publish-sdk-python:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - name: Set up Python
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: "3.9"
+#      - name: Install Dependencies
+#        run: |
+#          python -m pip install --upgrade pip setuptools wheel
+#          pip install poetry
+#      - name: Tests
+#        working-directory: ./sdk-python
+#        run: |
+#          poetry install
+#          poetry run python -m unittest -v
+#          poetry build
+#      - name: Publish Package
+#        uses: pypa/gh-action-pypi-publish@v1.8.10
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_API_TOKEN }}
+#          packages-dir: ./sdk-python/dist/
   publish-docker-image:
     runs-on: ubuntu-latest
     steps:
@@ -74,6 +73,10 @@ jobs:
           pnpm build
       - name: Tests
         run: ./gradlew server:test
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -88,17 +91,17 @@ jobs:
         with:
           mask-password: "true"
           registry-type: public
-      - name: Push Server Image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          ECR_REGISTRY_ALIAS: littlehorse
-          ECR_REPOSITORY: lh-server
-          IMAGE_TAG: ${{ github.ref_name }}
-        run: |
-          docker build -f docker/server/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#      - name: Push Server Image to Amazon ECR
+#        env:
+#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+#          ECR_REGISTRY_ALIAS: littlehorse
+#          ECR_REPOSITORY: lh-server
+#          IMAGE_TAG: ${{ github.ref_name }}
+#        run: |
+#          docker buildx build -f docker/server/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
       - name: Push Standalone Image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
@@ -106,29 +109,29 @@ jobs:
           ECR_REPOSITORY: lh-standalone
           IMAGE_TAG: ${{ github.ref_name }}
         run: |
-          docker build -f docker/standalone/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker buildx build -f docker/standalone/Dockerfile --platform linux/amd64,linux/arm64 -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-      - name: Push lhctl CLI Image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          ECR_REGISTRY_ALIAS: littlehorse
-          ECR_REPOSITORY: lhctl
-          IMAGE_TAG: ${{ github.ref_name }}
-        run: |
-          docker build -f docker/lhctl/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-      - name: Push Dashboard Image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          ECR_REGISTRY_ALIAS: littlehorse
-          ECR_REPOSITORY: lh-dashboard
-          IMAGE_TAG: ${{ github.ref_name }}
-        run: |
-          docker build -f docker/dashboard/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#      - name: Push lhctl CLI Image to Amazon ECR
+#        env:
+#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+#          ECR_REGISTRY_ALIAS: littlehorse
+#          ECR_REPOSITORY: lhctl
+#          IMAGE_TAG: ${{ github.ref_name }}
+#        run: |
+#          docker build -f docker/lhctl/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#      - name: Push Dashboard Image to Amazon ECR
+#        env:
+#          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+#          ECR_REGISTRY_ALIAS: littlehorse
+#          ECR_REPOSITORY: lh-dashboard
+#          IMAGE_TAG: ${{ github.ref_name }}
+#        run: |
+#          docker build -f docker/dashboard/Dockerfile -t $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG .
+#          docker tag $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:$IMAGE_TAG
+#          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$ECR_REPOSITORY:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ./docker/standalone/Dockerfile
+          context: ./
 #      - name: Push Standalone Image to Amazon ECR
 #        env:
 #          ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Push Standalone Image to Amazon ECR
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: false
           tags: "${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:latest,${{ steps.login-ecr-public.outputs.registry }}/littlehorse/lh-standalone:${{ github.ref_name }}"
           platforms: "linux/amd64,linux/arm64"
           cache-from: type=gha

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -1,8 +1,3 @@
-FROM gradle:8 as builder
-WORKDIR /lh
-COPY . /lh
-RUN gradle server:shadowJar -x test
-
 FROM ubuntu:22.04
 
 LABEL maintainer="engineering@littlehorse.io"
@@ -38,6 +33,6 @@ COPY ./docker/standalone/log4j2.properties /lh
 
 WORKDIR /
 
-COPY --from=builder /lh/server/build/libs/server-*-all.jar /lh/server.jar
+COPY ./server/build/libs/server-*-all.jar /lh/server.jar
 
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -21,15 +21,15 @@ COPY ./docker/standalone/dashboard-entrypoint.sh /lh
 COPY ./docker/standalone/docker-entrypoint.sh /lh
 COPY ./docker/standalone/log4j2.properties /lh
 
-#COPY ./dashboard /lh/dashboard
-#WORKDIR /lh/dashboard
-#ENV NODE_ENV=production
-#EXPOSE 8080
-#
-#COPY ./dashboard/apps/web/.next/standalone ./
-#COPY ./dashboard/apps/web/.next/static ./apps/web/.next/static
-#COPY ./dashboard/apps/web/public ./apps/web/public
-#COPY ./docker/dashboard/docker-entrypoint.sh ./
+COPY ./dashboard /lh/dashboard
+WORKDIR /lh/dashboard
+ENV NODE_ENV=production
+EXPOSE 8080
+
+COPY ./dashboard/apps/web/.next/standalone ./
+COPY ./dashboard/apps/web/.next/static ./apps/web/.next/static
+COPY ./dashboard/apps/web/public ./apps/web/public
+COPY ./docker/dashboard/docker-entrypoint.sh ./
 
 WORKDIR /
 

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -26,15 +26,15 @@ COPY ./docker/standalone/dashboard-entrypoint.sh /lh
 COPY ./docker/standalone/docker-entrypoint.sh /lh
 COPY ./docker/standalone/log4j2.properties /lh
 
-COPY ./dashboard /lh/dashboard
-WORKDIR /lh/dashboard
-ENV NODE_ENV=production
-EXPOSE 8080
-
-COPY ./dashboard/apps/web/.next/standalone ./
-COPY ./dashboard/apps/web/.next/static ./apps/web/.next/static
-COPY ./dashboard/apps/web/public ./apps/web/public
-COPY ./docker/dashboard/docker-entrypoint.sh ./
+#COPY ./dashboard /lh/dashboard
+#WORKDIR /lh/dashboard
+#ENV NODE_ENV=production
+#EXPOSE 8080
+#
+#COPY ./dashboard/apps/web/.next/standalone ./
+#COPY ./dashboard/apps/web/.next/static ./apps/web/.next/static
+#COPY ./dashboard/apps/web/public ./apps/web/public
+#COPY ./docker/dashboard/docker-entrypoint.sh ./
 
 WORKDIR /
 

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -21,7 +21,6 @@ COPY ./docker/standalone/dashboard-entrypoint.sh /lh
 COPY ./docker/standalone/docker-entrypoint.sh /lh
 COPY ./docker/standalone/log4j2.properties /lh
 
-COPY ./dashboard /lh/dashboard
 WORKDIR /lh/dashboard
 ENV NODE_ENV=production
 EXPOSE 8080
@@ -29,10 +28,12 @@ EXPOSE 8080
 COPY ./dashboard/apps/web/.next/standalone ./
 COPY ./dashboard/apps/web/.next/static ./apps/web/.next/static
 COPY ./dashboard/apps/web/public ./apps/web/public
-COPY ./docker/dashboard/docker-entrypoint.sh ./
 
 WORKDIR /
 
 COPY ./server/build/libs/server-*-all.jar /lh/server.jar
+
+ENV LHD_API_HOST=localhost
+ENV LHD_API_PORT=2023
 
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]

--- a/docker/standalone/dashboard-entrypoint.sh
+++ b/docker/standalone/dashboard-entrypoint.sh
@@ -40,7 +40,7 @@ else
   export AUTH_SECRET=$(uuidgen)
 fi
 
-export HOSTNAME=localhost
+export HOSTNAME=0.0.0.0
 export PORT=8080
 
 node /lh/dashboard/apps/web/server.js

--- a/docker/standalone/docker-entrypoint.sh
+++ b/docker/standalone/docker-entrypoint.sh
@@ -9,6 +9,6 @@ if ! kafka-topics.sh --bootstrap-server=localhost:9092 --list > /dev/null 2>&1; 
     exit 1
 fi
 
-#/lh/dashboard-entrypoint.sh &
+/lh/dashboard-entrypoint.sh &
 
 /lh/littlehorse-entrypoint.sh

--- a/docker/standalone/docker-entrypoint.sh
+++ b/docker/standalone/docker-entrypoint.sh
@@ -9,6 +9,6 @@ if ! kafka-topics.sh --bootstrap-server=localhost:9092 --list > /dev/null 2>&1; 
     exit 1
 fi
 
-/lh/dashboard-entrypoint.sh &
+#/lh/dashboard-entrypoint.sh &
 
 /lh/littlehorse-entrypoint.sh


### PR DESCRIPTION
All our images are built for the linux/amd64 platform because that's the platform of the Github Agent. This means that our images do not work on ARM-based Mac computers (e.g. M1, M2, etc.). That is a big problem considering that a lot of developers use Macs for their day to day work.

This PR introduces the `docker/build-push-action` action to help us build a multiplatform image (namely linux/amd64 and linux/arm64) for the `lh-standalone` image. We should probably consider doing all our other images multiplatform, the major drawback is that the image size seems to become quite bigger.

Also, the dashboard was not working on `lh-standalone`. That's also fixed as part of this PR.