### PR TITLE
fix(server): fixes rebalance implementation during instance shutdowns

### DIFF
--- a/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
@@ -82,6 +82,7 @@ public class InstanceState implements MeterBinder, KafkaStreams.StateListener, C
                 // There is nothing that we can do here if the server rebalance logic fails.
                 // This can fail with a IllegalStateException or any other Runtime exception
                 // if kafka streams is closing the instance
+                log.warn("Failed to handle async waiters reassignment: " + toIgnore.getMessage());
             }
         }
         log.info("New state for core topology: {}", newState);

--- a/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
@@ -76,7 +76,13 @@ public class InstanceState implements MeterBinder, KafkaStreams.StateListener, C
 
         if (newState == KafkaStreams.State.RUNNING) {
             activeTasks.set(currentActiveTaskIds);
-            internalComms.handleRebalance(activeTasks.get());
+            try {
+                internalComms.handleRebalance(activeTasks.get());
+            } catch (Exception toIgnore) {
+                // There is nothing that we can do here if the server rebalance logic fails.
+                // This can fail with a IllegalStateException or any other Runtime exception
+                // if kafka streams is closing the instance
+            }
         }
         log.info("New state for core topology: {}", newState);
     }


### PR DESCRIPTION
This caused unclean shutdowns in the kafka streams instance. Follow up PR will be created after this to implement a proper mechanism to handle uncaught exceptions in kafka streams. 