### PR TITLE
fix(server): report on standby lag

### DIFF
--- a/server/src/main/java/io/littlehorse/server/monitoring/health/ServerHealthState.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/health/ServerHealthState.java
@@ -118,7 +118,7 @@ public class ServerHealthState {
                 .lagInfoForPartition(
                         metadata.topicPartitions().stream().findFirst().get().partition())
                 .orElse(null);
-        if (lagInfo == null) {
+        if (lagInfo != null) {
             return Optional.of(new StandbyTaskState(metadata, lagInfo));
         } else {
             return Optional.empty();


### PR DESCRIPTION
This PR fixes the issue where the `/status` endpoint wasn't returning an empty list for the standby states.

However, I think there is some other issue. While constantly running 5 workflow's per second (so the changelog topics should have stuff being produced to them), I see the following numbers _never get updated_ which means probably the `onBatchRestored()` isn't getting called...?

```
    "partition": 42,
    "lag": 16960,
    "changelogEndOffset": 34322
```

The `lag` never changes, nor does the `changelogEndOffset`, except on a rebalance.