### PR TITLE
ci(dashboard): use setup-node to handle cache and pnpm/actions-setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,24 +113,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          package_json_file: ./dashboard/package.json
+
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      - name: Cache Dependencies
-        id: cache-dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-npm-cache-dir
-      - name: Tests
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache: pnpm
+
+      - name: Build Dashboard
         working-directory: ./dashboard
         run: |
-          npm install pnpm --global
           pnpm install
           pnpm test


### PR DESCRIPTION
It fixed the pnpm version to be run during tests.