### PR TITLE
Handle dashboard loading when there's no data

### DIFF
--- a/dashboard/apps/web/app/(main)/components/metrics/TaskExecutionMetrics.tsx
+++ b/dashboard/apps/web/app/(main)/components/metrics/TaskExecutionMetrics.tsx
@@ -28,6 +28,7 @@ interface TaskExecutionMetricsProps{
 export function TaskExecutionMetrics({ windows= 16, lastWindowStart=moment().toDate(), type='HOURS_2' }:TaskExecutionMetricsProps) {
     const [ data, setData ] = useState<any[]>([])
     const [ chart, setChart ] = useState('tasks')
+    const [ isLoading, setIsLoading ] = useState(false)
 
     const windowsNotOverpassing300 = windows > 300 ? 300 : windows
 
@@ -112,6 +113,7 @@ export function TaskExecutionMetrics({ windows= 16, lastWindowStart=moment().toD
     }
 
     const getData = async () => {
+        setIsLoading(true)
         const res = await fetch('/api/metrics/taskDef',{
             method:'POST',
             body: JSON.stringify({
@@ -125,6 +127,7 @@ export function TaskExecutionMetrics({ windows= 16, lastWindowStart=moment().toD
             const content = await res.json()
             setData( timeoutP(lastWindowStart,content.results))
         }
+        setIsLoading(false)
 
     }
 
@@ -145,14 +148,21 @@ export function TaskExecutionMetrics({ windows= 16, lastWindowStart=moment().toD
                 </div>
             </header>
 
+            {isLoading ? (
+                <Loader />
+            ) : (
+
             <div className={`${data.length === 0 ? 'flex items-center justify-items-center justify-center': ''}`} style={{
                 height: data.length === 0 ? '400px' : 'auto'
-            }}>{
+                    }}>
+                        {
                     data.length > 0 ? <>
                         {chart === 'tasks' && <TaskChart data={data} type={type} />}
                         {chart === 'latency' && <LatencyTaskChart data={data} type={type}  />}
-                    </> : <Loader />
-                }</div>
+                    </> : <p> No data available</p>
+                        }
+                    </div>
+            )}
         </article>
     )
 }

--- a/dashboard/apps/web/app/(main)/components/metrics/WorkflowExecutionMetrics.tsx
+++ b/dashboard/apps/web/app/(main)/components/metrics/WorkflowExecutionMetrics.tsx
@@ -28,6 +28,7 @@ interface WorkflowExecutionMetricsProps{
 export function WorkflowExecutionMetrics({ windows= 16, lastWindowStart=moment().toDate(), type='HOURS_2' }:WorkflowExecutionMetricsProps) {
     const [ data, setData ] = useState<any[]>([])
     const [ chart, setChart ] = useState('workflows')
+    const [ isLoading, setIsLoading ] = useState(false)
     const windowsNotOverpassing300 = windows > 300 ? 300 : windows
 
     function timeoutP (_lastWindowStart:Date, metrics:any[]) {
@@ -112,6 +113,7 @@ export function WorkflowExecutionMetrics({ windows= 16, lastWindowStart=moment()
     }
 
     const getData = async () => {
+        setIsLoading(true)
         const res = await fetch('./api/metrics/wfSpec',{
             method:'POST',
             body: JSON.stringify({
@@ -127,6 +129,7 @@ export function WorkflowExecutionMetrics({ windows= 16, lastWindowStart=moment()
             const content = await res.json()
             setData( timeoutP(lastWindowStart,content.results))
         }
+        setIsLoading(false)
     }
 
     useEffect( () => {
@@ -146,18 +149,21 @@ export function WorkflowExecutionMetrics({ windows= 16, lastWindowStart=moment()
                 </div>
             </header>
 
+            {isLoading ? (
+                <Loader />
+            ) : (
+
             <div className={`${data.length === 0 ? 'flex items-center justify-items-center justify-center': ''}`} style={{
                 height: data.length === 0 ? '400px' : 'auto'
-            }}>
-                {
-                    data.length > 0 ?
-                        <>
-                            {chart === 'workflows' && <WorkflowsChart data={data} type={type}  />}
-                            {chart === 'latency' && <LatencyChart data={data} type={type}  />}
-                        </>
-                        : <Loader />
-                }
-            </div>
+                    }}>
+                        {
+                    data.length > 0 ? <>
+                        {chart === 'workflows' && <WorkflowsChart data={data} type={type} />}
+                        {chart === 'latency' && <LatencyChart data={data} type={type}  />}
+                    </> : <p> No data available</p>
+                        }
+                    </div>
+            )}
         </article>
     )
 }

--- a/dashboard/apps/web/app/(main)/components/search/MetadataSearchTable.tsx
+++ b/dashboard/apps/web/app/(main)/components/search/MetadataSearchTable.tsx
@@ -3,11 +3,17 @@ import type { Result } from '../../sections/MetadataSearch'
 
 
 interface MetadataSearchTableProps {
-    results?:Result[]
+    results :Result[]
 }
-export function MetadataSearchTable({ results }:MetadataSearchTableProps) {
+export function MetadataSearchTable({ results }: MetadataSearchTableProps) {
 
-    return <div className="table">
+    if (results.length === 0) {
+        return (<div className="flex items-center justify-items-center justify-center text-center flex-1">
+                    <p>No data available</p>
+                </div>)
+    }
+
+    return <div className="table flex-1">
         { results ? <table className="flex-1" style={{ width:'100%' }}>
             <thead className="flex" style={{
                 width:'100%'

--- a/dashboard/apps/web/app/(main)/sections/MetadataSearch.tsx
+++ b/dashboard/apps/web/app/(main)/sections/MetadataSearch.tsx
@@ -18,7 +18,7 @@ let myTimeout: NodeJS.Timeout
 export function MetadataSearch() {
     let first = true
 
-    const [ loading, setLoading ] = useState(false)
+    const [ isLoading, setIsLoading ] = useState(false)
     const [ firstLoad, setFirstLoad ] = useState(false)
     const [ limit, setLimit ] = useState(defaultLimit)
     const [ userTaskDefBookmark, setUserTaskDefBookmark ] = useState()
@@ -51,14 +51,14 @@ export function MetadataSearch() {
         }
     }
     const getData = async () => {
-        setLoading(true)
+        setIsLoading(true)
         const { results, bookmark } = await fetchData(metadataType)
         if (metadataType === 'wfSpec') {setWfSpecBookmark(bookmark)}
         if (metadataType === 'taskDef') {setTaskDefBookmark(bookmark)}
         if (metadataType === 'userTaskDef') {setUserTaskDefBookmark(bookmark)}
         if (metadataType === 'externalEventDef') {setExternalEventDefBookmark(bookmark)}
         setMetadataResults(results.map((v: Result) => ({ ...v, type: metadataType.charAt(0).toUpperCase() + metadataType.slice(1) })))
-        setLoading(false)
+        setIsLoading(false)
     }
     const getMData = async () => {
         setWfSpecBookmark(undefined)
@@ -67,7 +67,7 @@ export function MetadataSearch() {
         setExternalEventDefBookmark(undefined)
         if (metadataType) {return getData()}
 
-        setLoading(true)
+        setIsLoading(true)
         // setResults([])
 
         const wfSpecs = await fetchData('wfSpec', false, false)
@@ -102,11 +102,11 @@ export function MetadataSearch() {
         }
 
         setFirstLoad(true)
-        setLoading(false)
+        setIsLoading(false)
     }
     const loadMMore = async () => {
         if (metadataType) {return loadMore()}
-        setLoading(true)
+        setIsLoading(true)
 
         if (wfSpecBookmark) {
             const wfSpecs = await fetchData('wfSpec', true, false)
@@ -147,10 +147,10 @@ export function MetadataSearch() {
             }
         }
 
-        setLoading(false)
+        setIsLoading(false)
     }
     const loadMore = async () => {
-        setLoading(true)
+        setIsLoading(true)
 
         const { results, bookmark, status } = await fetchData(metadataType, true)
 
@@ -164,7 +164,7 @@ export function MetadataSearch() {
             ...v,
             type: metadataType.charAt(0).toUpperCase() + metadataType.slice(1)
         })) ])
-        setLoading(false)
+        setIsLoading(false)
     }
 
     const keyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -198,13 +198,11 @@ export function MetadataSearch() {
                     onClick={() => { setMetadataType('externalEventDef') }}>ExternalEventDef</Button>
             </div>
         </div>
-        <div className={`${metadataResults.length === 0 ? 'flex items-center justify-items-center justify-center' : ''}`}
-            style={{ minHeight: '568px' }}
-        >
-            {metadataResults.length ? (
-                <MetadataSearchTable results={metadataResults}/>
+        <div className="flex" style={{ minHeight: '568px' }}>
+            {!isLoading ? (
+                <MetadataSearchTable results={metadataResults} />
             ) : (
-                <Loader/>
+                <Loader />
             )}
         </div>
 
@@ -214,11 +212,10 @@ export function MetadataSearch() {
                     value={limit}
                     values={[ 10, 20, 30, 60, 100 ]}/> </> : undefined}
                 <LoadMoreButton disabled={!externalEventDefBookmark && !wfSpecBookmark && !taskDefBookmark}
-                    loading={loading}
+                    loading={isLoading}
                     onClick={loadMMore}>Load More</LoadMoreButton>
             </div>
         </div>
-
     </section>
 
 }

--- a/dashboard/packages/eslint-config-custom/next.js
+++ b/dashboard/packages/eslint-config-custom/next.js
@@ -77,7 +77,7 @@ module.exports = {
             'allowTemplateLiterals': true, 'avoidEscape': true
         } ],
         '@stylistic/prefer-named-capture-group': 'off', // not needed
-        '@stylistic/indent': [ 'error', 4 ],
+        '@stylistic/indent': [ 'warn', 4 ],
         '@stylistic/object-curly-spacing': [ 'error', 'always' ],
         '@stylistic/jsx-curly-spacing': 'error',
         '@stylistic/array-bracket-spacing': [ 'error', 'always' ],

--- a/dashboard/packages/ui/components/Loader.tsx
+++ b/dashboard/packages/ui/components/Loader.tsx
@@ -1,3 +1,7 @@
 export function Loader() {
-  return <div>Loading...</div>
+  return (
+    <div className="flex items-center justify-items-center justify-center flex-1">
+      Loading...
+    </div>
+  );
 }


### PR DESCRIPTION
Show a `No data available` instead of persisting the `Loading...` message.

![image](https://github.com/littlehorse-enterprises/littlehorse/assets/1911813/183a84d1-6b58-49f0-8030-9a57572e1f22)


Fixes #410

This doesn't solve the issue in inner pages and will be fixed through #676 