### PR TITLE
feat(server): use kip-899 to rebootstrap clients

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -659,6 +660,7 @@ public class LHServerConfig extends ConfigBase {
     public Properties getKafkaProducerConfig(String component) {
         Properties conf = new Properties();
         conf.put("client.id", this.getClientId(component));
+        conf.put(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG, "rebootstrap");
         conf.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
         conf.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         conf.put(
@@ -872,6 +874,17 @@ public class LHServerConfig extends ConfigBase {
 
     private Properties getBaseStreamsConfig() {
         Properties props = new Properties();
+
+        props.put(StreamsConfig.producerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
+        props.put(StreamsConfig.consumerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
+        props.put(
+                StreamsConfig.restoreConsumerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG),
+                "rebootstrap");
+        props.put(
+                StreamsConfig.globalConsumerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG),
+                "rebootstrap");
+        props.put(
+                StreamsConfig.adminClientPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
 
         if (getOrSetDefault(X_LEAVE_GROUP_ON_SHUTDOWN_KEY, "false").equals("true")) {
             log.warn("Using experimental internal config to leave group on shutdonw!");


### PR DESCRIPTION
In testing, I observed that when moving from a 3-node Kafka cluster with mixed brokers and controllers to a Kafka cluster with separate brokers and controllers, all of the Kafka clients got stuck and continued trying to connect to the controllers which no longer had the broker role.

It turns out that KIP-899 indirectly solves this problem by allowing clients to re-bootstrap and discover which servers are the brokers now. When tested with my fix for KAFKA-17455, we are successfully able to continue processing workflows without a crash / TaskCorruptedException when migrating the Kafka Cluster from mixed mode to separate mode.