### PR TITLE
Fix broken docker publish

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Tests and Build
         run: ./gradlew server:test server:shadowJar
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: server-jar
+          path: server/build/libs/server-*-all.jar
+
       - name: Build and publish
         uses: ./.github/actions/publish-image
         with:
@@ -44,16 +49,66 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: pnpm/action-setup@v2
+        with:
+          package_json_file: dashboard/package.json
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache: pnpm
+
       - name: Build Dashboard
         working-directory: ./dashboard
         run: |
-          npm install pnpm --global
           pnpm install
           pnpm build
+
       - name: Build and publish
         uses: ./.github/actions/publish-image
         with:
           image-name: lh-dashboard
           dockerfile: docker/dashboard/Dockerfile
+          registry: ecr
+          prefix: branch-
+
+  lh-standalone:
+    runs-on: ubuntu-latest
+    needs:
+      - lh-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          package_json_file: ./dashboard/package.json
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache: pnpm
+
+      - name: Build Dashboard
+        working-directory: ./dashboard
+        run: |
+          pnpm install
+          pnpm build
+
+      - name: Dowload Server Jar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: server-jar
+          path: server/build/libs/
+
+      - name: Build and publish
+        uses: ./.github/actions/publish-image
+        with:
+          image-name: lh-standalone
+          dockerfile: docker/standalone/Dockerfile
           registry: ecr
           prefix: branch-

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -69,13 +69,14 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          package_json_file: ./dashboard/package.json
 
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache: pnpm
 
       - name: Build Dashboard
         working-directory: ./dashboard
@@ -100,13 +101,14 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          package_json_file: ./dashboard/package.json
 
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache: pnpm
 
       - name: Build Dashboard
         working-directory: ./dashboard

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -30,5 +30,5 @@
   "dependencies": {
     "material-icons": "^1.13.12"
   },
-  "packageManager": "pnpm@7.15.0"
+  "packageManager": "pnpm@7.33.6"
 }


### PR DESCRIPTION
Forgot to add the `cache-dependency-path` on node setup action,

This also adds the functionality to push standalone images to the private registry