### PR TITLE
Update `lhctl` install guide

### DIFF
--- a/lhctl/README.md
+++ b/lhctl/README.md
@@ -1,6 +1,19 @@
 # LittleHorse CLI
 
-To install `lhctl`, simply run:
+## Installing `lhctl`
+
+1. To install `lhctl` from the source code, first run the following commands within the `/lhctl/` directory:
+
+```bash
+go work init
+go work use ./../sdk-go
+go work use .
+```
+
+[!NOTE]
+This sets up a multi-module workspace in Go that links `sdk-go` to `lhctl`. This is necessary to use `lhctl`, as it depends on the `sdk-go` implementation of the LittleHorse client. Alternatively,  `lhctl` is **not** bundled alongside official releases of `sdk-go`.
+
+2. Run the following command within the `/lhctl/` directory to update your local installation of `lhctl` whenever you make changes.
 
 ```
 go install .

--- a/lhctl/README.md
+++ b/lhctl/README.md
@@ -10,8 +10,8 @@ go work use ./../sdk-go
 go work use .
 ```
 
-[!NOTE]
-This sets up a multi-module workspace in Go that links `sdk-go` to `lhctl`. This is necessary to use `lhctl`, as it depends on the `sdk-go` implementation of the LittleHorse client. Alternatively,  `lhctl` is **not** bundled alongside official releases of `sdk-go`.
+> [!NOTE]
+> This sets up a multi-module workspace in Go that links `sdk-go` to `lhctl`. This is necessary to use `lhctl`, as it depends on the `sdk-go` implementation of the LittleHorse client. Alternatively,  `lhctl` is **not** bundled alongside official releases of `sdk-go`.
 
 2. Run the following command within the `/lhctl/` directory to update your local installation of `lhctl` whenever you make changes.
 


### PR DESCRIPTION
Updates the README.md for installing `lhctl` from local source code to include new Go Workspace install instructions.