### PR TITLE
fix(server): Ignore predefined errors when validating specific failures

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/node/NodeModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/node/NodeModel.java
@@ -20,12 +20,14 @@ import io.littlehorse.common.model.getable.global.wfspec.thread.ThreadSpecModel;
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.Edge;
 import io.littlehorse.sdk.common.proto.FailureHandlerDef;
+import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.sdk.common.proto.Node;
 import io.littlehorse.sdk.common.proto.Node.NodeCase;
 import io.littlehorse.sdk.common.proto.NopNode;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import io.littlehorse.server.streams.topology.core.MetadataCommandExecution;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -223,9 +225,12 @@ public class NodeModel extends LHSerializable<Node> {
     }
 
     private void validateFailureHandlers() {
+        List<String> predefinedErrors =
+                Arrays.stream(LHErrorType.values()).map(LHErrorType::toString).toList();
         String invalidNames = failureHandlers.stream()
                 .map(FailureHandlerDefModel::getSpecificFailure)
                 .filter(Objects::nonNull)
+                .filter(failureName -> !predefinedErrors.contains(failureName))
                 .filter(Predicate.not(LHUtil::isValidLHName))
                 .collect(Collectors.joining(", "));
         if (!invalidNames.isEmpty()) {

--- a/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/node/NodeModelTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/node/NodeModelTest.java
@@ -6,6 +6,7 @@ import io.littlehorse.TestUtil;
 import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.metadatacommand.MetadataCommandModel;
 import io.littlehorse.common.model.metadatacommand.subcommand.PutTenantRequestModel;
+import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.server.TestCommandExecutionContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,8 @@ public class NodeModelTest {
     private final SubNode mockSubnode = mock();
     private final FailureHandlerDefModel exceptionHandlerDef = TestUtil.exceptionHandler("my-handler");
     private final FailureHandlerDefModel invalidExceptionHandlerDef = TestUtil.exceptionHandler("my.handler");
+    private final FailureHandlerDefModel technicalErrorHandlerDef =
+            TestUtil.exceptionHandler(LHErrorType.TIMEOUT.name());
     private final PutTenantRequestModel dummySubcommand = new PutTenantRequestModel("my-tenant");
     private final MetadataCommandModel dummyCommand = new MetadataCommandModel(dummySubcommand);
     private TestCommandExecutionContext commandContext =
@@ -33,5 +36,13 @@ public class NodeModelTest {
                 .isInstanceOf(LHApiException.class)
                 .hasMessage("INVALID_ARGUMENT: Invalid names for exception handlers: my.handler");
         verify(mockSubnode, never()).validate(Mockito.any());
+    }
+
+    @Test
+    public void shouldNotValidatePredefinedTechnicalErrors() {
+        doReturn(mockSubnode).when(node).getSubNode();
+        node.getFailureHandlers().add(technicalErrorHandlerDef);
+        node.validate(commandContext);
+        verify(mockSubnode, times(1)).validate(Mockito.any());
     }
 }


### PR DESCRIPTION
This PR solves a bug when clients try to handle technical errors in a wfspec:
`NodeOutput node = wf.execute("fail");

                wf.handleError( // Handle technical failure
                    node,
                    LHErrorType.TIMEOUT,
                    handler -> {
                        handler.execute("my-task");
                    }
                );`