### PR TITLE
docs(style): Add text decoration and new color to links

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -16,7 +16,15 @@
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-navbar-link-color: #392215;
+  --ifm-link-color: #a56441;
 }
+
+p a {
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+
 code {
   border: 0.15rem solid rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
- Added new color to links site wide.
- Added underline and bold weight to links in paragraph elements (in page bodies effectively).

# Before:
<img width="759" alt="image" src="https://github.com/user-attachments/assets/28f8bac5-1756-42d2-a911-38625d1a1e2a">

--------------------------

# After:
<img width="663" alt="image" src="https://github.com/user-attachments/assets/4492830a-e02e-4685-b4b0-6bf44045bfd8">
