### PR TITLE
docs: Adds reference to the post external events doc

### DIFF
--- a/docs/docs/05-developer-guide/08-wfspec-development/05-interrupts.md
+++ b/docs/docs/05-developer-guide/08-wfspec-development/05-interrupts.md
@@ -132,6 +132,9 @@ def my_entrypoint(wf: WorkflowThread) -> None:
    </TabItem>
 </Tabs>
 
+## How to trigger an Interrupt event
+Please refer to: [Posting External Events](../09-grpc/15-posting-external-events.md))
+
 ## Notes and Best Practices
 
 First, only one `ThreadSpec` may register an Interrupt Handler for a given `ExternalEventDef`.


### PR DESCRIPTION
From the interrupt handler doc make a link to the instructions on how to post a new external event.