### PR TITLE
Rebuild dashboard for standalone and dashboard docker images

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,6 +1,7 @@
 name: branch
 run-name: Publishing images for branch ${{ github.ref_name }}
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - "master"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8
@@ -92,6 +92,8 @@ jobs:
 
   lh-standalone:
     runs-on: ubuntu-latest
+    needs:
+      - build-server
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -61,38 +61,27 @@ jobs:
           dockerfile: docker/lhctl/Dockerfile
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  dashboard-build:
+  lh-dashboard:
     runs-on: ubuntu-latest
-    needs:
-      - build-server
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Build Dashboard
         working-directory: ./dashboard
         run: |
-          npm install pnpm --global
           pnpm install
           pnpm build
-      - uses: actions/upload-artifact@v4
-        with:
-          name: nextjs
-          path: dashboard/apps/web/.next
-
-  lh-dashboard:
-    runs-on: ubuntu-latest
-    needs:
-      - dashboard-build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Dowload NextJS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: nextjs
-          path: dashboard/apps/web/.next
 
       - name: Build and publish
         uses: ./.github/actions/publish-image
@@ -103,17 +92,25 @@ jobs:
 
   lh-standalone:
     runs-on: ubuntu-latest
-    needs:
-      - dashboard-build
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Dowload NextJS artifact
-        uses: actions/download-artifact@v4
+      - uses: pnpm/action-setup@v2
         with:
-          name: nextjs
-          path: dashboard/apps/web/.next
+          version: 8
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Build Dashboard
+        working-directory: ./dashboard
+        run: |
+          pnpm install
+          pnpm build
 
       - name: Dowload Server Jar artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
While building the docker image, pnpm creates symbolic links to dependencies that cannot be recovered with a cache action through artifacts.

This disable the artifact action but instead builds the artifact for standalone and dashboard images.