### PR TITLE
fix(dashboard): threadRunNumber 0 is valid now

### DIFF
--- a/dashboard/src/app/(authenticated)/taskDef/[name]/components/TaskDef.tsx
+++ b/dashboard/src/app/(authenticated)/taskDef/[name]/components/TaskDef.tsx
@@ -108,7 +108,7 @@ export const TaskDef: FC<Props> = ({ spec }) => {
                             <Link
                               className="py-2 text-blue-500 hover:underline"
                               target="_blank"
-                              href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber || taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeName=${taskRun.source?.taskNode?.nodeRunId?.position}-${taskRun.source?.taskNode?.nodeRunId}-TASK`}
+                              href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber ?? taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeName=${taskRun.source?.taskNode?.nodeRunId?.position}-${taskRun.source?.taskNode?.nodeRunId}-TASK`}
                             >
                               {concatWfRunIds(taskRun.id?.wfRunId!)}
                             </Link>


### PR DESCRIPTION
This is cause of the incorrect use of the falsey operator `||` 