### PR TITLE
chore(server): Upgrade kafka version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.10.1
 group=io.littlehorse
-kafkaVersion=3.7.0
+kafkaVersion=3.8.0
 lombokVersion=1.18.28
 grpcVersion=1.56.1
 junitVersion=5.9.2


### PR DESCRIPTION
Upgrade kafka versions. StateUpdater is now enabled by default in kafka 3.8.