### PR TITLE
fix(server): don't busy-retry on wait-for-command

### DIFF
--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -261,6 +261,7 @@ public class KafkaStreamsServerImpl extends LittleHorseImplBase {
     private Context.Key<RequestExecutionContext> contextKey = Context.key("executionContextKey");
     private final MetadataCache metadataCache;
     private final CoreStoreProvider coreStoreProvider;
+    private final ScheduledExecutorService networkThreadpool;
 
     private RequestExecutionContext requestContext() {
         return contextKey.get();
@@ -288,7 +289,7 @@ public class KafkaStreamsServerImpl extends LittleHorseImplBase {
             return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
         });
 
-        ScheduledExecutorService networkThreadpool = Executors.newScheduledThreadPool(config.getNumNetworkThreads());
+        this.networkThreadpool = Executors.newScheduledThreadPool(config.getNumNetworkThreads());
         coreStoreProvider = new CoreStoreProvider(this.coreStreams);
         this.internalComms = new BackendInternalComms(
                 config, coreStreams, timerStreams, networkThreadpool, metadataCache, contextKey, coreStoreProvider);
@@ -1036,7 +1037,11 @@ public class KafkaStreamsServerImpl extends LittleHorseImplBase {
                 internalComms,
                 command,
                 context,
-                Duration.ofMillis(config.getStreamsSessionTimeout()));
+                // Streams Session Timeout is how long it takes to notice that the server is down.
+                // Then we need the rebalance to occur, and the new server must process the command.
+                // So we give it a buffer of 10 additional seconds.
+                Duration.ofMillis(10_000 + config.getStreamsSessionTimeout()),
+                networkThreadpool);
 
         Callback callback = (meta, exn) -> this.productionCallback(meta, exn, commandObserver, command, context);
 

--- a/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
+++ b/server/src/main/java/io/littlehorse/server/KafkaStreamsServerImpl.java
@@ -235,8 +235,8 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -288,7 +288,7 @@ public class KafkaStreamsServerImpl extends LittleHorseImplBase {
             return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT;
         });
 
-        Executor networkThreadpool = Executors.newFixedThreadPool(config.getNumNetworkThreads());
+        ScheduledExecutorService networkThreadpool = Executors.newScheduledThreadPool(config.getNumNetworkThreads());
         coreStoreProvider = new CoreStoreProvider(this.coreStreams);
         this.internalComms = new BackendInternalComms(
                 config, coreStreams, timerStreams, networkThreadpool, metadataCache, contextKey, coreStoreProvider);

--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -80,6 +80,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiPredicate;
 import java.util.regex.Matcher;
@@ -130,7 +131,7 @@ public class BackendInternalComms implements Closeable {
             LHServerConfig config,
             KafkaStreams coreStreams,
             KafkaStreams timerStreams,
-            Executor networkThreadPool,
+            ScheduledExecutorService networkThreadPool,
             MetadataCache metadataCache,
             Context.Key<RequestExecutionContext> contextKey,
             CoreStoreProvider coreStoreProvider) {
@@ -163,7 +164,7 @@ public class BackendInternalComms implements Closeable {
 
         thisHost = new HostInfo(config.getInternalAdvertisedHost(), config.getInternalAdvertisedPort());
         this.producer = config.getProducer();
-        this.asyncWaiters = new AsyncWaiters();
+        this.asyncWaiters = new AsyncWaiters(networkThreadPool);
     }
 
     public void start() throws IOException {

--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -125,7 +125,6 @@ public class BackendInternalComms implements Closeable {
     private final Context.Key<RequestExecutionContext> contextKey;
     private final Pattern tenantScopedObjectIdExtractorPattern = Pattern.compile("[0-9]+/[0-9]+/");
     private Executor networkThreadPool;
-    private final MetadataCache metadataCache;
 
     public BackendInternalComms(
             LHServerConfig config,
@@ -139,7 +138,6 @@ public class BackendInternalComms implements Closeable {
         this.coreStreams = coreStreams;
         this.channels = new HashMap<>();
         this.contextKey = contextKey;
-        this.metadataCache = metadataCache;
         this.networkThreadPool = networkThreadPool;
         otherHosts = new ConcurrentHashMap<>();
 

--- a/server/src/test/java/io/littlehorse/server/streams/util/AsyncWaitersTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/util/AsyncWaitersTest.java
@@ -30,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class AsyncWaitersTest {
 
-    public AsyncWaiters asyncWaiters = new AsyncWaiters();
+    public AsyncWaiters asyncWaiters = new AsyncWaiters(mock());
     private final InternalWaitForWfEventRequest mockRequest = mock(Answers.RETURNS_DEEP_STUBS);
     private final RequestExecutionContext requestContext = mock(Answers.RETURNS_DEEP_STUBS);
     private final WorkflowEventModel mockEvent = mock(Answers.RETURNS_DEEP_STUBS);


### PR DESCRIPTION
- Uses network thread pool for internal GRPC clients to reduce number of total threads used by server
- Uses network thread pool to clean up old command waiters
- Fixes stack overflow error on the wait for command retry logic and avoids busy waiting by using network thread pool to schedule retries later.