### PR TITLE
chore(server): logs core topology KafkaStreams state

### DIFF
--- a/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
@@ -78,6 +78,7 @@ public class InstanceState implements MeterBinder, KafkaStreams.StateListener, C
             activeTasks.set(currentActiveTaskIds);
             internalComms.handleRebalance(activeTasks.get());
         }
+        log.info("New state for core topology: {}", newState);
     }
 
     @Override


### PR DESCRIPTION
There was a refactor made that removes this log, which made me sad. This fixes it so that the Core Topology is logged the same as the Timer Topology (actually, Core is more important to log anyways :wink: )