### PR TITLE
fix(dashboard): better external event UX

### DIFF
--- a/dashboard/src/app/(authenticated)/externalEventDef/[name]/components/ExternalEventDef.tsx
+++ b/dashboard/src/app/(authenticated)/externalEventDef/[name]/components/ExternalEventDef.tsx
@@ -19,6 +19,7 @@ import { Details } from './Details'
 type Props = {
   spec: ExternalEventDefProto
 }
+
 export const ExternalEventDef: FC<Props> = ({ spec }) => {
   const [createdAfter, setCreatedAfter] = useState('')
   const [createdBefore, setCreatedBefore] = useState('')
@@ -27,7 +28,7 @@ export const ExternalEventDef: FC<Props> = ({ spec }) => {
   const { tenantId } = useWhoAmI()
 
   const { isPending, data, hasNextPage, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['taskRun', tenantId, 10, createdAfter, createdBefore, isClaimed],
+    queryKey: ['externalEvent', tenantId, createdAfter, limit, createdBefore, isClaimed],
     initialPageParam: undefined,
     getNextPageParam: (lastPage: PaginatedExternalEventList) => lastPage.bookmarkAsString,
     queryFn: async ({ pageParam }) => {

--- a/dashboard/src/app/(authenticated)/taskDef/[name]/components/TaskDef.tsx
+++ b/dashboard/src/app/(authenticated)/taskDef/[name]/components/TaskDef.tsx
@@ -26,7 +26,7 @@ export const TaskDef: FC<Props> = ({ spec }) => {
   const [limit, setLimit] = useState<number>(SEARCH_DEFAULT_LIMIT)
 
   const { isPending, data, hasNextPage, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['taskRun', selectedStatus, tenantId, 10, createdAfter, createdBefore],
+    queryKey: ['taskRun', selectedStatus, tenantId, limit, createdAfter, createdBefore],
     initialPageParam: undefined,
     getNextPageParam: (lastPage: PaginatedTaskRunList) => lastPage.bookmarkAsString,
     queryFn: async ({ pageParam }) => {

--- a/dashboard/src/app/utils/date.ts
+++ b/dashboard/src/app/utils/date.ts
@@ -14,3 +14,28 @@ export const utcToLocalDateTime = (utcISODateTime: string): string =>
   new Date(Date.parse(utcISODateTime)).toLocaleString(undefined, { hour12: false, timeZoneName: 'short' })
 
 export const localDateTimeToUTCIsoString = (localDateTime: string): string => new Date(localDateTime).toISOString()
+
+export const formatTime = (seconds: number): string => {
+  const minute = 60
+  const hour = 60 * minute
+  const day = 24 * hour
+  const year = 365 * day
+
+  const years = Math.floor(seconds / year)
+  seconds %= year
+  const days = Math.floor(seconds / day)
+  seconds %= day
+  const hours = Math.floor(seconds / hour)
+  seconds %= hour
+  const minutes = Math.floor(seconds / minute)
+  seconds %= minute
+
+  const parts: string[] = []
+  if (years > 0) parts.push(`${years}y`)
+  if (days > 0) parts.push(`${days}d`)
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0) parts.push(`${minutes}m`)
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`)
+
+  return parts.join(' ')
+}


### PR DESCRIPTION
- Timeouts are now shown
- Timeouts are formatted 165 seconds -> "2m 45s"
- `Inspect TaskRun` -> `Inspect ExternalEvent`
- `Inspect ExternalEvent` only shown once `ExternalEvent` has been called

# Timeouts:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/740506f4-883e-4925-8775-5d2f091b4770">
<img width="434" alt="image" src="https://github.com/user-attachments/assets/54031946-8d1a-450e-adcd-71c11d0feb95">