### PR TITLE
MINOR: Cache instance name

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -55,6 +55,8 @@ public class LHServerConfig extends ConfigBase {
     @Getter
     private WriteBufferManager globalRocksdbWriteBufferManager;
 
+    private String instanceName;
+
     // Kafka Global Configs
     public static final String KAFKA_BOOTSTRAP_KEY = "LHS_KAFKA_BOOTSTRAP_SERVERS";
     public static final String LHS_CLUSTER_ID_KEY = "LHS_CLUSTER_ID"; // determines application.id
@@ -335,9 +337,13 @@ public class LHServerConfig extends ConfigBase {
     }
 
     public String getLHInstanceName() {
-        return getLHInstanceId().isPresent()
+        if (instanceName != null) return instanceName;
+
+        instanceName = getLHInstanceId().isPresent()
                 ? getLHInstanceId().get().toString()
                 : UUID.randomUUID().toString();
+
+        return instanceName;
     }
 
     public String getStateDirectory() {


### PR DESCRIPTION
In the CommandProcessor, we log the 'config.getLHInstanceName()'. When the LHS_INSTANCE_ID is not set, this causes the 'ConfigBase.java' to do a WARN log of 'LHS_INSTANCE_ID not set'.

This is a short-term fix to just not do that log every time. The long term fix is that the getOrSetDefault(foo, null) should make ConfigBase 'remember' that the key 'foo' has already been asked for, so it only does the WARN log on the first time.