### PR TITLE
feature: Adds task name on the error that mention that it already exists

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTaskDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTaskDefRequestModel.java
@@ -16,6 +16,7 @@ import io.littlehorse.sdk.common.proto.VariableDef;
 import io.littlehorse.server.streams.storeinternals.MetadataManager;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import io.littlehorse.server.streams.topology.core.MetadataCommandExecution;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +75,9 @@ public class PutTaskDefRequestModel extends MetadataSubCommand<PutTaskDefRequest
         if (oldVersion != null) {
             if (TaskDefUtil.equals(spec, oldVersion))
                 return oldVersion.toProto().build();
-            throw new LHApiException(Status.ALREADY_EXISTS, "TaskDef already exists and is immutable.");
+            throw new LHApiException(
+                    Status.ALREADY_EXISTS,
+                    MessageFormat.format("TaskDef [{0}] already exists and is immutable.", name));
         }
 
         metadataManager.put(spec);

--- a/server/src/test/java/e2e/TaskDefLifecycleTest.java
+++ b/server/src/test/java/e2e/TaskDefLifecycleTest.java
@@ -52,7 +52,7 @@ public class TaskDefLifecycleTest {
 
         assertThatThrownBy(() -> client.putTaskDef(taskUpdated.toPutTaskDefRequest()))
                 .isInstanceOf(StatusRuntimeException.class)
-                .hasMessage("ALREADY_EXISTS: TaskDef already exists and is immutable.");
+                .hasMessage("ALREADY_EXISTS: TaskDef [greet-with-update] already exists and is immutable.");
     }
 
     @Test


### PR DESCRIPTION
Old message: ALREADY_EXISTS: TaskDef already exists and is immutable.
New Message: ALREADY_EXISTS: TaskDef [task-def-name] already exists and is immutable.