### PR TITLE
fix(dotnet-sdk): refactor task signature to not build schema output with no return type

### DIFF
--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHMappingHelperTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHMappingHelperTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using LittleHorse.Common.Proto;
 using LittleHorse.Sdk.Helper;
 using Google.Protobuf.WellKnownTypes;
-using LittleHorse.Sdk.Exceptions;
 using LittleHorse.Sdk.Tests;
 using Xunit;
 using Type = System.Type;
@@ -71,16 +70,6 @@ public class LHMappingHelperTest
     }
     
     [Fact]
-    public void LHHelper_WithSystemVoidVariableType_ShouldReturnLHVariableJsonObjType()
-    {
-        var type = typeof(void);
-        
-        var result = LHMappingHelper.MapDotNetTypeToLHVariableType(type);
-        
-        Assert.True(result == VariableType.JsonObj);
-    }
-    
-    [Fact]
     public void LHHelper_WithSystemArrayObjectVariableType_ShouldReturnLHVariableJsonArrType()
     {
         var test_allowed_types = new List<Type>() { typeof(List<object>), typeof(List<string>), typeof(List<int>)};
@@ -94,15 +83,15 @@ public class LHMappingHelperTest
     }
     
     [Fact]
-    public void LHHelper_WithoutSystemVariableType_ShouldThrowException()
+    public void LHHelper_WithNotAllowedSystemVariableTypes_ShouldReturnLHJsonObj()
     {
-        var test_not_allowed_types = new List<Type>() { typeof(decimal), typeof(char) };
+        var test_not_allowed_types = new List<Type>() { typeof(decimal), typeof(char), typeof(void) };
         
         foreach (var type in test_not_allowed_types)
         {
-            var exception = Assert.Throws<Exception>(() => LHMappingHelper.MapDotNetTypeToLHVariableType(type));
+            var result = LHMappingHelper.MapDotNetTypeToLHVariableType(type);
             
-            Assert.Equal($"Unaccepted variable type.", exception.Message);
+            Assert.Equal(VariableType.JsonObj, result);
         }
     }
 

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/LHTaskSignatureTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/LHTaskSignatureTest.cs
@@ -9,6 +9,7 @@ using Xunit;
 public class LHTaskSignatureTest
 {
     const string TASK_DEF_NAME_ADD = "add-task-worker";
+    const string TASK_DEF_NAME_INFORM = "inform-task-worker";
     const string TASK_DEF_NAME_UPDATE = "update-task-worker";
     const string TASK_DEF_NAME_DELETE = "delete-task-worker";
     const string TASK_DEF_NAME_GET = "get-task-worker";
@@ -60,6 +61,32 @@ public class LHTaskSignatureTest
         Assert.Equal(expectedOutput.ValueDef.Name, taskSignature.TaskDefOutputSchema!.ValueDef.Name);
         Assert.Equal(expectedOutput.ValueDef.Type, taskSignature.TaskDefOutputSchema.ValueDef.Type);
         Assert.Equal(expectedOutput.ValueDef.MaskedValue, taskSignature.TaskDefOutputSchema.ValueDef.MaskedValue);
+        Assert.False(taskSignature.HasWorkerContextAtEnd);
+    }
+    
+    [Fact]
+    public void TaskSignature_WithoutReturnTypeInLHTaskMethod_ShouldBuildLHSignatureWithoutSchemaOutput()
+    {
+        int number_of_method_params = 1;
+        
+        var taskSignature = new LHTaskSignature<TestWorker>(TASK_DEF_NAME_INFORM, new TestWorker());
+        
+        var expectedLHMethodParam = new LHMethodParam
+        {
+            Type = VariableType.Str,
+            Name = "name",
+            IsMasked = TRUE_IS_MASKET
+        };
+
+        Assert.True(taskSignature.LhMethodParams.Count == number_of_method_params);
+        foreach (var actualLHMethodParam in taskSignature.LhMethodParams)
+        {
+            Assert.Equal(expectedLHMethodParam.Name, actualLHMethodParam.Name);
+            Assert.Equal(expectedLHMethodParam.Type, actualLHMethodParam.Type);
+            Assert.Equal(expectedLHMethodParam.IsMasked, actualLHMethodParam.IsMasked);
+        }
+        
+        Assert.Null(taskSignature.TaskDefOutputSchema);
         Assert.False(taskSignature.HasWorkerContextAtEnd);
     }
     
