### PR TITLE
feat(dotnet-sdk): read config variables from dictionary

### DIFF
--- a/sdk-dotnet/Examples/BasicExample/Program.cs
+++ b/sdk-dotnet/Examples/BasicExample/Program.cs
@@ -16,19 +16,41 @@ public class Program
                 config.SetMinimumLevel(LogLevel.Debug);
             })
             .BuildServiceProvider();
-    } 
-    
+    }
+
+    private static Dictionary<string, string> GetDictionaryFromMainArgs(string[] args)
+    {
+        var keyValueArgs = args.Select(item => item.Split('='))
+            .ToDictionary(item => item[0], item => item[1]);
+
+        return keyValueArgs;
+    }
+
+    private static LHConfig GetLHConfig(string[] args, ILoggerFactory loggerFactory)
+    {
+        var config = new LHConfig(loggerFactory);
+        
+        string filePath = Path.Combine(Directory.GetCurrentDirectory(), ".config/littlehorse.config");
+        if (File.Exists(filePath))
+            config = new LHConfig(filePath, loggerFactory);
+        
+        if (args.Length > 0)
+        {
+            var lhConfigs = GetDictionaryFromMainArgs(args);
+            config = new LHConfig(lhConfigs, loggerFactory);
+        }
+
+        return config;
+    }
+
     static void Main(string[] args)
     {
         SetupApplication();
         if (_serviceProvider != null)
         {
             var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
-            var config = new LHConfig(loggerFactory);
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), ".config/littlehorse.config");
-            if (File.Exists(filePath))
-                config = new LHConfig(filePath, loggerFactory);
-
+            var config = GetLHConfig(args, loggerFactory);
+            
             MyWorker executable = new MyWorker();
             var taskWorker = new LHTaskWorker<MyWorker>(executable, "greet-dotnet", config);
 

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/LHInputVariablesTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/LHInputVariablesTest.cs
@@ -198,34 +198,28 @@ namespace LittleHorse.Sdk.Tests.Internal
         [Fact]
         public void LHConfigVariables_WithInputArguments_ShouldReturnSetValues()
         {
-            string[] args = new string[4] 
+            var args = new Dictionary<string, string> 
                 { 
-                    "LHC_API_HOST=localhost", 
-                    "LHC_API_PORT=123", 
-                    "LHC_API_PROTOCOL=TLS", 
-                    "LHC_CA_CERT=ca_test.crt"
+                    { "LHC_API_HOST", "localhost" },
+                    { "LHC_API_PORT", "123" },
+                    { "LHC_API_PROTOCOL", "TLS" },
+                    { "LHC_CA_CERT", "ca_test.crt" }
                 };
 
             var inputVariables = new LHInputVariables(args);
             
-            var keyValueLHConfigs = args.Select(a => a.Split('='))
-                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
-            
-            Assert.Equal(keyValueLHConfigs["LHC_API_HOST"], inputVariables.LHC_API_HOST);
-            Assert.Equal(int.Parse(keyValueLHConfigs["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
-            Assert.Equal(keyValueLHConfigs["LHC_API_PROTOCOL"], inputVariables.LHC_API_PROTOCOL);
-            Assert.Equal(keyValueLHConfigs["LHC_CA_CERT"], inputVariables.LHC_CA_CERT);
+            Assert.Equal(args["LHC_API_HOST"], inputVariables.LHC_API_HOST);
+            Assert.Equal(int.Parse(args["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
+            Assert.Equal(args["LHC_API_PROTOCOL"], inputVariables.LHC_API_PROTOCOL);
+            Assert.Equal(args["LHC_CA_CERT"], inputVariables.LHC_CA_CERT);
         }
         
         [Fact]
-        public void LHConfigVariables_WithoutInputArguments_ShouldReturnDefaultOptions()
+        public void LHConfigVariables_WithoutInputArguments_ShouldReturnDefaultValues()
         {
-            string[] args = new string[] { };
+            var args = new Dictionary<string, string>();
 
             var inputVariables = new LHInputVariables(args);
-            
-            var keyValueLHConfigs = args.Select(a => a.Split('='))
-                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
             
             Assert.Equal(DefaultLHConfigVariables.LHC_API_HOST, inputVariables.LHC_API_HOST);
             Assert.Equal(DefaultLHConfigVariables.LHC_API_PORT, inputVariables.LHC_API_PORT);
@@ -236,21 +230,18 @@ namespace LittleHorse.Sdk.Tests.Internal
         }
         
         [Fact]
-        public void LHConfigVariables_WithSomeInputArguments_ShouldReturnSetOptions()
+        public void LHConfigVariables_WithSomeInputArguments_ShouldReturnSetValues()
         {
-            string[] args = new string[2] 
+            Dictionary<string, string> args = new Dictionary<string, string>()
             { 
-                "LHC_API_HOST=localhost", 
-                "LHC_API_PORT=123", 
+                { "LHC_API_HOST", "localhost" },
+                { "LHC_API_PORT", "123" }
             };
 
             var inputVariables = new LHInputVariables(args);
             
-            var keyValueLHConfigs = args.Select(a => a.Split('='))
-                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
-            
-            Assert.Equal(keyValueLHConfigs["LHC_API_HOST"], inputVariables.LHC_API_HOST);
-            Assert.Equal(int.Parse(keyValueLHConfigs["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
+            Assert.Equal(args["LHC_API_HOST"], inputVariables.LHC_API_HOST);
+            Assert.Equal(int.Parse(args["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
             Assert.Equal(DefaultLHConfigVariables.LHC_API_PROTOCOL, inputVariables.LHC_API_PROTOCOL);
             Assert.StartsWith(DefaultLHConfigVariables.LHC_CLIENT_ID, inputVariables.LHC_CLIENT_ID);
             Assert.Equal(DefaultLHConfigVariables.LHW_NUM_WORKER_THREADS, inputVariables.LHW_NUM_WORKER_THREADS);

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/LHInputVariablesTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/LHInputVariablesTest.cs
@@ -194,5 +194,67 @@ namespace LittleHorse.Sdk.Tests.Internal
             Assert.Equal(DefaultLHConfigVariables.LHW_NUM_WORKER_THREADS, inputVariables.LHW_NUM_WORKER_THREADS);
             Assert.Equal(DefaultLHConfigVariables.LHW_TASK_WORKER_VERSION, inputVariables.LHW_TASK_WORKER_VERSION);
         }
+
+        [Fact]
+        public void LHConfigVariables_WithInputArguments_ShouldReturnSetValues()
+        {
+            string[] args = new string[4] 
+                { 
+                    "LHC_API_HOST=localhost", 
+                    "LHC_API_PORT=123", 
+                    "LHC_API_PROTOCOL=TLS", 
+                    "LHC_CA_CERT=ca_test.crt"
+                };
+
+            var inputVariables = new LHInputVariables(args);
+            
+            var keyValueLHConfigs = args.Select(a => a.Split('='))
+                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
+            
+            Assert.Equal(keyValueLHConfigs["LHC_API_HOST"], inputVariables.LHC_API_HOST);
+            Assert.Equal(int.Parse(keyValueLHConfigs["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
+            Assert.Equal(keyValueLHConfigs["LHC_API_PROTOCOL"], inputVariables.LHC_API_PROTOCOL);
+            Assert.Equal(keyValueLHConfigs["LHC_CA_CERT"], inputVariables.LHC_CA_CERT);
+        }
+        
+        [Fact]
+        public void LHConfigVariables_WithoutInputArguments_ShouldReturnDefaultOptions()
+        {
+            string[] args = new string[] { };
+
+            var inputVariables = new LHInputVariables(args);
+            
+            var keyValueLHConfigs = args.Select(a => a.Split('='))
+                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
+            
+            Assert.Equal(DefaultLHConfigVariables.LHC_API_HOST, inputVariables.LHC_API_HOST);
+            Assert.Equal(DefaultLHConfigVariables.LHC_API_PORT, inputVariables.LHC_API_PORT);
+            Assert.Equal(DefaultLHConfigVariables.LHC_API_PROTOCOL, inputVariables.LHC_API_PROTOCOL);
+            Assert.StartsWith(DefaultLHConfigVariables.LHC_CLIENT_ID, inputVariables.LHC_CLIENT_ID);
+            Assert.Equal(DefaultLHConfigVariables.LHW_NUM_WORKER_THREADS, inputVariables.LHW_NUM_WORKER_THREADS);
+            Assert.Equal(DefaultLHConfigVariables.LHW_TASK_WORKER_VERSION, inputVariables.LHW_TASK_WORKER_VERSION);
+        }
+        
+        [Fact]
+        public void LHConfigVariables_WithSomeInputArguments_ShouldReturnSetOptions()
+        {
+            string[] args = new string[2] 
+            { 
+                "LHC_API_HOST=localhost", 
+                "LHC_API_PORT=123", 
+            };
+
+            var inputVariables = new LHInputVariables(args);
+            
+            var keyValueLHConfigs = args.Select(a => a.Split('='))
+                .ToDictionary(a => a[0], a => a.Length == 2 ? a[1] : null);
+            
+            Assert.Equal(keyValueLHConfigs["LHC_API_HOST"], inputVariables.LHC_API_HOST);
+            Assert.Equal(int.Parse(keyValueLHConfigs["LHC_API_PORT"]!), inputVariables.LHC_API_PORT);
+            Assert.Equal(DefaultLHConfigVariables.LHC_API_PROTOCOL, inputVariables.LHC_API_PROTOCOL);
+            Assert.StartsWith(DefaultLHConfigVariables.LHC_CLIENT_ID, inputVariables.LHC_CLIENT_ID);
+            Assert.Equal(DefaultLHConfigVariables.LHW_NUM_WORKER_THREADS, inputVariables.LHW_NUM_WORKER_THREADS);
+            Assert.Equal(DefaultLHConfigVariables.LHW_TASK_WORKER_VERSION, inputVariables.LHW_TASK_WORKER_VERSION);
+        }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk/LHConfig.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/LHConfig.cs
@@ -5,7 +5,6 @@ using LittleHorse.Common.Proto;
 using LittleHorse.Sdk.Internal;
 using LittleHorse.Sdk.Utils;
 using Microsoft.Extensions.Logging;
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Net.Security;
 using static LittleHorse.Common.Proto.LittleHorse;
@@ -36,6 +35,14 @@ namespace LittleHorse.Sdk {
             LHLoggerFactoryProvider.Initialize(loggerFactory);
             _logger = LHLoggerFactoryProvider.GetLogger<LHConfig>();
             _inputVariables = new LHInputVariables(configOptionsFilePath);
+            _createdChannels = new Dictionary<string, LittleHorseClient>();
+        }
+        
+        public LHConfig(Dictionary<string, string> configArgs, ILoggerFactory? loggerFactory = null)
+        {
+            LHLoggerFactoryProvider.Initialize(loggerFactory);
+            _logger = LHLoggerFactoryProvider.GetLogger<LHConfig>();
+            _inputVariables = new LHInputVariables(configArgs);
             _createdChannels = new Dictionary<string, LittleHorseClient>();
         }
 

--- a/sdk-dotnet/LittleHorse.Sdk/LHInputVariables.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/LHInputVariables.cs
@@ -110,5 +110,55 @@ namespace LittleHorse.Sdk
             if (!string.IsNullOrEmpty(taskWorkerVersion))
                 LHW_TASK_WORKER_VERSION = taskWorkerVersion;
         }
+
+        internal LHInputVariables(Dictionary<string, string> configArguments)
+        {
+            var host = GetValueIfKeyIsPresent(configArguments!, "LHC_API_HOST");
+            if (!string.IsNullOrEmpty(host))
+                LHC_API_HOST = host;
+            var port = GetValueIfKeyIsPresent(configArguments!, "LHC_API_PORT");
+            if (!string.IsNullOrEmpty(port))
+                LHC_API_PORT = IntegerConverter.FromString(port);
+            var apiProtocol = GetValueIfKeyIsPresent(configArguments!,  "LHC_API_PROTOCOL");
+            if (!string.IsNullOrEmpty(apiProtocol))
+                LHC_API_PROTOCOL = apiProtocol;
+            var clientId = GetValueIfKeyIsPresent(configArguments!, "LHC_CLIENT_ID");
+            if (!string.IsNullOrEmpty(clientId))
+                LHC_CLIENT_ID = clientId;
+            var caCert = GetValueIfKeyIsPresent(configArguments!, "LHC_CA_CERT");
+            if (!string.IsNullOrEmpty(caCert))
+                LHC_CA_CERT = caCert;
+            var clientCert = GetValueIfKeyIsPresent(configArguments!, "LHC_CLIENT_CERT");
+            if (!string.IsNullOrEmpty(clientCert))
+                LHC_CLIENT_CERT = clientCert;
+            var clientKey = GetValueIfKeyIsPresent(configArguments!, "LHC_CLIENT_KEY");
+            if (!string.IsNullOrEmpty(clientKey))
+                LHC_CLIENT_KEY = clientKey;
+            var oauthClientId = GetValueIfKeyIsPresent(configArguments!, "LHC_OAUTH_CLIENT_ID");
+            if (!string.IsNullOrEmpty(oauthClientId))
+                LHC_OAUTH_CLIENT_ID = oauthClientId;
+            var oauthClientSecret = GetValueIfKeyIsPresent(configArguments!, "LHC_OAUTH_CLIENT_SECRET");
+            if (!string.IsNullOrEmpty(oauthClientSecret))
+                LHC_OAUTH_CLIENT_SECRET = oauthClientSecret;
+            var oauthAccessTokenUrl = GetValueIfKeyIsPresent(
+                configArguments!, "LHC_OAUTH_ACCESS_TOKEN_URL");
+            if (!string.IsNullOrEmpty(oauthAccessTokenUrl))
+                LHC_OAUTH_ACCESS_TOKEN_URL = oauthAccessTokenUrl;
+            var numberWorkerThreads = GetValueIfKeyIsPresent(configArguments!, "LHW_NUM_WORKER_THREADS");
+            if (!string.IsNullOrEmpty(numberWorkerThreads))
+                LHW_NUM_WORKER_THREADS = IntegerConverter.FromString(numberWorkerThreads);
+            var taskWorkerVersion = GetValueIfKeyIsPresent(configArguments!, "LHW_TASK_WORKER_VERSION");
+            if (!string.IsNullOrEmpty(taskWorkerVersion))
+                LHW_TASK_WORKER_VERSION = taskWorkerVersion;
+        }
+
+        private string GetValueIfKeyIsPresent(Dictionary<string, string?> pairInFile, string keyName)
+        {
+            var tryGetValue = pairInFile.TryGetValue(keyName, out var value);
+            if (tryGetValue)
+                return value!;
+
+            return string.Empty;
+        }
     }
 }


### PR DESCRIPTION
- Add constructor to build LHConfig from a dictionary
- Add unit tests
- Change basic example