### PR TITLE
fix(server): Support blank `SearchPrincipalRequest`

### DIFF
--- a/lhctl/internal/principal.go
+++ b/lhctl/internal/principal.go
@@ -200,7 +200,6 @@ func init() {
 	searchPrincipalCmd.Flags().Bool("isAdmin", false, "List only Principals that are admins")
 	searchPrincipalCmd.Flags().Int("earliestMinutesAgo", -1, "Search only for Principals that were created no more than this number of minutes ago")
 	searchPrincipalCmd.Flags().Int("latestMinutesAgo", -1, "Search only for Principals that were created at least this number of minutes ago")
-	// searchPrincipalCmd.MarkFlagsOneRequired("tenantId", "isAdmin")
 
 	deployCmd.AddCommand(deployPrincipalCmd)
 	deleteCmd.AddCommand(deletePrincipalCmd)

--- a/lhctl/internal/principal.go
+++ b/lhctl/internal/principal.go
@@ -1,11 +1,12 @@
 package internal
 
 import (
-	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
-	"github.com/littlehorse-enterprises/littlehorse/sdk-go/littlehorse"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/littlehorse"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -199,7 +200,7 @@ func init() {
 	searchPrincipalCmd.Flags().Bool("isAdmin", false, "List only Principals that are admins")
 	searchPrincipalCmd.Flags().Int("earliestMinutesAgo", -1, "Search only for Principals that were created no more than this number of minutes ago")
 	searchPrincipalCmd.Flags().Int("latestMinutesAgo", -1, "Search only for Principals that were created at least this number of minutes ago")
-	searchPrincipalCmd.MarkFlagsOneRequired("tenantId", "isAdmin")
+	// searchPrincipalCmd.MarkFlagsOneRequired("tenantId", "isAdmin")
 
 	deployCmd.AddCommand(deployPrincipalCmd)
 	deleteCmd.AddCommand(deletePrincipalCmd)

--- a/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
@@ -75,6 +75,8 @@ public class SearchPrincipalRequestModel
             case TENANTID:
                 builder.setTenantId(tenantId);
                 break;
+            default:
+                break;
         }
 
         return builder;
@@ -105,6 +107,8 @@ public class SearchPrincipalRequestModel
                 break;
             case TENANTID:
                 tenantId = p.getTenantId();
+                break;
+            default:
                 break;
         }
     }

--- a/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
@@ -2,7 +2,6 @@ package io.littlehorse.server.streams.lhinternalscan.publicrequests;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import io.grpc.Status;
 import io.littlehorse.common.LHStore;
 import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.getable.objectId.PrincipalIdModel;

--- a/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
+++ b/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchPrincipalRequestModel.java
@@ -76,8 +76,6 @@ public class SearchPrincipalRequestModel
             case TENANTID:
                 builder.setTenantId(tenantId);
                 break;
-            case PRINCIPALCRITERIA_NOT_SET:
-                throw new LHApiException(Status.FAILED_PRECONDITION, "Principal query criteria is not valid.");
         }
 
         return builder;
@@ -109,8 +107,6 @@ public class SearchPrincipalRequestModel
             case TENANTID:
                 tenantId = p.getTenantId();
                 break;
-            case PRINCIPALCRITERIA_NOT_SET:
-                throw new LHSerdeError("Principal query criteria is not valid.");
         }
     }
 


### PR DESCRIPTION
Removes requirement for one of `principal_criteria` field to be submitted with each `SearchPrincipalRequest` from server and lhctl.

Resolves #1152.