### PR TITLE
ci(tests): run tests on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,10 @@ name: tests
 run-name: Tests
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
-      - "**"
+      - master
 jobs:
   tests-sdk-java:
     if: ${{ !contains(github.event.head_commit.message, '[skip main]') }}


### PR DESCRIPTION
When an external contributor creates a pull request from a fork, it's not being triggered. This is intended to fix that.