### PR TITLE
Create principals with admin privileges and no tenant

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
@@ -98,8 +98,9 @@ public class PutPrincipalRequestModel extends MetadataSubCommand<PutPrincipalReq
 
             toSave.setCreatedAt(oldPrincipal.getCreatedAt());
         }
-
-        if (perTenantAcls.isEmpty()) {
+        boolean canWriteAdminPrincipals = requester.isAdmin();
+        if (perTenantAcls.isEmpty()
+                && !(canWriteAdminPrincipals && !globalAcls.getAcls().isEmpty())) {
             throw new LHApiException(Status.INVALID_ARGUMENT, "Must provide list of tenants");
         }
         ensureThatIsAllowedToWriteInRequestedTenants(requester);

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
@@ -99,9 +99,9 @@ public class PutPrincipalRequestModel extends MetadataSubCommand<PutPrincipalReq
             toSave.setCreatedAt(oldPrincipal.getCreatedAt());
         }
         boolean canWriteAdminPrincipals = requester.isAdmin();
-        if (perTenantAcls.isEmpty()
-                && !(canWriteAdminPrincipals && !globalAcls.getAcls().isEmpty())) {
-            throw new LHApiException(Status.INVALID_ARGUMENT, "Must provide list of tenants");
+        if (!globalAcls.getAcls().isEmpty() && !canWriteAdminPrincipals) {
+            throw new LHApiException(
+                    Status.INVALID_ARGUMENT, "Only admin users can create a principal with global privileges");
         }
         ensureThatIsAllowedToWriteInRequestedTenants(requester);
         for (Map.Entry<String, ServerACLsModel> perTenantAcl : perTenantAcls.entrySet()) {

--- a/server/src/test/java/io/littlehorse/common/model/metadatacommand/PrincipalAdministrationTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/metadatacommand/PrincipalAdministrationTest.java
@@ -106,12 +106,18 @@ public class PrincipalAdministrationTest {
     @Test
     public void supportStorePrincipalWithGlobalAcls() {
         defaultStore.put(new StoredGetable<>(new TenantModel(tenantId)));
+        StoredGetable storedRequester =
+                defaultStore.get(new PrincipalIdModel(requesterId).getStoreableKey(), StoredGetable.class);
+        PrincipalModel requester = (PrincipalModel) storedRequester.getStoredObject();
+        requester.getPerTenantAcls().clear();
+        requester.setGlobalAcls(TestUtil.singleAdminAcl("tyler"));
+        defaultStore.put(new StoredGetable<>(requester));
+
         putPrincipalRequest.getPerTenantAcls().clear();
-        putPrincipalRequest.setPerTenantAcls(Map.of(tenantId, TestUtil.singleAcl()));
         putPrincipalRequest.setGlobalAcls(TestUtil.singleAcl());
         sendCommand(putPrincipalRequest);
 
-        assertThat(storedPrincipal().getPerTenantAcls().keySet()).isNotEmpty();
+        assertThat(storedPrincipal().getPerTenantAcls().keySet()).isEmpty();
         assertThat(storedPrincipal().getGlobalAcls().getAcls()).containsExactly(TestUtil.acl());
     }
 

--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -107,7 +107,6 @@ public class LHExtension implements BeforeAllCallback, TestInstancePostProcessor
                     .putPrincipal(PutPrincipalRequest.newBuilder()
                             .setId(principalId)
                             .setGlobalAcls(acls)
-                            .putPerTenantAcls(testContext.getConfig().getTenantId(), acls)
                             .build());
             // wait until the principal is propagated into the server
             Awaitility.await()


### PR DESCRIPTION
This PR enables LH server to create principal without specifying any tenant. This is useful when clients need to create principal that are able to do any operation in any tenant. 
The principal requester must have admin privileges:

- `ACL_ALL_RESOURCES`

- `ALL_ACTIONS`  