### PR TITLE
Expose dashboard on 0.0.0.0

### DIFF
--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -19,7 +19,7 @@ COPY ./docker/dashboard/docker-entrypoint.sh ./
 EXPOSE 8080
 
 ENV PORT 8080
-ENV HOSTNAME localhost
+ENV HOSTNAME 0.0.0.0
 
 ENTRYPOINT ["/lh/dashboard/docker-entrypoint.sh"]
 CMD ["dashboard"]


### PR DESCRIPTION
## Context

This enables the docker image to expose the service on any host. The current setup only admits to listen on localhost which is okay for a local setup but on kubernetes it would require to setup the environment variable `HOSTNAME` to expose it through a service. 

Using `0.0.0.0` by default would make it easier to use because must likely you'll need to change the hostname anyway.

