### PR TITLE
fix(ci): Revert test workflow triggers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - "**"
-  pull_request:
-    branches: 
-      - "**"
 jobs:
   tests-sdk-java:
     if: ${{ !contains(github.event.head_commit.message, '[skip main]') }}


### PR DESCRIPTION
@mijailr brought up a good point about allowing outside collaborators to run workflows on pull requests, see the below 

- https://github.com/ossf/scorecard/issues/3827

Proper solution:
- https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks