### PR TITLE
Introduces LHS_KAFKA_LINGER_MS configuration

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.jetbrains.annotations.Nullable;
@@ -79,6 +80,7 @@ public class LHServerConfig extends ConfigBase {
     public static final String NUM_STANDBY_REPLICAS_KEY = "LHS_STREAMS_NUM_STANDBY_REPLICAS";
     public static final String ROCKSDB_COMPACTION_THREADS_KEY = "LHS_ROCKSDB_COMPACTION_THREADS";
     public static final String STREAMS_METRICS_LEVEL_KEY = "LHS_STREAMS_METRICS_LEVEL";
+    public static final String LINGER_MS_KEY = "LHS_KAFKA_LINGER_MS";
 
     // General LittleHorse Runtime Behavior Config Env Vars
     public static final String NUM_NETWORK_THREADS_KEY = "LHS_NUM_NETWORK_THREADS";
@@ -633,6 +635,7 @@ public class LHServerConfig extends ConfigBase {
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 org.apache.kafka.common.serialization.StringSerializer.class);
         conf.put(ProducerConfig.ACKS_CONFIG, "all");
+        conf.put(ProducerConfig.LINGER_MS_CONFIG, getOrSetDefault(LINGER_MS_KEY, "0"));
         addKafkaSecuritySettings(conf);
         return conf;
     }
@@ -755,6 +758,11 @@ public class LHServerConfig extends ConfigBase {
         props.put(
                 "statestore.cache.max.bytes",
                 Long.valueOf(getOrSetDefault(CORE_STATESTORE_CACHE_BYTES_KEY, String.valueOf(1024L * 1024L * 32))));
+
+        // Kafka Streams calls KafkaProducer#commitTransaction() which flushes messages anyways. Sending earlier does
+        // not help at all in any way (this is because the Core topology is EOS). Therefore, having a big linger.ms
+        // does not have any downsides in theory.
+        props.put(StreamsConfig.producerPrefix("linger.ms"), 1000);
         return props;
     }
 
@@ -785,6 +793,10 @@ public class LHServerConfig extends ConfigBase {
         props.put(
                 "statestore.cache.max.bytes",
                 Long.valueOf(getOrSetDefault(TIMER_STATESTORE_CACHE_BYTES_KEY, String.valueOf(1024L * 1024L * 64))));
+
+        // For the Timer, which is ALOS, the linger ms does potentially impact the latency of a timer coming in.
+        // Future work might allow this to be a separate config from the linger ms used for the GRPC server.
+        props.put(StreamsConfig.producerPrefix("linger.ms"), getOrSetDefault(LINGER_MS_KEY, "0"));
 
         return props;
     }


### PR DESCRIPTION
`linger.ms` is the time that the Kafka Producer waits to batch events before sending the request.

This PR allows configuring it on the GRPC producer, which is the thing that sends `Command`s to Kafka. Interestingly, with a single Task Worker and 8 threads, having `LHS_LINGER_MS=10` actually _slows down_ the throughput, because more of the time is spent blocking.

However, we should have this config and test it in a larger use-case with dozens of task workers all polling and sending tasks at the same time. With only one client, the advantages of batching are limited. With many, we can improve our efficiency quite a bit.