### PR TITLE
fix(java-sdk): Detect if poll thread stops running and re-establish connection

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/PollThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/PollThread.java
@@ -112,6 +112,10 @@ public class PollThread extends Thread implements Closeable, StreamObserver<Poll
         this.stillRunning = false;
     }
 
+    public boolean isRunning() {
+        return this.stillRunning;
+    }
+
     private void doTask(
             ScheduledTask scheduledTask,
             LittleHorseGrpc.LittleHorseStub specificStub,

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
@@ -104,11 +104,12 @@ final class RebalanceThread extends Thread {
                         removed.close();
                     }
                 }
-                LittleHorseGrpc.LittleHorseStub stub = config.getAsyncStub(runningConnection.getHost(),
-                        runningConnection.getPort());
+                LittleHorseGrpc.LittleHorseStub stub =
+                        config.getAsyncStub(runningConnection.getHost(), runningConnection.getPort());
                 // This loop replaces each PollThread that stops running with a fresh PollThread
                 for (int i = 0; i < runningConnections.get(runningConnection).size(); i++) {
-                    PollThread existingPollThread = runningConnections.get(runningConnection).get(i);
+                    PollThread existingPollThread =
+                            runningConnections.get(runningConnection).get(i);
                     ArrayList<PollThread> pollThreads = new ArrayList<>();
                     if (existingPollThread.isRunning()) {
                         pollThreads.add(existingPollThread);
@@ -124,8 +125,8 @@ final class RebalanceThread extends Thread {
             for (LHHostInfo lhHostInfo : availableHosts) {
                 if (!runningConnections.containsKey(lhHostInfo)) {
                     final List<PollThread> connections = new ArrayList<>();
-                    LittleHorseGrpc.LittleHorseStub stub = config.getAsyncStub(lhHostInfo.getHost(),
-                            lhHostInfo.getPort());
+                    LittleHorseGrpc.LittleHorseStub stub =
+                            config.getAsyncStub(lhHostInfo.getHost(), lhHostInfo.getPort());
                     for (int i = 0; i < config.getWorkerThreads(); i++) {
                         String threadName = String.format("lh-poll-%s", i);
                         PollThread connection = createConnection(stub, threadName);
@@ -143,7 +144,6 @@ final class RebalanceThread extends Thread {
         }
 
         @Override
-        public void onCompleted() {
-        }
+        public void onCompleted() {}
     }
 }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
@@ -106,24 +106,31 @@ final class RebalanceThread extends Thread {
                 }
                 LittleHorseGrpc.LittleHorseStub stub =
                         config.getAsyncStub(runningConnection.getHost(), runningConnection.getPort());
-
                 List<PollThread> originalPollThreads = runningConnections.get(runningConnection);
-                ArrayList<PollThread> newPollThreads = new ArrayList<>();
-
-                // This loop replaces each PollThread that stops running with a fresh PollThread
-                for (int i = 0; i < originalPollThreads.size(); i++) {
-                    PollThread currentPollThread = originalPollThreads.get(i);
-                    if (currentPollThread.isRunning()) {
-                        newPollThreads.add(currentPollThread);
-                    } else {
-                        String threadName = String.format("lh-poll-%s", i);
-                        PollThread connection = createConnection(stub, threadName);
-                        connection.start();
-                        newPollThreads.add(connection);
+                // Check if any PollThreads have failed
+                boolean hasAPollThreadFailed = false;
+                for (PollThread p : originalPollThreads) {
+                    if (!p.isRunning()) {
+                        hasAPollThreadFailed = true;
+                        break;
                     }
                 }
-
-                runningConnections.put(runningConnection, newPollThreads);
+                if (hasAPollThreadFailed) {
+                    ArrayList<PollThread> newPollThreads = new ArrayList<>();
+                    // This loop replaces each PollThread that stops running with a fresh PollThread
+                    for (int i = 0; i < originalPollThreads.size(); i++) {
+                        PollThread currentPollThread = originalPollThreads.get(i);
+                        if (currentPollThread.isRunning()) {
+                            newPollThreads.add(currentPollThread);
+                        } else {
+                            String threadName = String.format("lh-poll-%s", i);
+                            PollThread connection = createConnection(stub, threadName);
+                            connection.start();
+                            newPollThreads.add(connection);
+                        }
+                    }
+                    runningConnections.put(runningConnection, newPollThreads);
+                }
             }
             for (LHHostInfo lhHostInfo : availableHosts) {
                 if (!runningConnections.containsKey(lhHostInfo)) {

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
@@ -104,15 +104,11 @@ final class RebalanceThread extends Thread {
                         removed.close();
                     }
                 }
-
-
-                LittleHorseGrpc.LittleHorseStub stub =
-                config.getAsyncStub(runningConnection.getHost(), runningConnection.getPort());
-
+                LittleHorseGrpc.LittleHorseStub stub = config.getAsyncStub(runningConnection.getHost(),
+                        runningConnection.getPort());
                 // This loop replaces each PollThread that stops running with a fresh PollThread
                 for (int i = 0; i < runningConnections.get(runningConnection).size(); i++) {
                     PollThread existingPollThread = runningConnections.get(runningConnection).get(i);
-
                     ArrayList<PollThread> pollThreads = new ArrayList<>();
                     if (existingPollThread.isRunning()) {
                         pollThreads.add(existingPollThread);
@@ -122,16 +118,14 @@ final class RebalanceThread extends Thread {
                         connection.start();
                         pollThreads.add(connection);
                     }
-
                     runningConnections.put(runningConnection, pollThreads);
                 }
-
             }
             for (LHHostInfo lhHostInfo : availableHosts) {
                 if (!runningConnections.containsKey(lhHostInfo)) {
                     final List<PollThread> connections = new ArrayList<>();
-                    LittleHorseGrpc.LittleHorseStub stub =
-                            config.getAsyncStub(lhHostInfo.getHost(), lhHostInfo.getPort());
+                    LittleHorseGrpc.LittleHorseStub stub = config.getAsyncStub(lhHostInfo.getHost(),
+                            lhHostInfo.getPort());
                     for (int i = 0; i < config.getWorkerThreads(); i++) {
                         String threadName = String.format("lh-poll-%s", i);
                         PollThread connection = createConnection(stub, threadName);
@@ -149,6 +143,7 @@ final class RebalanceThread extends Thread {
         }
 
         @Override
-        public void onCompleted() {}
+        public void onCompleted() {
+        }
     }
 }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
@@ -104,6 +104,11 @@ final class RebalanceThread extends Thread {
                         removed.close();
                     }
                 }
+                for (PollThread pollThread : runningConnections.get(runningConnection)) {
+                    if (!pollThread.isRunning()) {
+                        runningConnections.remove(runningConnection);
+                    }
+                }
             }
             for (LHHostInfo lhHostInfo : availableHosts) {
                 if (!runningConnections.containsKey(lhHostInfo)) {

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/RebalanceThread.java
@@ -107,6 +107,7 @@ final class RebalanceThread extends Thread {
                 for (PollThread pollThread : runningConnections.get(runningConnection)) {
                     if (!pollThread.isRunning()) {
                         runningConnections.remove(runningConnection);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
When PollThreads stop running for any reason, a private boolean in the PollThread class `stillRunning` is set to false. Until now, this variable wasn't being used in the RebalanceThread, so when PollThreads stopped running they would never start up again.

This pull request attempts to remedy this by checking the state of the PollThread in the RebalanceThread. If the PollThread `isRunning` variable is true, it is kept. If the PollThread `isRunning` variable is false, it is replaced with a new PollThread.

Refs: #826

