### PR TITLE
Solves #596: Stackoverflow when an illegal reference is passed to the #execute method

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/LHFormatString.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/LHFormatString.java
@@ -1,3 +1,5 @@
 package io.littlehorse.sdk.wfsdk;
 
-public interface LHFormatString {}
+import java.io.Serializable;
+
+public interface LHFormatString extends Serializable {}

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
@@ -2,8 +2,10 @@ package io.littlehorse.sdk.wfsdk;
 
 import io.littlehorse.sdk.common.proto.VariableType;
 
+import java.io.Serializable;
+
 /** A WfRunVariable is a handle on a Variable in a WfSpec. */
-public interface WfRunVariable {
+public interface WfRunVariable extends Serializable {
     /**
      * Valid only for output of the JSON_OBJ or JSON_ARR types. Returns a new WfRunVariable handle
      * which points to Json element referred to by the json path.

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
@@ -1,7 +1,6 @@
 package io.littlehorse.sdk.wfsdk;
 
 import io.littlehorse.sdk.common.proto.VariableType;
-
 import java.io.Serializable;
 
 /** A WfRunVariable is a handle on a Variable in a WfSpec. */

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
@@ -4,6 +4,8 @@ import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.sdk.common.proto.ThreadRetentionPolicy;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
+
+import java.io.Serializable;
 import java.util.Map;
 
 /** This interface is what is used to define the logic of a ThreaSpec in a ThreadFunc. */
@@ -33,7 +35,7 @@ public interface WorkflowThread {
      *     pass that literal value in.
      * @return A NodeOutput for that TASK node.
      */
-    TaskNodeOutput execute(String taskName, Object... args);
+    TaskNodeOutput execute(String taskName, Serializable... args);
 
     /**
      * Adds a User Task Node, and assigns it to a specific user

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
@@ -4,7 +4,6 @@ import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.sdk.common.proto.ThreadRetentionPolicy;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
-
 import java.io.Serializable;
 import java.util.Map;
 

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
@@ -45,7 +45,6 @@ import io.littlehorse.sdk.wfsdk.WaitForThreadsNodeOutput;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.WorkflowCondition;
 import io.littlehorse.sdk.wfsdk.WorkflowThread;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
@@ -45,6 +45,8 @@ import io.littlehorse.sdk.wfsdk.WaitForThreadsNodeOutput;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.WorkflowCondition;
 import io.littlehorse.sdk.wfsdk.WorkflowThread;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -233,7 +235,8 @@ final class WorkflowThreadImpl implements WorkflowThread {
         return new LHFormatStringImpl(this, format, args);
     }
 
-    public TaskNodeOutputImpl execute(String taskName, Object... args) {
+    @Override
+    public TaskNodeOutputImpl execute(String taskName, Serializable... args) {
         checkIfIsActive();
         TaskNode taskNode = createTaskNode(taskName, args);
         String nodeName = addNode(taskName, NodeCase.TASK, taskNode);

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImplTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImplTest.java
@@ -1,8 +1,5 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.Node;
 import io.littlehorse.sdk.common.proto.Node.NodeCase;
@@ -16,13 +13,17 @@ import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.WorkflowRetentionPolicy;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.Workflow;
+import lombok.AllArgsConstructor;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import net.datafaker.Faker;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WorkflowThreadImplTest {
 

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImplTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImplTest.java
@@ -1,5 +1,8 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.Node;
 import io.littlehorse.sdk.common.proto.Node.NodeCase;
@@ -13,17 +16,13 @@ import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.WorkflowRetentionPolicy;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.Workflow;
-import lombok.AllArgsConstructor;
-import net.datafaker.Faker;
-import org.junit.jupiter.api.Test;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import lombok.AllArgsConstructor;
+import net.datafaker.Faker;
+import org.junit.jupiter.api.Test;
 
 public class WorkflowThreadImplTest {
 


### PR DESCRIPTION
I propose adding a breaking change that prevents users from passing incorrect object references as arguments to the `#execute` method.

This is the current signature of the method:

`TaskNodeOutputImpl execute(String taskName, Object... args)`

Serializing the arguments as JSON and appending them to the spec file can be dangerous since not every object is serializable.

When users do something like this:

```
TaskNodeOutput nodeOutput = createUserThread.execute("find-current-user", newUser.jsonPath("$.id"));
WfRunVariable existingUser = createUserThread.addVariable("existing-user", nodeOutput);
```

It causes a stackoverflow because `TaskNodeOutput` instances contain circular references, which means that this class is not serializable.

This PR proposes modifying the method signature as follows:

`TaskNodeOutputImpl execute(String taskName, Serializable... args)`

This will cause a compilation error when users try to pass an instance that is not serializable.