### PR TITLE
feat(python-sdk): Add customizable timeout for workflow `TaskRuns`

### DIFF
--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1877,7 +1877,7 @@ class Workflow:
         self._default_exponential_backoff = exponential_backoff
         return self
     
-    def with_timeout_seconds_policy(
+    def with_task_timeout_seconds(
         self,
         timeout_seconds: Optional[int] = None
     ) -> Workflow:

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -740,6 +740,7 @@ class WorkflowThread:
         initializer: "ThreadInitializer",
         default_retries: Optional[int] = None,
         default_exponential_backoff: Optional[ExponentialBackoffRetryPolicy] = None,
+        default_timeout_seconds: Optional[int] = None,
     ) -> None:
         """This is used to define the logic of a ThreadSpec in a ThreadInitializer.
 
@@ -750,6 +751,7 @@ class WorkflowThread:
         self._default_exponential_backoff: Optional[ExponentialBackoffRetryPolicy] = (
             default_exponential_backoff
         )
+        self._default_timeout_seconds: Optional[int] = default_timeout_seconds
         self._default_retries: Optional[int] = default_retries
         self._wf_run_variables: list[WfRunVariable] = []
         self._wf_interruptions: list[WorkflowInterruption] = []
@@ -1038,12 +1040,13 @@ class WorkflowThread:
         self._check_if_active()
         task_node: TaskNode
         readable_name: str
+
         if isinstance(task_name, str):
             readable_name = task_name
             task_node = TaskNode(
                 task_def_id=TaskDefId(name=task_name),
                 variables=[to_variable_assignment(arg) for arg in args],
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=timeout_seconds if timeout_seconds is not None else self._default_timeout_seconds,
                 retries=retries if retries is not None else self._default_retries,
                 exponential_backoff=(
                     exponential_backoff
@@ -1056,6 +1059,7 @@ class WorkflowThread:
             task_node = TaskNode(
                 dynamic_task=to_variable_assignment(task_name),
                 variables=[to_variable_assignment(arg) for arg in args],
+                timeout_seconds=timeout_seconds if timeout_seconds is not None else self._default_timeout_seconds,
                 retries=retries if retries is not None else self._default_retries,
                 exponential_backoff=(
                     exponential_backoff
@@ -1069,6 +1073,7 @@ class WorkflowThread:
             task_node = TaskNode(
                 dynamic_task=to_variable_assignment(task_name),
                 variables=[to_variable_assignment(arg) for arg in args],
+                timeout_seconds=timeout_seconds if timeout_seconds is not None else self._default_timeout_seconds,
                 retries=retries if retries is not None else self._default_retries,
                 exponential_backoff=(
                     exponential_backoff
@@ -1755,6 +1760,7 @@ class Workflow:
         self._allowed_updates: Optional[AllowedUpdateType] = None
         self._parent_wf: Optional[WfSpec.ParentWfSpecReference] = None
         self._retention_policy: Optional[WorkflowRetentionPolicy] = None
+        self._default_timeout_seconds: Optional[int] = None
         self._default_exponential_backoff: Optional[ExponentialBackoffRetryPolicy] = (
             None
         )
@@ -1826,6 +1832,7 @@ class Workflow:
                 initializer,
                 self._default_retries,
                 self._default_exponential_backoff,
+                self._default_timeout_seconds
             )
             thread_specs[name] = builder.compile()
 
@@ -1868,6 +1875,20 @@ class Workflow:
         """
         self._default_retries = retries
         self._default_exponential_backoff = exponential_backoff
+        return self
+    
+    def with_timeout_seconds_policy(
+        self,
+        timeout_seconds: Optional[int] = None
+    ) -> Workflow:
+        """Configures the default timeout length (seconds) of the tasks.
+
+        Args:
+            timeout_seconds(Optional[int]): Length of time before the TaskRun times out.
+
+        Returns: This instance.
+        """
+        self._default_timeout_seconds = timeout_seconds
         return self
 
 

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1016,7 +1016,7 @@ class WorkflowThread:
         self,
         task_name: Union[str, LHFormatString, WfRunVariable],
         *args: Any,
-        timeout: Optional[int] = None,
+        timeout_seconds: Optional[int] = None,
         retries: Optional[int] = None,
         exponential_backoff: Optional[ExponentialBackoffRetryPolicy] = None,
     ) -> NodeOutput:
@@ -1043,7 +1043,7 @@ class WorkflowThread:
             task_node = TaskNode(
                 task_def_id=TaskDefId(name=task_name),
                 variables=[to_variable_assignment(arg) for arg in args],
-                timeout_seconds=timeout,
+                timeout_seconds=timeout_seconds,
                 retries=retries if retries is not None else self._default_retries,
                 exponential_backoff=(
                     exponential_backoff

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1016,6 +1016,7 @@ class WorkflowThread:
         self,
         task_name: Union[str, LHFormatString, WfRunVariable],
         *args: Any,
+        timeout: Optional[int] = None,
         retries: Optional[int] = None,
         exponential_backoff: Optional[ExponentialBackoffRetryPolicy] = None,
     ) -> NodeOutput:
@@ -1042,6 +1043,7 @@ class WorkflowThread:
             task_node = TaskNode(
                 task_def_id=TaskDefId(name=task_name),
                 variables=[to_variable_assignment(arg) for arg in args],
+                timeout_seconds=timeout,
                 retries=retries if retries is not None else self._default_retries,
                 exponential_backoff=(
                     exponential_backoff

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -1662,10 +1662,10 @@ class TestWorkflow(unittest.TestCase):
         )
 
     def test_wf_task_timeout(self):
-        timeout = 5
+        timeout_seconds = 5
 
         def my_entrypoint(thread: WorkflowThread) -> None:
-            thread.execute("example_task", timeout=timeout)
+            thread.execute("example_task", timeout_seconds=timeout_seconds)
         
         wf = Workflow("my-wf", my_entrypoint)
 
@@ -1684,7 +1684,7 @@ class TestWorkflow(unittest.TestCase):
                             ),
                             "1-example_task-TASK": Node(
                                 task=TaskNode(task_def_id=TaskDefId(name="example_task"),
-                                              timeout_seconds=timeout),
+                                              timeout_seconds=timeout_seconds),
                                 outgoing_edges=[Edge(sink_node_name="2-exit-EXIT")]
                             ),
                             "2-exit-EXIT": Node(exit=ExitNode()),

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -1665,7 +1665,7 @@ class TestWorkflow(unittest.TestCase):
         timeout_seconds = 5
 
         def my_entrypoint(thread: WorkflowThread) -> None:
-            thread.execute("example_task", timeout_seconds=timeout_seconds)
+            thread.execute("example-task", timeout_seconds=timeout_seconds)
         
         wf = Workflow("my-wf", my_entrypoint)
 
@@ -1680,10 +1680,10 @@ class TestWorkflow(unittest.TestCase):
                         nodes={
                             "0-entrypoint-ENTRYPOINT": Node(
                                 entrypoint=EntrypointNode(),
-                                outgoing_edges=[Edge(sink_node_name="1-example_task-TASK")],
+                                outgoing_edges=[Edge(sink_node_name="1-example-task-TASK")],
                             ),
-                            "1-example_task-TASK": Node(
-                                task=TaskNode(task_def_id=TaskDefId(name="example_task"),
+                            "1-example-task-TASK": Node(
+                                task=TaskNode(task_def_id=TaskDefId(name="example-task"),
                                               timeout_seconds=timeout_seconds),
                                 outgoing_edges=[Edge(sink_node_name="2-exit-EXIT")]
                             ),
@@ -1693,6 +1693,48 @@ class TestWorkflow(unittest.TestCase):
                 },
             ),
         )
