### PR TITLE
Add validation for principal ID containing slashes

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
@@ -85,10 +85,15 @@ public class PutPrincipalRequestModel extends MetadataSubCommand<PutPrincipalReq
         PrincipalModel toSave = new PrincipalModel();
         toSave.setId(new PrincipalIdModel(id));
 
-        // Check if the ID contains a slash
-        if (id.contains("/")) {
-            throw new LHApiException(Status.INVALID_ARGUMENT, "Principal ID cannot contain slashes.");
+        char[] disallowedCharacters = {'/', '\\'};
+        // Check if the ID contains any disallowed characters
+        for (char disallowedChar : disallowedCharacters) {
+            if (id.contains(String.valueOf(disallowedChar))) {
+                throw new LHApiException(
+                        Status.INVALID_ARGUMENT, "Principal ID cannot contain slashes or backslashes.");
+            }
         }
+
         if (oldPrincipal != null) {
             if (!overwrite) {
                 throw new LHApiException(

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
@@ -87,8 +87,7 @@ public class PutPrincipalRequestModel extends MetadataSubCommand<PutPrincipalReq
 
         // Check if the ID contains a slash
         if (id.contains("/")) {
-            throw new LHApiException(
-                    Status.INVALID_ARGUMENT, "Principal ID cannot contain slashes.");
+            throw new LHApiException(Status.INVALID_ARGUMENT, "Principal ID cannot contain slashes.");
         }
         if (oldPrincipal != null) {
             if (!overwrite) {

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutPrincipalRequestModel.java
@@ -84,6 +84,12 @@ public class PutPrincipalRequestModel extends MetadataSubCommand<PutPrincipalReq
                 context.service().getPrincipal(context.authorization().principalId());
         PrincipalModel toSave = new PrincipalModel();
         toSave.setId(new PrincipalIdModel(id));
+
+        // Check if the ID contains a slash
+        if (id.contains("/")) {
+            throw new LHApiException(
+                    Status.INVALID_ARGUMENT, "Principal ID cannot contain slashes.");
+        }
         if (oldPrincipal != null) {
             if (!overwrite) {
                 throw new LHApiException(


### PR DESCRIPTION
This commit adds a check to ensure that the principal ID provided does not contain slashes. If the ID contains a slash ("/"), it throws a LHApiException with an INVALID_ARGUMENT status, indicating that slashes are not allowed in the principal ID.

This validation helps maintain data integrity and prevents potential issues with principal IDs.

Issue 456