### PR TITLE
ci(lhctl): use golang 1.21.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.21.3"
 
       - name: Build
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
From golang `1.20` the `go.mod` version format had changed.