### PR TITLE
FIX: NPE when accessing variable outside of scope.

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.reflections:reflections:0.10.2' // This reflection API isNOT under active development or maintenance, look for an alternative
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'org.testcontainers:kafka:1.18.3'
+    implementation group: 'org.awaitility', name: 'awaitility', version: '4.2.0'
     testImplementation project(':test-utils')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-
 import org.awaitility.Awaitility;
 
 public class ATInterruptsBasic extends WorkflowLogicTest {

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
@@ -5,6 +5,7 @@ import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
 import io.littlehorse.sdk.common.proto.VariableType;
+import io.littlehorse.sdk.common.proto.WfRunId;
 import io.littlehorse.sdk.common.util.Arg;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.Workflow;
@@ -14,8 +15,11 @@ import io.littlehorse.sdk.worker.LHTaskMethod;
 import io.littlehorse.tests.TestFailure;
 import io.littlehorse.tests.WorkflowLogicTest;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+
+import org.awaitility.Awaitility;
 
 public class ATInterruptsBasic extends WorkflowLogicTest {
 
@@ -65,8 +69,9 @@ public class ATInterruptsBasic extends WorkflowLogicTest {
             throws TestFailure, InterruptedException, IOException {
         String id = runWf(client, Arg.of("my-int", 5));
         assertStatus(client, id, LHStatus.RUNNING);
-        Thread.sleep(3 * 1000);
-        assertStatus(client, id, LHStatus.COMPLETED);
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> {
+            return client.getWfRun(WfRunId.newBuilder().setId(id).build()).getStatus() == LHStatus.COMPLETED;
+        });
         assertVarEqual(client, id, 0, "my-int", 5);
         return id;
     }

--- a/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/cases/workflow/ATInterruptsBasic.java
@@ -105,8 +105,9 @@ public class ATInterruptsBasic extends WorkflowLogicTest {
         assertTaskOutputsMatch(client, id, 1, "hello there");
         assertTaskOutputsMatch(client, id, 2, "hello there");
         assertStatus(client, id, LHStatus.RUNNING);
-        Thread.sleep(7 * 1000);
-        assertStatus(client, id, LHStatus.COMPLETED);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> {
+            return client.getWfRun(WfRunId.newBuilder().setId(id).build()).getStatus() == LHStatus.COMPLETED;
+        });
         assertVarEqual(client, id, 0, "my-int", 25);
         return id;
     }
@@ -118,7 +119,9 @@ public class ATInterruptsBasic extends WorkflowLogicTest {
 
         Thread.sleep(3 * 1000);
 
-        assertStatus(client, id, LHStatus.COMPLETED);
+        Awaitility.await().atMost(Duration.ofSeconds(15)).until(() -> {
+            return client.getWfRun(WfRunId.newBuilder().setId(id).build()).getStatus() == LHStatus.COMPLETED;
+        });
         assertVarEqual(client, id, 0, "my-int", 15);
         assertTaskOutputsMatch(client, id, 1, "hello there");
         return id;

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadRunModel.java
@@ -601,7 +601,7 @@ public class ThreadRunModel extends LHSerializable<ThreadRun> {
                     break;
                 }
             } catch (LHVarSubError exn) {
-                log.error("Failing threadrun due to VarSubError {} {}", wfRun.getId(), currentNodePosition, exn);
+                log.debug("Failing threadrun due to VarSubError {} {}", wfRun.getId(), currentNodePosition, exn);
                 fail(
                         new FailureModel(
                                 "Failed evaluating outgoing edge: " + exn.getMessage(), LHConstants.VAR_MUTATION_ERROR),
@@ -723,7 +723,6 @@ public class ThreadRunModel extends LHSerializable<ThreadRun> {
             try {
                 mut.execute(this, varCache, nodeOutput);
             } catch (LHVarSubError exn) {
-                log.error(exn.getMessage(), exn);
                 exn.addPrefix("Mutating variable " + mut.lhsName + " with operation " + mut.operation);
                 throw exn;
             }

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
@@ -424,7 +424,7 @@ public class WfRunModel extends CoreGetable<WfRun> {
             if (fh.status == LHStatus.ERROR) {
                 fh.fail(
                         new FailureModel(
-                                "Failed launching interrupt thread with id: " + fh.number, LHConstants.CHILD_FAILURE),
+                                "Failed launching exception handler thread with id: " + fh.number, LHConstants.CHILD_FAILURE),
                         time);
             } else {
                 failedThr.acknowledgeXnHandlerStarted(pfh, fh.number);

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
@@ -424,7 +424,8 @@ public class WfRunModel extends CoreGetable<WfRun> {
             if (fh.status == LHStatus.ERROR) {
                 fh.fail(
                         new FailureModel(
-                                "Failed launching exception handler thread with id: " + fh.number, LHConstants.CHILD_FAILURE),
+                                "Failed launching exception handler thread with id: " + fh.number,
+                                LHConstants.CHILD_FAILURE),
                         time);
             } else {
                 failedThr.acknowledgeXnHandlerStarted(pfh, fh.number);

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
@@ -3,6 +3,7 @@ package io.littlehorse.common.model.getable.global.wfspec.variable;
 import com.google.protobuf.Message;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.exceptions.LHVarSubError;
+import io.littlehorse.common.model.getable.core.variable.VariableModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.model.getable.core.wfrun.ThreadRunModel;
 import io.littlehorse.sdk.common.proto.VariableMutation;
@@ -90,11 +91,19 @@ public class VariableMutationModel extends LHSerializable<VariableMutation> {
 
     private VariableValueModel getVarValFromThreadInTxn(
             String varName, ThreadRunModel thread, Map<String, VariableValueModel> txnCache) throws LHVarSubError {
-        VariableValueModel lhsVar = txnCache.get(this.lhsName);
-        if (lhsVar == null) {
-            lhsVar = thread.getVariable(this.lhsName).getValue();
+        VariableValueModel result = txnCache.get(this.lhsName);
+        if (result == null) {
+            VariableModel rawVariable = thread.getVariable(varName);
+            if (rawVariable == null) {
+                throw new LHVarSubError(
+                        null,
+                        "Variable %s is out of scope for threadRun %d of spec %s. Invalid WfSpec!"
+                                .formatted(varName, thread.getNumber(), thread.getThreadSpecName()));
+            }
+            result = rawVariable.getValue();
         }
-        return lhsVar.getCopy();
+
+        return result.getCopy();
     }
 
     public VariableValueModel getRhsValue(

--- a/server/src/test/java/e2e/VarSubErrorTest.java
+++ b/server/src/test/java/e2e/VarSubErrorTest.java
@@ -31,11 +31,12 @@ public class VarSubErrorTest {
         verifier.prepareRun(accessOutOfScopeVarWf)
                 // this WfRun should be terminated on the first RPC since there are no
                 // TaskRun's, ExternalEvents, or User Tasks. Everything is synchronous.
+                //
+                // Therefore, we should NOT do a waitForStatus().
                 .thenVerifyWfRun(wfRun -> {
                     Assertions.assertThat(wfRun.getStatus()).isEqualTo(LHStatus.ERROR);
-                })
-                .thenVerifyNodeRun(0, 2, nodeRun -> {
-                    Assertions.assertThat(nodeRun.getStatus()).isEqualTo(LHStatus.ERROR);
+                    Assertions.assertThat(wfRun.getThreadRuns(1).getStatus()).isEqualTo(LHStatus.EXCEPTION);
+                    Assertions.assertThat(wfRun.getThreadRuns(2).getStatus()).isEqualTo(LHStatus.ERROR);
                 })
                 .start();
     }

--- a/server/src/test/java/e2e/VarSubErrorTest.java
+++ b/server/src/test/java/e2e/VarSubErrorTest.java
@@ -1,0 +1,66 @@
+package e2e;
+
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.VariableMutationType;
+import io.littlehorse.sdk.common.proto.VariableType;
+import io.littlehorse.sdk.wfsdk.NodeOutput;
+import io.littlehorse.sdk.wfsdk.SpawnedThread;
+import io.littlehorse.sdk.wfsdk.SpawnedThreads;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.test.LHTest;
+import io.littlehorse.test.LHWorkflow;
+import io.littlehorse.test.WorkflowVerifier;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@LHTest
+public class VarSubErrorTest {
+
+    // Need to put it here so that we can access it in an illegal manner
+    private WfRunVariable variableOnlyAccessibleInChild;
+
+    private WorkflowVerifier verifier;
+
+    @LHWorkflow("access-out-of-scope-var")
+    private Workflow accessOutOfScopeVarWf;
+
+    @Test
+    void shouldThrowVarSubErrorOnIllegalAccess() {
+        verifier.prepareRun(accessOutOfScopeVarWf)
+                // this WfRun should be terminated on the first RPC since there are no
+                // TaskRun's, ExternalEvents, or User Tasks. Everything is synchronous.
+                .thenVerifyWfRun(wfRun -> {
+                    Assertions.assertThat(wfRun.getStatus()).isEqualTo(LHStatus.ERROR);
+                })
+                .thenVerifyNodeRun(0, 2, nodeRun -> {
+                    Assertions.assertThat(nodeRun.getStatus()).isEqualTo(LHStatus.ERROR);
+                })
+                .start();
+    }
+
+    @LHWorkflow("access-out-of-scope-var")
+    public Workflow getAccessOutOfScopeVarWf() {
+        return Workflow.newWorkflow("access-out-of-scope-var", wf -> {
+            SpawnedThread spawnedThread = wf.spawnThread(
+                    child -> {
+                        variableOnlyAccessibleInChild = child.addVariable("out-of-scope-var", VariableType.BOOL);
+                        child.fail("some-failure", "some failure message");
+                    },
+                    "child-thread",
+                    Map.of());
+
+            // In order to "trick" the SDK into creating a WfSpec that accesses an
+            // out-of-scope variable, we have to use a failure handler on a waitForThreads
+            // node.
+            NodeOutput nodeThatWillFail = wf.waitForThreads(SpawnedThreads.of(spawnedThread));
+
+            wf.handleException(nodeThatWillFail, handler -> {
+                // We once had an NPE in which accessing a variable from the child in this thread
+                // was permitted by the SDK but the server threw an orzdash.
+                handler.mutate(variableOnlyAccessibleInChild, VariableMutationType.ASSIGN, true);
+            });
+        });
+    }
+}


### PR DESCRIPTION
When a ThreadSpec attempts to mutate a real variable (but that variable is out of scope for that threadspec) the server threw an NPE and ignored the Command that triggered the advance that resulted in reading that variable.

The proper behavior is for the illegal access to throw an LHVarSubError.

This commit adds a failing e2e test for that case and fixes it. However, the e2e test has apparently discovered another bug related to moving a failed thread from HALTED to ERROR, which will be addressed in subsequent commits.