### PR TITLE
docs: Add Algolia DocSearch to docs website

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -138,5 +138,14 @@ module.exports = {
         theme: lightCodeTheme,
         additionalLanguages: ["java", "go", "groovy", "protobuf"],
       },
+      algolia: {
+        appId: 'G6OXK45P4J', // The application ID provided by Algolia
+        apiKey: '038f9d47703c58c2c8abace8998eaed1', // Public API key: it is safe to commit it
+        indexName: 'littlehorse',
+        externalUrlRegex: "littlehorse\\.dev",
+        contextualSearch: true, // Enforces context of language and version on search results
+        searchPagePath: 'search', // path for search page that enabled by default
+        insights: false,
+      },
     }),
 };


### PR DESCRIPTION
This PR adds the Algolia DocSearch Bar to our Docusaurus Documentation deployed at [https://www.littlehorse.dev/](https://www.littlehorse.dev/).

Algolia Search for Docusaurus is a free service provided by Algolia that crawls our documentation once a week, updating its internal index and exposing it on a public search endpoint.

This PR contains a public API key provided by Algolia. Their documentation says it is okay to expose their public API key in our version control [link](https://docsearch.algolia.com/docs/DocSearch-program#can-i-share-the-apikey-in-my-repo) and that it is pre-configured with rate-limiting [link](https://www.algolia.com/doc/guides/security/api-keys/in-depth/api-key-restrictions/).

Here are additional resources to learn about Algolia DocSearch:
- [Docusaurus Integration](https://docusaurus.io/docs/search#using-algolia-docsearch)
- [Algolia DocSearch Program](https://docsearch.algolia.com/docs/DocSearch-program)