### PR TITLE
feat(server)!: changes variable access level api

### DIFF
--- a/sdk-go/littlehorse/wf_lib_internal.go
+++ b/sdk-go/littlehorse/wf_lib_internal.go
@@ -2,11 +2,12 @@ package littlehorse
 
 import (
 	"errors"
-	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 	"log"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 
 	"github.com/ztrue/tracerr"
 )
@@ -745,7 +746,8 @@ func (t *WorkflowThread) addVariable(
 	}
 
 	threadVarDef := &lhproto.ThreadVarDef{
-		VarDef: varDef,
+		VarDef:      varDef,
+		AccessLevel: lhproto.WfRunVariableAccessLevel_PRIVATE_VAR,
 	}
 
 	t.spec.VariableDefs = append(t.spec.VariableDefs, threadVarDef)

--- a/sdk-go/littlehorse/wf_lib_internal_test.go
+++ b/sdk-go/littlehorse/wf_lib_internal_test.go
@@ -1,9 +1,10 @@
 package littlehorse_test
 
 import (
+	"testing"
+
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/littlehorse"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -538,10 +539,10 @@ func TestJsonPath(t *testing.T) {
 
 func TestVariableAccessLevel(t *testing.T) {
 	wf := littlehorse.NewWorkflow(func(t *littlehorse.WorkflowThread) {
-		inheritedVar := t.AddVariable("my-var", lhproto.VariableType_BOOL)
-		inheritedVar.WithAccessLevel(lhproto.WfRunVariableAccessLevel_PRIVATE_VAR)
+		publicVar := t.AddVariable("my-var", lhproto.VariableType_BOOL)
+		publicVar.AsPublic()
 
-		// Test that default is PUBLIC_VAR
+		// Test that default is PRIVATE_VAR
 		t.AddVariable("default-access", lhproto.VariableType_INT)
 
 		t.Execute("some-task")
@@ -550,11 +551,11 @@ func TestVariableAccessLevel(t *testing.T) {
 	putWf, _ := wf.Compile()
 	entrypoint := putWf.ThreadSpecs[putWf.EntrypointThreadName]
 	varDef := entrypoint.VariableDefs[0]
-	assert.Equal(t, varDef.AccessLevel, lhproto.WfRunVariableAccessLevel_PRIVATE_VAR)
+	assert.Equal(t, varDef.AccessLevel, lhproto.WfRunVariableAccessLevel_PUBLIC_VAR)
 	assert.Equal(t, varDef.VarDef.Name, "my-var")
 
 	varDef = entrypoint.VariableDefs[1]
-	assert.Equal(t, varDef.AccessLevel, lhproto.WfRunVariableAccessLevel_PUBLIC_VAR)
+	assert.Equal(t, varDef.AccessLevel, lhproto.WfRunVariableAccessLevel_PRIVATE_VAR)
 	assert.Equal(t, varDef.VarDef.Name, "default-access")
 }
 

--- a/sdk-go/littlehorse/wf_lib_public.go
+++ b/sdk-go/littlehorse/wf_lib_public.go
@@ -110,6 +110,14 @@ func (w *WfRunVariable) WithAccessLevel(accessLevel lhproto.WfRunVariableAccessL
 	return w.withAccessLevel(accessLevel)
 }
 
+func (w *WfRunVariable) AsPublic() WfRunVariable {
+	return w.withAccessLevel(lhproto.WfRunVariableAccessLevel_PUBLIC_VAR)
+}
+
+func (w *WfRunVariable) AsInherited() WfRunVariable {
+	return w.withAccessLevel(lhproto.WfRunVariableAccessLevel_INHERITED_VAR)
+}
+
 func (w *WfRunVariable) Searchable() *WfRunVariable {
 	return w.searchableImpl()
 }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WfRunVariable.java
@@ -27,13 +27,35 @@ public interface WfRunVariable extends Serializable {
     WfRunVariable required();
 
     /**
-     * Marks the Variable as "Searchable", which:
-     * - Creates an Index on the Variable in the LH Data Store
-     * - Due to the fact that the Variable is now Searchable, all future WfSpec
-     *   versions must use the same Type for this Variable.
+     * Marks the Variable as "Searchable", which creates an Index on the Variable
+     * in the LH Data Store.
      * @return same {@link WfRunVariable} instance
      */
     WfRunVariable searchable();
+
+    /**
+     * Marks the Variable as a `PUBLIC_VAR`, which does three things:
+     * 1. Considers this variable in determining whether a new version of this WfSpec
+     *    should be a major version or minor revision.
+     * 2. Freezes the type of this variable so that you cannot create future WfSpec
+     *    versions with a variable of the same name and different type.
+     * 3. Allows defining child WfSpec's that use this variable.
+     *
+     * This is an advanced feature that you should use in any of the following cases:
+     * - You are treating a WfSpec as a data model and a WfRun as an instance of data.
+     * - You need child workflows to access this variable.
+     * @return same {@link WfRunVariable} instance
+     */
+    WfRunVariable asPublic();
+
+    /**
+     * Marks the Variable as a `INHERITED_VAR`, which means that it comes from the
+     * parent `WfRun`. This means that:
+     * - There must be a parent WfSpec reference.
+     * - The parent must have a PUBLIC_VAR variable of the same name and type.
+     * @return same {@link WfRunVariable} instance
+     */
+    WfRunVariable asInherited();
 
     /**
      * Marks the JSON_OBJ or JSON_ARR Variable as "Searchable", and creates an

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImpl.java
@@ -33,8 +33,8 @@ class WfRunVariableImpl implements WfRunVariable {
         this.name = name;
         this.typeOrDefaultVal = typeOrDefaultVal;
 
-        // This is the default zero value.
-        this.accessLevel = WfRunVariableAccessLevel.PUBLIC_VAR;
+        // As per GH Issue #582, the default is now PRIVATE_VAR.
+        this.accessLevel = WfRunVariableAccessLevel.PRIVATE_VAR;
         initializeType();
     }
 
@@ -121,5 +121,15 @@ class WfRunVariableImpl implements WfRunVariable {
                 .addAllJsonIndexes(jsonIndexes)
                 .setAccessLevel(accessLevel)
                 .build();
+    }
+
+    @Override
+    public WfRunVariableImpl asPublic() {
+        return this.withAccessLevel(WfRunVariableAccessLevel.PUBLIC_VAR);
+    }
+
+    @Override
+    public WfRunVariable asInherited() {
+        return this.withAccessLevel(WfRunVariableAccessLevel.INHERITED_VAR);
     }
 }

--- a/sdk-python/littlehorse/model/__init__.py
+++ b/sdk-python/littlehorse/model/__init__.py
@@ -5,8 +5,8 @@ from .external_event_pb2 import *
 from .node_run_pb2 import *
 from .object_id_pb2 import *
 from .scheduled_wf_run_pb2 import *
-from .service_pb2 import *
 from .service_pb2_grpc import *
+from .service_pb2 import *
 from .task_def_pb2 import *
 from .task_run_pb2 import *
 from .user_tasks_pb2 import *

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -56,6 +56,7 @@ from littlehorse.model import (
     WfRunVariableAccessLevel,
     WorkflowRetentionPolicy,
 )
+from littlehorse.model.wf_spec_pb2 import PRIVATE_VAR
 from littlehorse.utils import negate_comparator, to_variable_value
 from littlehorse.worker import _create_task_def
 
@@ -363,6 +364,28 @@ class WfRunVariable:
         out = WfRunVariable(self.name, self.type, self.default_value)
         out.json_path = json_path
         return out
+
+    def as_public(self) -> "WfRunVariable":
+        """Sets the access level to PUBLIC_VAR, which has three implications:
+        - Future versions of this WfSpec cannot define a variable with the
+          same name and a different type.
+        - Child workflows can access this variable.
+        - This variable is now considered in determining whether a new
+          version of the WfSpec is a majorVersion or revision.
+        """
+        self._access_level = WfRunVariableAccessLevel.PUBLIC_VAR
+        return self
+
+    def as_inherited(self) -> "WfRunVariable":
+        """Sets the access level to INHERITED_VAR, which has three implications:
+        - Future versions of this WfSpec cannot define a variable with the
+          same name and a different type.
+        - Child workflows can access this variable.
+        - This variable is now considered in determining whether a new
+          version of the WfSpec is a majorVersion or revision.
+        """
+        self._access_level = WfRunVariableAccessLevel.INHERITED_VAR
+        return self
 
     def with_access_level(
         self, access_level: WfRunVariableAccessLevel
@@ -1474,7 +1497,7 @@ class WorkflowThread:
         self,
         variable_name: str,
         variable_type: VariableType,
-        access_level: Optional[Union[WfRunVariableAccessLevel, str]] = None,
+        access_level: Optional[Union[WfRunVariableAccessLevel, str]] = PRIVATE_VAR,
         default_value: Any = None,
     ) -> WfRunVariable:
         """Defines a Variable in the ThreadSpec and returns a handle to it.

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -199,6 +199,7 @@ class TestThreadBuilder(unittest.TestCase):
                 variable_defs=[
                     ThreadVarDef(
                         var_def=VariableDef(name="input-name", type=VariableType.STR),
+                        access_level=WfRunVariableAccessLevel.PRIVATE_VAR,
                     ),
                 ],
                 nodes={
@@ -884,6 +885,7 @@ class TestThreadBuilder(unittest.TestCase):
                 variable_defs=[
                     ThreadVarDef(
                         var_def=VariableDef(name="input-name", type=VariableType.STR),
+                        access_level=WfRunVariableAccessLevel.PRIVATE_VAR,
                     )
                 ],
                 nodes={
@@ -1046,6 +1048,7 @@ class TestThreadBuilder(unittest.TestCase):
                 variable_defs=[
                     ThreadVarDef(
                         var_def=VariableDef(name="value", type=VariableType.INT),
+                        access_level=WfRunVariableAccessLevel.PRIVATE_VAR,
                     ),
                 ],
                 nodes={
@@ -1609,7 +1612,8 @@ class TestWorkflow(unittest.TestCase):
                             ThreadVarDef(
                                 var_def=VariableDef(
                                     name="input-name", type=VariableType.STR
-                                )
+                                ),
+                                access_level=WfRunVariableAccessLevel.PRIVATE_VAR,
                             ),
                         ],
                         nodes={
@@ -1642,7 +1646,8 @@ class TestWorkflow(unittest.TestCase):
                             ThreadVarDef(
                                 var_def=VariableDef(
                                     name="input-name", type=VariableType.STR
-                                )
+                                ),
+                                access_level=WfRunVariableAccessLevel.PRIVATE_VAR,
                             ),
                         ],
                         nodes={

--- a/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/TriggeredTaskRun.java
+++ b/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/TriggeredTaskRun.java
@@ -74,19 +74,19 @@ public class TriggeredTaskRun extends CoreSubCommand<TriggeredTaskRunPb> {
     public Empty process(ProcessorExecutionContext executionContext, LHServerConfig config) {
         WfRunIdModel wfRunId = source.getWfRunId();
 
-        log.info("Might schedule a one-off task for wfRun {} due to UserTask", wfRunId);
+        log.trace("Might schedule a one-off task for wfRun {} due to UserTask", wfRunId);
         WfRunModel wfRunModel = executionContext.getableManager().get(wfRunId);
         if (wfRunModel == null) {
-            log.info("WfRun no longer exists! Skipping the scheduled action trigger");
+            log.trace("WfRun no longer exists! Skipping the scheduled action trigger");
             return null;
         }
 
         // Now verify that the thing hasn't yet been completed.
         ThreadRunModel thread = wfRunModel.getThreadRun(source.getThreadRunNumber());
 
-        // Impossible for thread to be null, but check anyways
+        // This can happen in the case of ThreadRetentionPolicy being set.
         if (thread == null) {
-            log.warn("Triggered scheduled task refers to missing thread!");
+            log.trace("Triggered scheduled task refers to missing thread!");
             return null;
         }
 
@@ -96,12 +96,12 @@ public class TriggeredTaskRun extends CoreSubCommand<TriggeredTaskRunPb> {
         UserTaskRunModel userTaskRun = executionContext.getableManager().get(userTaskRunId);
 
         if (userTaskNR.getStatus() != LHStatus.RUNNING) {
-            log.info("NodeRun is not RUNNING anymore, so can't take action!");
+            log.trace("NodeRun is not RUNNING anymore, so can't take action!");
             return null;
         }
 
         // At this point, need to update the events.
-        log.info("Scheduling a one-off task for wfRun {} due to UserTask", wfRunId);
+        log.trace("Scheduling a one-off task for wfRun {} due to UserTask", wfRunId);
 
         try {
             List<VarNameAndValModel> inputVars = taskToSchedule.assignInputVars(thread, executionContext);

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/thread/ThreadSpecModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/thread/ThreadSpecModel.java
@@ -21,6 +21,7 @@ import io.littlehorse.sdk.common.proto.WfRunVariableAccessLevel;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import io.littlehorse.server.streams.topology.core.MetadataCommandExecution;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -126,6 +127,15 @@ public class ThreadSpecModel extends LHSerializable<ThreadSpec> {
         }
 
         return out;
+    }
+
+    /**
+     * Returns all ThreadVarDef's that are of type `PUBLIC_VAR`.
+     */
+    public Collection<ThreadVarDefModel> getPublicVarDefs() {
+        return getVariableDefs().stream()
+                .filter(varDef -> varDef.getAccessLevel() == WfRunVariableAccessLevel.PUBLIC_VAR)
+                .toList();
     }
 
     /*

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/thread/ThreadVarDefModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/thread/ThreadVarDefModel.java
@@ -10,9 +10,11 @@ import io.littlehorse.sdk.common.proto.WfRunVariableAccessLevel;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode(callSuper = false)
 public class ThreadVarDefModel extends LHSerializable<ThreadVarDef> {
 
     private VariableDefModel varDef;

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/JsonIndexModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/JsonIndexModel.java
@@ -5,14 +5,15 @@ import io.littlehorse.common.LHSerializable;
 import io.littlehorse.sdk.common.proto.JsonIndex;
 import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class JsonIndexModel extends LHSerializable<JsonIndex> {
 
     private String fieldPath;
@@ -35,17 +36,5 @@ public class JsonIndexModel extends LHSerializable<JsonIndex> {
         JsonIndex p = (JsonIndex) proto;
         fieldPath = p.getFieldPath();
         fieldType = p.getFieldType();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == null) return false;
-
-        if (!(other instanceof JsonIndexModel)) {
-            return false;
-        }
-
-        JsonIndexModel o = (JsonIndexModel) other;
-        return Objects.equals(fieldPath, o.getFieldPath()) && Objects.equals(fieldType, o.getFieldType());
     }
 }

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableDefModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableDefModel.java
@@ -9,11 +9,13 @@ import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.sdk.common.proto.VariableDef;
 import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@EqualsAndHashCode(callSuper = false)
 public class VariableDefModel extends LHSerializable<VariableDef> {
 
     private VariableType type;

--- a/server/src/test/java/e2e/WfSpecLifecycleTest.java
+++ b/server/src/test/java/e2e/WfSpecLifecycleTest.java
@@ -71,7 +71,7 @@ public class WfSpecLifecycleTest {
 
             Workflow updatedWorkflow = Workflow.newWorkflow("sample", wf -> {
                 wf.addVariable("variable", VariableType.BOOL).required();
-                wf.addVariable("searchable", VariableType.BOOL).searchable();
+                wf.addVariable("second-required", VariableType.BOOL).required();
             });
 
             WfSpec updatedSpec = client.putWfSpec(updatedWorkflow.compileWorkflow());
@@ -180,7 +180,7 @@ public class WfSpecLifecycleTest {
 
             Workflow updatedWorkflow = Workflow.newWorkflow("sample", wf -> {
                         wf.addVariable("variable", VariableType.BOOL).required();
-                        wf.addVariable("searchable", VariableType.BOOL).searchable();
+                        wf.addVariable("searchable", VariableType.BOOL).required();
                     })
                     .withUpdateType(AllowedUpdateType.MINOR_REVISION_UPDATES);
 

--- a/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/WfSpecModelTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/WfSpecModelTest.java
@@ -110,7 +110,7 @@ public class WfSpecModelTest {
     }
 
     @Test
-    public void shouldIncreaseTheMajorVersionWhenAInheritedVariableChangesItsAccessLevelToPrivate() {
+    public void shouldNotIncreaseTheMajorVersionWhenAInheritedVariableChangesItsAccessLevelToPrivate() {
         WfSpecModel oldVersion = TestUtil.wfSpec("my-parent-wf");
         ThreadVarDefModel inheritedVar =
                 new ThreadVarDefModel(variableDef, false, false, WfRunVariableAccessLevel.INHERITED_VAR);
@@ -127,11 +127,12 @@ public class WfSpecModelTest {
         wfSpec.setThreadSpecs(Map.of(wfSpec.getEntrypointThreadName(), entrypointThread));
         Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(0);
         wfSpec.validateAndMaybeBumpVersion(Optional.of(oldVersion), mockContext);
-        Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(1);
+        Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(0);
+        Assertions.assertThat(wfSpec.getId().getRevision()).isEqualTo(1);
     }
 
     @ParameterizedTest
-    @MethodSource("provideNonBreakingChangeArguments")
+    @MethodSource("provideBreakingChangeArguments")
     public void shouldNotIncreaseTheMajorVersionWhenVariablesAreStillAccessibleFromChildWorkflows(
             WfRunVariableAccessLevel from, WfRunVariableAccessLevel to) {
         WfSpecModel oldVersion = TestUtil.wfSpec("my-parent-wf");
@@ -148,19 +149,16 @@ public class WfSpecModelTest {
         wfSpec.setThreadSpecs(Map.of(wfSpec.getEntrypointThreadName(), entrypointThread));
         Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(0);
         wfSpec.validateAndMaybeBumpVersion(Optional.of(oldVersion), mockContext);
-        Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(0);
+        Assertions.assertThat(wfSpec.getId().getMajorVersion()).isEqualTo(1);
     }
 
     /*
     Access level combinations when the major version shouldn't increase
      */
-    private static Stream<Arguments> provideNonBreakingChangeArguments() {
+    private static Stream<Arguments> provideBreakingChangeArguments() {
         return Stream.of(
                 Arguments.of(WfRunVariableAccessLevel.PUBLIC_VAR, WfRunVariableAccessLevel.INHERITED_VAR),
-                Arguments.of(WfRunVariableAccessLevel.PUBLIC_VAR, WfRunVariableAccessLevel.PUBLIC_VAR),
                 Arguments.of(WfRunVariableAccessLevel.PRIVATE_VAR, WfRunVariableAccessLevel.PUBLIC_VAR),
-                Arguments.of(WfRunVariableAccessLevel.PRIVATE_VAR, WfRunVariableAccessLevel.PRIVATE_VAR),
-                Arguments.of(WfRunVariableAccessLevel.INHERITED_VAR, WfRunVariableAccessLevel.PUBLIC_VAR),
-                Arguments.of(WfRunVariableAccessLevel.INHERITED_VAR, WfRunVariableAccessLevel.INHERITED_VAR));
+                Arguments.of(WfRunVariableAccessLevel.INHERITED_VAR, WfRunVariableAccessLevel.PUBLIC_VAR));
     }
 }


### PR DESCRIPTION
- Fixes ticket #582
- Default access level is now PRIVATE
- Only PUBLIC_VAR and required input variables are considered in WfSpec versioning
- Only PUBLIC_VAR can be frozen