### PR TITLE
build(server): use tag version on server artifact

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -2,6 +2,11 @@ name: publish-docker
 run-name: Publish Docker Images
 on:
   workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: ''
 permissions:
   packages: write
   contents: read
@@ -11,11 +16,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: "corretto"
           java-version: 17
+
+      - name: Dump version
+        if: inputs.tag != ''
+        run: sed -i "s/version=.*/version=${{ inputs.tag }}/g" gradle.properties
 
       - name: Tests and Build
         run: ./gradlew server:test server:shadowJar
@@ -81,8 +91,6 @@ jobs:
 
   lhctl:
     runs-on: ubuntu-latest
-    needs:
-      - build-server
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,6 +101,9 @@ jobs:
           image-name: lhctl
           dockerfile: docker/lhctl/Dockerfile
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          build-args: |
+            VERSION=${{ inputs.tag || github.ref_name }}
+            COMMIT=${{ github.sha }}
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
 
   publish-docker:
     uses: ./.github/workflows/publish-docker.yml
+    needs:
+      - prepare
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
 
   sdk-java:
     runs-on: ubuntu-latest
@@ -73,7 +77,7 @@ jobs:
       - name: Dump version
         env:
           TAG: ${{ needs.prepare.outputs.tag }}
-        run: sed -i "s/version = '.*'/version = '${TAG}'/g" sdk-python/pyproject.toml
+        run: sed -i "s/version = \".*\"/version = \"${TAG}\"/g" sdk-python/pyproject.toml
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -167,6 +171,9 @@ jobs:
   create-release:
     needs:
       - lhctl
+      - sdk-java
+      - sdk-python
+      - sdk-js
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docker/lhctl/Dockerfile
+++ b/docker/lhctl/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.22-alpine
+FROM golang:1.22-alpine AS builder
+
+ARG VERSION=0.0.0-development
+ARG COMMIT=HEAD
 
 WORKDIR /lh
 COPY . .
@@ -8,8 +11,9 @@ WORKDIR /lh/lhctl
 RUN rm -f go.work
 
 RUN go work init && go work use ../sdk-go && go work use .
-RUN GOBIN=/usr/local/bin go install .
-WORKDIR /
-RUN rm -rf /lh
+RUN go build -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT}"
+
+FROM scratch
+COPY --from=builder /lh/lhctl/lhctl /usr/local/bin/lhctl
 
 ENTRYPOINT ["/usr/local/bin/lhctl"]

--- a/server/src/main/java/io/littlehorse/server/Version.java
+++ b/server/src/main/java/io/littlehorse/server/Version.java
@@ -11,12 +11,16 @@ public class Version {
 
     public static ServerVersionResponse getServerVersion() {
         if (matcher.matches()) {
-            return ServerVersionResponse.newBuilder()
+            ServerVersionResponse.Builder builder = ServerVersionResponse.newBuilder()
                     .setMajorVersion(Integer.parseInt(matcher.group("major")))
                     .setMinorVersion(Integer.parseInt(matcher.group("minor")))
-                    .setPatchVersion(Integer.parseInt(matcher.group("patch")))
-                    .setPreReleaseIdentifier(matcher.group("prerelease") != null ? matcher.group("prerelease") : "")
-                    .build();
+                    .setPatchVersion(Integer.parseInt(matcher.group("patch")));
+
+            if (matcher.group("prerelease") != null) {
+                builder.setPreReleaseIdentifier(matcher.group("prerelease"));
+            }
+
+            return builder.build();
         }
         return null;
     }

--- a/server/src/test/java/io/littlehorse/server/VersionTest.java
+++ b/server/src/test/java/io/littlehorse/server/VersionTest.java
@@ -8,14 +8,20 @@ public class VersionTest {
     @Test
     void testDevelopmentVersion() {
 
-        Assertions.assertThat(ServerVersion.VERSION).isEqualTo("0.0.0-development");
+        Assertions.assertThat(ServerVersion.VERSION).isNotNull();
 
-        Assertions.assertThat(Version.getServerVersion())
-                .isEqualTo(ServerVersionResponse.newBuilder()
-                        .setMajorVersion(0)
-                        .setMinorVersion(0)
-                        .setPatchVersion(0)
-                        .setPreReleaseIdentifier("development")
-                        .build());
+        ServerVersionResponse serverVersionResponse = Version.getServerVersion();
+
+        String version = String.format(
+                "%s.%s.%s",
+                serverVersionResponse.getMajorVersion(),
+                serverVersionResponse.getMinorVersion(),
+                serverVersionResponse.getPatchVersion());
+
+        Assertions.assertThat(
+                        serverVersionResponse.getPreReleaseIdentifier().isEmpty()
+                                ? version
+                                : String.format("%s-%s", version, serverVersionResponse.getPreReleaseIdentifier()))
+                .isEqualTo(ServerVersion.VERSION);
     }
 }


### PR DESCRIPTION
Fixes some issues with the advertised version for lh-server and lhctl docker image.

For `lhctl` now we pass two variables `VERSION` and `COMMIT` which are set as build args and in consequence the resulting `lhctl` binary will output the correct version when calling `lhctl version` from the docker image.

For `lh-server` the version class was adding the `PreReleaseIdentifier` as empty string, which caused lhctl to print an additional character `-`. Also after the version replacement occurs during a release, the test was expecting to have a static value `0.0.0-development` but during the production build that value would change. So I refactored the test to be flexible enough to validate the version to be published.