### PR TITLE
fix(dashboard): Move useEffect so that it is not called conditionally

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10815,11 +10815,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-import": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.0.0-canary-7118f5dd7-20230705",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",

--- a/dashboard/src/app/(authenticated)/components/tables/WfSpecTable.tsx
+++ b/dashboard/src/app/(authenticated)/components/tables/WfSpecTable.tsx
@@ -11,15 +11,15 @@ export const WfSpecTable: FC<SearchResultProps> = ({ pages = [] }) => {
   const [wfSpecs, setWfSpecs] = useState<WfSpecData[]>([])
   const { tenantId } = useWhoAmI()
 
-  if (pages.length === 0) {
-    return <div className="flex min-h-[360px] items-center justify-center text-center italic">No WfSpecs</div>
-  }
-
   useEffect(() => {
     if (!tenantId) return
     const wfSpecNames = pages.flatMap(page => page.results).map(wfSpec => wfSpec.name)
     getLatestWfSpecs(tenantId, wfSpecNames).then(setWfSpecs)
   }, [pages, tenantId])
+
+  if (pages.length === 0) {
+    return <div className="flex min-h-[360px] items-center justify-center text-center italic">No WfSpecs</div>
+  }
 
   return (
     <div className="py-4">


### PR DESCRIPTION
Fixes error on failed run of dashboard job, which says:

```
./src/app/(authenticated)/components/tables/WfSpecTable.tsx
18:3  Error: React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?  react-hooks/rules-of-hooks
```

Job Run Link: https://github.com/littlehorse-enterprises/littlehorse/actions/runs/11967285971/job/33391162714