### PR TITLE
docs: Fix CSS by disabling advanced CSS minifier

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build website
         working-directory: ./docs
+        env: 
+          USE_SIMPLE_CSS_MINIFIER: true
         run: npm run build
 
       - name: Deploy to GitHub Pages

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -12,6 +12,10 @@
 
   --docsearch-muted-color: var(--ifm-font-color-base) !important;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --white-filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(336deg) brightness(110%) contrast(101%);
+  --brown-filter: invert(24%) sepia(12%) saturate(1484%) hue-rotate(334deg) brightness(100%) contrast(87%);
+  --black-filter:  brightness(0%);
 }
 
 [data-theme='light'] {
@@ -23,14 +27,16 @@
   --ifm-color-primary-lighter: #925939;
   --ifm-color-primary-lightest: #a56441;
 
-  --filter: invert(24%) sepia(12%) saturate(1484%) hue-rotate(334deg) brightness(30%) contrast(87%);
-
   code {
     border-color: rgba(0, 0, 0, 0.1);
   }
 
+  /* Navbar logo and home page feature graphics */
   .navbar__logo img {
-    filter: var(--filter);
+    filter: var(--brown-filter);
+  }
+  .feature-img {
+    filter: var(--black-filter);
   }
 }
 
@@ -46,8 +52,6 @@
   
   --docsearch-highlight-color: #7b7bc4 !important;
 
-  --filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(336deg) brightness(110%) contrast(101%);
-
   code {
     border-color: rgba(255, 255, 255, 0.1);
   }
@@ -55,6 +59,11 @@
   .hero {
     color: white;
     --ifm-hero-background-color: #5C4033 !important;
+  }
+
+  /* Navbar logo and home page feature graphics */
+  .navbar__logo img, .feature-img {
+    filter: var(--white-filter);
   }
 }
 
@@ -82,12 +91,6 @@ code {
   outline: var(--ifm-font-color-base) 0.2rem solid;
   outline-offset: -1px;
   border-radius: 1rem;
-}
-
-/* Switch color between light and dark modes */
-.feature-img,
-.navbar__logo img {
-  filter: var(--filter);
 }
 
 /* ------------------- NAVBAR ICONS ------------------- */


### PR DESCRIPTION
The Docusaurus build tool uses the "advanced cssnano preset" and several plugins that break our CSS file upon building the production version of our documentation.

This PR adds an environment variable setting to disable the advanced CSS minifier and use the default CSS minifier settings.

See this Docusaurus link for more info: https://docusaurus.io/docs/cli#docusaurus-build-sitedir

# Before:
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/93f821ba-bbfb-458e-88cd-a2644a602ed9">

# After:
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/1d61f7ea-3e70-4ce3-8204-10c33c00fb5f">