@@ -200,6 +227,12 @@ public class LHTaskSignatureTest
         public string Add([LHType(masked: TRUE_IS_MASKET)] string name)
         {
             return $"Output value: {name}";
+        }
+        
+        [LHTaskMethod(TASK_DEF_NAME_INFORM)]
+        public void Inform([LHType(masked: TRUE_IS_MASKET)] string name)
+        {
+            var test_variable = "test_variable" + name;
         }
         
         [LHTaskMethod(TASK_DEF_NAME_UPDATE)]

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHMappingHelper.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHMappingHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Net;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using LittleHorse.Common.Proto;
@@ -45,17 +44,7 @@ namespace LittleHorse.Sdk.Helper
                 return VariableType.JsonArr;
             }
 
-            if (!type.Namespace!.StartsWith("System"))
-            {
-                return VariableType.JsonObj;
-            }
-            
-            if (type.IsAssignableFrom(typeof(void)))
-            {
-                return VariableType.JsonObj;
-            }
-
-            throw new Exception("Unaccepted variable type.");
+            return VariableType.JsonObj;
         }
         
         public static DateTime? MapDateTimeFromProtoTimeStamp(Timestamp protoTimestamp)

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskSignature.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskSignature.cs
@@ -50,9 +50,10 @@ namespace LittleHorse.Sdk.Worker
 
             var methodParams = TaskMethod.GetParameters();
 
-            CreateInputVarsSignature(methodParams);
+            BuildInputVarsSignature(methodParams);
 
-            CreateOutputSchemaSignature();
+            if (!TaskMethod.ReturnType.IsAssignableFrom(typeof(void)))
+                BuildOutputSchemaSignature();
         }
         
         private bool IsValidLHTaskWorkerValue(Attribute? lhtaskWorkerAttribute, string taskDefName)
@@ -65,7 +66,7 @@ namespace LittleHorse.Sdk.Worker
             return false;
         }
 
-        private void CreateInputVarsSignature(ParameterInfo[] methodParams)
+        private void BuildInputVarsSignature(ParameterInfo[] methodParams)
         {
             for (int i = 0; i < methodParams.Length; i++)
             {
@@ -107,7 +108,7 @@ namespace LittleHorse.Sdk.Worker
             }
         }
         
-        private void CreateOutputSchemaSignature()
+        private void BuildOutputSchemaSignature()
         {
             var returnType = LHMappingHelper.MapDotNetTypeToLHVariableType(TaskMethod.ReturnType);
             var maskedValue = false;

--- a/sdk-dotnet/Littlehorse.sln
+++ b/sdk-dotnet/Littlehorse.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicExample", "Examples\Ba
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaskedFieldsExample", "Examples\MaskedFieldsExample\MaskedFieldsExample.csproj", "{AA9767C3-9F03-4414-A4C2-A0C3761A975C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LittleHorse.Sdk.Tests", "LittleHorse.Sdk.Tests\LittleHorse.Sdk.Tests.csproj", "{AC276D3F-ABAB-4E2D-B721-099681083390}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExceptionsHandlerExample", "Examples\ExceptionsHandlerExample\ExceptionsHandlerExample.csproj", "{6B7A8034-21C0-465D-8708-4F47A1780972}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,9 +36,18 @@ Global
 		{AA9767C3-9F03-4414-A4C2-A0C3761A975C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA9767C3-9F03-4414-A4C2-A0C3761A975C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA9767C3-9F03-4414-A4C2-A0C3761A975C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC276D3F-ABAB-4E2D-B721-099681083390}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC276D3F-ABAB-4E2D-B721-099681083390}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC276D3F-ABAB-4E2D-B721-099681083390}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC276D3F-ABAB-4E2D-B721-099681083390}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B7A8034-21C0-465D-8708-4F47A1780972}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B7A8034-21C0-465D-8708-4F47A1780972}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B7A8034-21C0-465D-8708-4F47A1780972}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B7A8034-21C0-465D-8708-4F47A1780972}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{88CB23B3-1174-45F5-9F72-46AB57BAB661} = {EEC3BB78-BFA5-4525-A965-4EAA3455BBAE}
 		{AA9767C3-9F03-4414-A4C2-A0C3761A975C} = {EEC3BB78-BFA5-4525-A965-4EAA3455BBAE}
+		{6B7A8034-21C0-465D-8708-4F47A1780972} = {EEC3BB78-BFA5-4525-A965-4EAA3455BBAE}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Create validation to not build schema output when there is not return type in LH Task Methods
- Change Mapping Type method to return JSON obj when a param or return type is not between the allowed primitive types
- Add and modify unit tests