### PR TITLE
FIX: internal task queue concurrency

### DIFF
--- a/server/src/test/java/io/littlehorse/server/streams/taskqueue/OneTaskQueueTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/taskqueue/OneTaskQueueTest.java
@@ -103,7 +103,7 @@ public class OneTaskQueueTest {
         boundedQueue.onTaskScheduled(task1);
         boundedQueue.onTaskScheduled(task2);
         boundedQueue.onTaskScheduled(task3);
-        Assertions.assertThat(boundedQueue.isOutOfCapacity()).isTrue();
+        Assertions.assertThat(boundedQueue.isHasMoreTasksOnDisk()).isTrue();
         boundedQueue.onTaskScheduled(task4);
 
         boundedQueue.onPollRequest(mockClient, requestContext);


### PR DESCRIPTION
Previous implementation was incorrect in keeping track of whether there are more tasks on disk.