### PR TITLE
chore(sdk-java): don't include jackson in api

### DIFF
--- a/e2e-tests/src/main/java/io/littlehorse/tests/Test.java
+++ b/e2e-tests/src/main/java/io/littlehorse/tests/Test.java
@@ -1,8 +1,8 @@
 package io.littlehorse.tests;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.config.LHConfig;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.sdk.common.proto.ExternalEvent;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
@@ -281,7 +281,7 @@ public abstract class Test {
                 getVariable(client, wfRunId, threadRunNumber, varName).getValue();
         try {
             return LHLibUtil.deserializeFromjson(varVal.getJsonArr(), List.class);
-        } catch (JsonProcessingException exn) {
+        } catch (LHJsonProcessingException exn) {
             throw new TestFailure(this, "Couldn't deserialize variable " + varName + ":" + exn.getMessage());
         }
     }
@@ -293,7 +293,7 @@ public abstract class Test {
                 getVariable(client, wfRunId, threadRunNumber, varName).getValue();
         try {
             return LHLibUtil.deserializeFromjson(varVal.getJsonObj(), cls);
-        } catch (JsonProcessingException exn) {
+        } catch (LHJsonProcessingException exn) {
             throw new TestFailure(this, "Couldn't deserialize variable " + varName + ":" + exn.getMessage());
         }
     }

--- a/sdk-java/build.gradle
+++ b/sdk-java/build.gradle
@@ -101,9 +101,9 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     // JSONPath
-    api 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2'
-    api 'com.jayway.jsonpath:json-path:2.9.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2'
+    implementation 'com.jayway.jsonpath:json-path:2.9.0'
 
     // Protobuf
     api "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/LHLibUtil.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/LHLibUtil.java
@@ -10,6 +10,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.exception.LHSerdeError;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
 import io.littlehorse.sdk.common.proto.TaskDefId;
