### PR TITLE
fix(tenant): make rpc PutTenant idempotent

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTenantRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutTenantRequestModel.java
@@ -57,7 +57,8 @@ public class PutTenantRequestModel extends MetadataSubCommand<PutTenantRequest> 
             throw new LHApiException(Status.PERMISSION_DENIED, "Unauthorized to create tenants");
         }
 
-        if (metadataManager.get(new TenantIdModel(id)) == null) {
+        TenantModel old = metadataManager.get(new TenantIdModel(id));
+        if (old == null) {
             if (Pattern.matches(".*[\\\\/].*", this.id)) {
                 throw new LHApiException(Status.INVALID_ARGUMENT, "/ and \\ are not valid characters for Tenant");
             }
@@ -67,7 +68,7 @@ public class PutTenantRequestModel extends MetadataSubCommand<PutTenantRequest> 
             metadataManager.put(toSave);
             return toSave.toProto().build();
         } else {
-            throw new LHApiException(Status.ALREADY_EXISTS, "Tenant %s already exists".formatted(id));
+            return old.toProto().build();
         }
     }
 }

--- a/server/src/test/java/io/littlehorse/common/model/metadatacommand/TenantAdministrationTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/metadatacommand/TenantAdministrationTest.java
@@ -97,7 +97,6 @@ public class TenantAdministrationTest {
                 new Record<>(UUID.randomUUID().toString(), command.toProto().build(), 0L, metadata));
         metadataProcessor.process(
                 new Record<>(UUID.randomUUID().toString(), command.toProto().build(), 0L, metadata));
-        verify(server, times(1)).sendErrorToClient(any(), any());
         assertThat(storedTenant()).isNotNull();
     }
 

--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -81,7 +81,7 @@ public class LHExtension implements BeforeAllCallback, TestInstancePostProcessor
         }
         try {
             Awaitility.await()
-                    .atMost(Duration.ofSeconds(20))
+                    .atMost(Duration.ofSeconds(25))
                     .ignoreException(RuntimeException.class)
                     .until(() -> {
                         testContext


### PR DESCRIPTION
- All other metadata requests in the LH Server are idempotent and return OK if duplicated.
- This includes TaskDef, Principal, WfSpec, ExternalEventDef, and UserTaskDef.