+
+    def test_wf_task_default_timeout(self):
+        default_timeout_seconds = 5
+        custom_timeout_seconds = 10
+
+        def my_entrypoint(thread: WorkflowThread) -> None:
+            thread.execute("use-default-timeout")
+            thread.execute("use-custom-timeout", timeout_seconds=custom_timeout_seconds)
+        
+        wf = Workflow("my-wf", my_entrypoint).with_timeout_seconds_policy(default_timeout_seconds)
+
+        self.assertEqual(
+            wf.compile(),
+            PutWfSpecRequest(
+                entrypoint_thread_name="entrypoint",
+                name="my-wf",
+                thread_specs={
+                    "entrypoint": ThreadSpec(
+                        variable_defs=[],
+                        nodes={
+                            "0-entrypoint-ENTRYPOINT": Node(
+                                entrypoint=EntrypointNode(),
+                                outgoing_edges=[Edge(sink_node_name="1-use-default-timeout-TASK")],
+                            ),
+                            "1-use-default-timeout-TASK": Node(
+                                task=TaskNode(task_def_id=TaskDefId(name="use-default-timeout"),
+                                              timeout_seconds=default_timeout_seconds),
+                                outgoing_edges=[Edge(sink_node_name="2-use-custom-timeout-TASK")]
+                            ),
+                            "2-use-custom-timeout-TASK": Node(
+                                task=TaskNode(task_def_id=TaskDefId(name="use-custom-timeout"),
+                                              timeout_seconds=custom_timeout_seconds),
+                                outgoing_edges=[Edge(sink_node_name="3-exit-EXIT")]
+                            ),
+                            "3-exit-EXIT": Node(exit=ExitNode()),
+                        },
+                    )
+                },
+            ),
+        )
+
+        
         
 
 

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -1702,7 +1702,7 @@ class TestWorkflow(unittest.TestCase):
             thread.execute("use-default-timeout")
             thread.execute("use-custom-timeout", timeout_seconds=custom_timeout_seconds)
         
-        wf = Workflow("my-wf", my_entrypoint).with_timeout_seconds_policy(default_timeout_seconds)
+        wf = Workflow("my-wf", my_entrypoint).with_task_timeout_seconds(default_timeout_seconds)
 
         self.assertEqual(
             wf.compile(),


### PR DESCRIPTION
Implements `timeout_seconds` property for Tasks in the Python SDK.

1. Python SDK users can customize the timeout length of TaskNodes from the `WorkflowThread.execute()` method.

The following example defines a workflow that executes the "greet" `TaskDef` with a `timeout_seconds` value of `40` seconds. 

```python
def get_workflow() -> Workflow:
  def my_entrypoint(wf: WorkflowThread) -> None:
      wf.execute("greet", the_name, timeout_seconds=40)
  
  return Workflow("example-basic", my_entrypoint)
```

---------

2. Python SDK users can also set a Workflow-wide default `timeout_seconds` value using
the `Workflow.with_task_timeout_seconds()` method.

The following example defines a workflow that executes two tasks, one that uses a default timeout (5 seconds) and one that uses a custom defined one (10 seconds). The default one would apply to any Task in the Workflow unless overwritten by the `thread.execute()` command for said Task.

```python
default_timeout_seconds = 5
custom_timeout_seconds = 10

def my_entrypoint(thread: WorkflowThread) -> None:
  thread.execute("use-default-timeout")
  thread.execute("use-custom-timeout", timeout_seconds=custom_timeout_seconds)
        
wf = Workflow("my-wf", my_entrypoint).with_task_timeout_seconds(default_timeout_seconds)
```

# Note
I added an argument to the `WorkflowThread.execute()` method for `timeout_seconds` to match the other arguments `retries` and `exponential_backoff`. However, in the Java SDK, updating the `timeout_seconds` is implemented using a `.timeout()` method. More discussion necessary as to the universal solution, as now our SDKs diverge.