@@ -69,12 +70,20 @@ public class LHLibUtil {
 
     private static ObjectMapper mapper = new ObjectMapper();
 
-    public static String serializeToJson(Object o) throws JsonProcessingException {
-        return mapper.writeValueAsString(o);
+    public static String serializeToJson(Object o) throws LHJsonProcessingException {
+        try {
+            return mapper.writeValueAsString(o);
+        } catch (JsonProcessingException exn) {
+            throw new LHJsonProcessingException(exn);
+        }
     }
 
-    public static <T extends Object> T deserializeFromjson(String json, Class<T> cls) throws JsonProcessingException {
-        return mapper.readValue(json, cls);
+    public static <T extends Object> T deserializeFromjson(String json, Class<T> cls) throws LHJsonProcessingException {
+        try {
+            return mapper.readValue(json, cls);
+        } catch (JsonProcessingException exn) {
+            throw new LHJsonProcessingException(exn);
+        }
     }
 
     public static WfRunId getWfRunId(TaskRunSourceOrBuilder taskRunSource) {
@@ -148,7 +157,7 @@ public class LHLibUtil {
             String jsonStr;
             try {
                 jsonStr = LHLibUtil.serializeToJson(o);
-            } catch (JsonProcessingException exn) {
+            } catch (LHJsonProcessingException exn) {
                 exn.printStackTrace();
                 throw new LHSerdeError(exn, "Failed deserializing json");
             }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/exception/LHJsonProcessingException.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/exception/LHJsonProcessingException.java
@@ -1,0 +1,10 @@
+package io.littlehorse.sdk.common.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class LHJsonProcessingException extends Exception {
+
+    public LHJsonProcessingException(JsonProcessingException exn) {
+        super(exn);
+    }
+}

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/VariableMapping.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/VariableMapping.java
@@ -1,8 +1,8 @@
 package io.littlehorse.sdk.worker.internal.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.exception.InputVarSubstitutionError;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.exception.TaskSchemaMismatchError;
 import io.littlehorse.sdk.common.proto.ScheduledTask;
 import io.littlehorse.sdk.common.proto.TaskDef;
@@ -116,7 +116,7 @@ public class VariableMapping {
 
         try {
             return LHLibUtil.deserializeFromjson(jsonStr, type);
-        } catch (JsonProcessingException exn) {
+        } catch (LHJsonProcessingException exn) {
             throw new InputVarSubstitutionError(
                     "Failed deserializing the Java object for variable " + taskDefParamName, exn);
         }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -61,12 +61,17 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus:1.11.2'
     implementation 'io.javalin:javalin:5.6.0'
 
-    // Lombok stuffs
+    // Lombok stuff
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testImplementation project(":test-utils")
+
+    // JSON and YAML processing
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2'
+    implementation 'com.jayway.jsonpath:json-path:2.9.0'
 
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.junit.platform:junit-platform-console-standalone:1.11.0-M2'

--- a/server/src/test/java/e2e/FailureHandlingTest.java
+++ b/server/src/test/java/e2e/FailureHandlingTest.java
@@ -1,7 +1,7 @@
 package e2e;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.exception.LHTaskException;
 import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.Failure;
@@ -87,7 +87,7 @@ public class FailureHandlingTest {
                         Map<String, String> outputData = LHLibUtil.deserializeFromjson(
                                 failure.getContent().getJsonObj(), Map.class);
                         Assertions.assertThat(outputData).containsOnlyKeys("date", "server");
-                    } catch (JsonProcessingException e) {
+                    } catch (LHJsonProcessingException e) {
                         throw new RuntimeException(e);
                     }
                     Assertions.assertThat(failure.getFailureHandlerThreadrunId())

--- a/server/src/test/java/e2e/JsonMutationTest.java
+++ b/server/src/test/java/e2e/JsonMutationTest.java
@@ -2,8 +2,8 @@ package e2e;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
 import io.littlehorse.sdk.common.proto.VariableType;
@@ -36,7 +36,7 @@ public class JsonMutationTest {
                 @SuppressWarnings("unchecked")
                 Map<String, String> jsonMap = LHLibUtil.deserializeFromjson(variableValue.getJsonObj(), Map.class);
                 assertThat(jsonMap).doesNotContainKey("foo");
-            } catch (JsonProcessingException e) {
+            } catch (LHJsonProcessingException e) {
                 throw new RuntimeException(e);
             }
         };
@@ -55,7 +55,7 @@ public class JsonMutationTest {
                 @SuppressWarnings("unchecked")
                 Map<String, String> jsonMap = LHLibUtil.deserializeFromjson(variableValue.getJsonObj(), Map.class);
                 assertThat(jsonMap).containsOnlyKeys("baz");
-            } catch (JsonProcessingException e) {
+            } catch (LHJsonProcessingException e) {
                 throw new RuntimeException(e);
             }
         };

--- a/server/src/test/java/e2e/VarMutationListsTest.java
+++ b/server/src/test/java/e2e/VarMutationListsTest.java
@@ -2,8 +2,8 @@ package e2e;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.exception.LHJsonProcessingException;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.VariableMutationType;
 import io.littlehorse.sdk.common.proto.VariableType;
@@ -38,7 +38,7 @@ public class VarMutationListsTest {
                 @SuppressWarnings("unchecked")
                 List<Object> variableList = LHLibUtil.deserializeFromjson(variableValue.getJsonArr(), List.class);
                 assertThat(variableList).containsExactly(expectedOutput);
-            } catch (JsonProcessingException exn) {
+            } catch (LHJsonProcessingException exn) {
                 throw new RuntimeException(exn);
             }
         };
@@ -56,7 +56,7 @@ public class VarMutationListsTest {
                 @SuppressWarnings("unchecked")
                 List<Object> variableList = LHLibUtil.deserializeFromjson(variableValue.getJsonArr(), List.class);
                 assertThat(variableList).containsExactly(workflowInput);
-            } catch (JsonProcessingException exn) {
+            } catch (LHJsonProcessingException exn) {
                 throw new RuntimeException(exn);
             }
         };


### PR DESCRIPTION
Shouldn't include the Jackson libraries as part of the API of sdk-java, since our users might have it in a different version which conflicts with the one provided by our library.