### PR TITLE
fix(lhctl): Post events with empty payload

### DIFF
--- a/examples/interrupt-handler/README.md
+++ b/examples/interrupt-handler/README.md
@@ -25,7 +25,7 @@ lhctl run example-interrupt-handler
 lhctl get wfRun <wf run id>
 
 # Note that it is 'RUNNING'. Next, post an external event using the following:
-lhctl postEvent <wf run id> interruption-event NULL
+lhctl postEvent <wf run id> interruption-event
 
 # Then inspect the wfRun:
 # Note that the threadRuns number 1 is 'ERROR' with type 'INTERRUPT'

--- a/lhctl/internal/post_event.go
+++ b/lhctl/internal/post_event.go
@@ -31,24 +31,23 @@ lhctl postEvent <wfRunId> <externalEventName> NULL
 			log.Fatal("Required args: <wfRunId> <externalEventName> <varType> <payload> or  <wfRunId> <externalEventName> (to send a null payload)")
 		}
 
-		wfRunIdStr, eedName, varTypeStr := args[0], args[1], args[2]
-		varType, validVarType := lhproto.VariableType_value[varTypeStr]
+		wfRunIdStr, eedName := args[0], args[1]
 
 		wfRunId := littlehorse.StrToWfRunId(wfRunIdStr)
-
-		if !validVarType {
-			log.Fatal(
-				"Unrecognized varType. Valid options: INT, STR, BYTES, BOOL, JSON_OBJ, JSON_ARR, DOUBLE or NULL.",
-			)
-		}
-
-		varTypeEnum := lhproto.VariableType(varType)
 
 		content := &lhproto.VariableValue{}
 
 		if len(args) == 4 {
+			varTypeStr := args[2]
 			payloadStr := args[3]
 
+			varType, validVarType := lhproto.VariableType_value[varTypeStr]
+			if !validVarType {
+				log.Fatal(
+					"Unrecognized varType. Valid options: INT, STR, BYTES, BOOL, JSON_OBJ, JSON_ARR, DOUBLE or NULL.",
+				)
+			}
+			varTypeEnum := lhproto.VariableType(varType)
 			var err error
 			content, err = littlehorse.StrToVarVal(payloadStr, varTypeEnum)
 			if err != nil {

--- a/lhctl/internal/post_event.go
+++ b/lhctl/internal/post_event.go
@@ -23,12 +23,12 @@ currently do not carry Schema information (this will change in a future release)
 The payload is deserialized according to the type. JSON objects should be provided as
 a string; BYTES objects should be b64-encoded.
 
-It's also possible to pass a null input:
-lhctl postEvent <wfRunId> <externalEventName> NULL
+It's also possible to pass an empty input:
+lhctl postEvent <wfRunId> <externalEventName>
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {
-			log.Fatal("Required args: <wfRunId> <externalEventName> <varType> <payload> or  <wfRunId> <externalEventName> (to send a null payload)")
+			log.Fatal("Required args: <wfRunId> <externalEventName> <varType> <payload> or  <wfRunId> <externalEventName> (to send an empty payload)")
 		}
 
 		wfRunIdStr, eedName := args[0], args[1]
@@ -44,7 +44,7 @@ lhctl postEvent <wfRunId> <externalEventName> NULL
 			varType, validVarType := lhproto.VariableType_value[varTypeStr]
 			if !validVarType {
 				log.Fatal(
-					"Unrecognized varType. Valid options: INT, STR, BYTES, BOOL, JSON_OBJ, JSON_ARR, DOUBLE or NULL.",
+					"Unrecognized varType. Valid options: INT, STR, BYTES, BOOL, JSON_OBJ, JSON_ARR or DOUBLE.",
 				)
 			}
 			varTypeEnum := lhproto.VariableType(varType)


### PR DESCRIPTION
Null variable value is not longer supported by Littlehorse server.