### PR TITLE
chore(protobuf): generate protobuf files from x86_64 and aarch_64

### DIFF
--- a/local-dev/Dockerfile
+++ b/local-dev/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:22.04
+ENV PROTOC_VERSION          23.4
+ENV PROTO_GEN_JAVA           1.57.2
+ENV PROTO_GEN_GO             1.31.0
+ENV PROTO_GEN_GO_GRPC        1.3.0
+ENV PROTO_GEN_GO_DOC         1.5.1
+ENV PROTO_GEN_PYTHON         1.57.0
+ENV PROTO_GEN_JS             1.178.0
+
+ENV GOBIN /usr/local/bin
+
+RUN apt update && apt install -y --no-install-recommends \
+  python3 \
+  git \
+  pip \
+  wget \
+  ca-certificates \
+  unzip \
+  golang \
+  nodejs \
+  npm && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install protoc
+RUN set -x; \
+  dpkgArch="$(uname -m)" && \
+  case "$dpkgArch" in \
+    x86_64) ARCH='x86_64';; \
+    aarch64) ARCH='aarch_64';; \
+  *) echo >&2 "error: unsupported architecture: $dpkgArch"; exit 1 ;; \
+  esac && \
+  wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip -O /tmp/protoc.zip && \
+  unzip /tmp/protoc.zip -d /usr/local && \
+  rm /tmp/protoc.zip && \
+  wget -q https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${PROTO_GEN_JAVA}/protoc-gen-grpc-java-${PROTO_GEN_JAVA}-linux-${ARCH}.exe -O /usr/local/bin/protoc-gen-grpc-java
+
+RUN chmod +x /usr/local/bin/* && \
+  rm -f /tmp/*
+
+  # Install protoc-gen-go
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTO_GEN_GO} && \
+  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${PROTO_GEN_GO_GRPC} && \
+  go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v${PROTO_GEN_GO_DOC}
+
+# Install protoc-gen-python
+RUN pip3 install grpcio-tools==${PROTO_GEN_PYTHON}
+# Install protoc-gen-js
+RUN npm install -g ts-proto@${PROTO_GEN_JS}

--- a/local-dev/compile-proto.sh
+++ b/local-dev/compile-proto.sh
@@ -53,8 +53,10 @@ $docker_run python3 -m grpc_tools.protoc \
 # fix python packages, no option python_package https://github.com/protocolbuffers/protobuf/issues/7061
 echo "Fixing python objects"
 for i in $(ls "$WORK_DIR"/schemas/littlehorse | grep -v -E "^internal" | sed 's/.proto/_pb2/'); do
-    sed -i '' "s/^import ${i}/import littlehorse.model.${i}/" "${WORK_DIR}"/sdk-python/littlehorse/model/*
+    sed -i.bak "s/^import ${i}/import littlehorse.model.${i}/" "${WORK_DIR}"/sdk-python/littlehorse/model/*
 done
+
+rm -f "${WORK_DIR}"/sdk-python/littlehorse/model/*.bak
 
 find "${WORK_DIR}/sdk-python/littlehorse/model" -type f -name "*.py" -print0 | sort -z | xargs -0 -I {} sh -c 'echo "from .$(basename $1 .py) import *" >> $(dirname $1)/__init__.py' _ {}
 


### PR DESCRIPTION
This PR enables compile-proto.sh to run with on `aarch_64` and `x86_64`

Here some findings while making this change:

- The package `github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc`  is outdated and is no longer compatible with newer golang versions.
- Upgrading protobuf to latest version requires additional changes for `sdk-java` since some of the utility classes were renamed.
- More architectures can be added by modifying the compile-proto.sh accordingly.