### PR TITLE
perf(server): use executor for returning tasks to client

### DIFF
--- a/server/src/main/java/io/littlehorse/common/util/LHProducer.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHProducer.java
@@ -21,20 +21,11 @@ public class LHProducer implements Closeable {
     }
 
     public Future<RecordMetadata> send(String key, AbstractCommand<?> t, String topic, Callback cb, Header... headers) {
-        return sendRecord(new ProducerRecord<>(topic, null, key, new Bytes(t.toBytes()), List.of(headers)), cb);
+        return doSend(new ProducerRecord<>(topic, null, key, new Bytes(t.toBytes()), List.of(headers)), cb);
     }
 
-    public Future<RecordMetadata> send(String key, AbstractCommand<?> t, String topic) {
-        return this.send(key, t, topic, null);
-    }
-
-    public Future<RecordMetadata> sendRecord(ProducerRecord<String, Bytes> record, Callback cb) {
+    private Future<RecordMetadata> doSend(ProducerRecord<String, Bytes> record, Callback cb) {
         return (cb != null) ? prod.send(record, cb) : prod.send(record);
-    }
-
-    public Future<RecordMetadata> sendToPartition(String key, AbstractCommand<?> val, String topic, int partition) {
-        Bytes valBytes = val == null ? null : new Bytes(val.toBytes());
-        return sendRecord(new ProducerRecord<>(topic, partition, key, valBytes), null);
     }
 
     public void close() {

--- a/server/src/main/java/io/littlehorse/server/LHServer.java
+++ b/server/src/main/java/io/littlehorse/server/LHServer.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.common.header.Headers;
@@ -67,7 +68,10 @@ public class LHServer {
     private Context.Key<RequestExecutionContext> contextKey = Context.key("executionContextKey");
     private final MetadataCache metadataCache;
     private final CoreStoreProvider coreStoreProvider;
+
+    @Getter
     private final ScheduledExecutorService networkThreadpool;
+
     private final List<LHServerListener> listeners;
 
     private RequestExecutionContext requestContext() {
@@ -338,6 +342,6 @@ public class LHServer {
     }
 
     public void onEventThrown(WorkflowEventModel event) {
-        internalComms.onWorkflowEventThrown(event);
+        networkThreadpool.submit(() -> internalComms.onWorkflowEventThrown(event));
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/ProcessorExecutionContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/ProcessorExecutionContext.java
@@ -102,7 +102,8 @@ public class ProcessorExecutionContext implements ExecutionContext {
                 authContext,
                 processorContext,
                 globalTaskQueueManager,
-                coreStore);
+                coreStore,
+                server.getNetworkThreadpool());
         return currentTaskManager;
     }
 


### PR DESCRIPTION
This commit needs extensive testing. The StreamObserver is not considered threadSafe; I haven't spent enough time with this commit to know whether we are opening up the chance of multiple concurrent calls to a client StreamObserver.