### PR TITLE
docs: add examples and PR guidelines to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Here at LittleHorse, we embrace sharing our product in open source and appreciate any contributions to our codebase. 
+The LittleHorse Server project is open-source according to the Server-Side Public License 1.0, and as such we appreciate any contributions to our codebase. Please note that all contributions will be subject to that license agreement.
 
 This document details all of the necessary information for contributing to LittleHorse.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ _NOTE: The configurations above are indeed the defaults._
 
 ## Running Examples
 
-We provide a number of examples to using our SDK for defining a `WfSpec`. It may help to run a few of these and become familiar with the platform when developing for LittleHorse.
+We provide a number of examples to use our SDK for defining a `WfSpec`. It may help to run a few of these and become familiar with the platform when developing for LittleHorse.
 
 - [Java Examples](https://github.com/littlehorse-enterprises/littlehorse/tree/master/examples)
 - [Python Examples](https://github.com/littlehorse-enterprises/littlehorse/tree/master/sdk-python/examples)
@@ -135,4 +135,4 @@ Certain *types* of commits correlate to semantic versioning updates:
 - feat: MINOR
 - a commit with the footer `BREAKING CHANGE:` or a `!` after the type/scope
 
-You should reference the Conventional Commits v1.0.0 [website](https://www.conventionalcommits.org/en/v1.0.0/) for additional *types*, detailed specification rules, and FAQs about the practice before making a pull request. 
+You should reference the Conventional Commits v1.0.0 [website](https://www.conventionalcommits.org/en/v1.0.0/) for additional *types*, detailed specification rules, examples, and FAQs about the practice before making a pull request. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
-## Development
+# Contributing
 
-This document details how to set up your laptop to develop LittleHorse.
+Here at LittleHorse, we embrace sharing our product in open source and appreciate any contributions to our codebase. 
+
+This document details all of the necessary information for contributing to LittleHorse.
+
+**Table of Contents**
+- [Getting Started](#getting-started)
+- [Running Examples](#running-examples)
+- [Writing a Pull Request](#writing-a-pull-request)
+
+## Getting Started
+
+This section details how to set up your machine to develop LittleHorse.
 
 ### Prerequisites
 
@@ -19,7 +30,6 @@ This repository requires the following system dependencies:
 - `python` and [poetry](https://python-poetry.org/).
     - [sdk-python](sdk-python): >= 3.9
 - `nvm` and `node` >= 20
-
 
 ### Setup Pre-commit
 
@@ -92,3 +102,37 @@ LHC_API_PORT=2023
 LHW_SERVER_CONNECT_LISTENER=PLAIN
 ```
 _NOTE: The configurations above are indeed the defaults._
+
+## Running Examples
+
+We provide a number of examples to using our SDK for defining a `WfSpec`. It may help to run a few of these and become familiar with the platform when developing for LittleHorse.
+
+- [Java Examples](https://github.com/littlehorse-enterprises/littlehorse/tree/master/examples)
+- [Python Examples](https://github.com/littlehorse-enterprises/littlehorse/tree/master/sdk-python/examples)
+- [Go Examples](https://github.com/littlehorse-enterprises/littlehorse/tree/master/sdk-go/examples)
+
+
+
+## Writing a Pull Request
+
+Here at LittleHorse, we use the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) specification for writing pull request messages.
+
+Conventional Commits provides a standardized format for describing proposed changes and provides semantic versioning support for certain *types* of changes.
+
+The basic structure of a conventional commit message is as follows.
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Certain *types* of commits correlate to semantic versioning updates:
+
+- fix: PATCH
+- feat: MINOR
+- a commit with the footer `BREAKING CHANGE:` or a `!` after the type/scope
+
+You should reference the Conventional Commits v1.0.0 [website](https://www.conventionalcommits.org/en/v1.0.0/) for additional *types*, detailed specification rules, and FAQs about the practice before making a pull request. 


### PR DESCRIPTION
Added new sections "Examples" and "Writing a Pull Request" to `CONTRIBUTING.MD` document to enhance the new developer experience.

Once decided upon, further additions should be made to this document that outline if and how users should approach creating issues, reporting bugs.