### PR TITLE
fix(server): Pass UserTask User details to WorkerContext

### DIFF
--- a/docs/docs/08-api.md
+++ b/docs/docs/08-api.md
@@ -3228,7 +3228,7 @@ SDK, which allows the Task Method to determine where the TaskRun comes from.
 | `node_run_id` | | [NodeRunId](#noderunid) | Is the NodeRun that the UserTaskRun belongs to. |
 | `user_task_event_number` | | int32 | Is the index in the `events` field of the UserTaskRun that the TaskRun corresponds to. |
 | `user_id` | optional| string | Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not asigned to a specific user_id. |
-| `user_group` | optional| string | Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not asigned to a specific user_id. |
+| `user_group` | optional| string | Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not asigned to a specific user_group. |
  <!-- end Fields -->
  <!-- end HasFields -->
 

--- a/schemas/littlehorse/user_tasks.proto
+++ b/schemas/littlehorse/user_tasks.proto
@@ -214,8 +214,8 @@ message UserTaskTriggerReference {
   // asigned to a specific user_id.
   optional string user_id = 3;
 
-  // Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-  // asigned to a specific user_id.
+  // Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+  // asigned to a specific user_group.
   optional string user_group = 4;
 }
 

--- a/sdk-go/lhproto/user_tasks.pb.go
+++ b/sdk-go/lhproto/user_tasks.pb.go
@@ -770,8 +770,8 @@ type UserTaskTriggerReference struct {
 	// Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
 	// asigned to a specific user_id.
 	UserId *string `protobuf:"bytes,3,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
-	// Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-	// asigned to a specific user_id.
+	// Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+	// asigned to a specific user_group.
 	UserGroup *string `protobuf:"bytes,4,opt,name=user_group,json=userGroup,proto3,oneof" json:"user_group,omitempty"`
 }
 

--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/proto/UserTaskTriggerReference.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/proto/UserTaskTriggerReference.java
@@ -174,8 +174,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object userGroup_ = "";
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>
@@ -187,8 +187,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>
@@ -209,8 +209,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>
@@ -980,8 +980,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object userGroup_ = "";
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>
@@ -992,8 +992,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>
@@ -1013,8 +1013,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>
@@ -1035,8 +1035,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>
@@ -1053,8 +1053,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>
@@ -1068,8 +1068,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-     * asigned to a specific user_id.
+     * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+     * asigned to a specific user_group.
      * </pre>
      *
      * <code>optional string user_group = 4;</code>

--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/proto/UserTaskTriggerReferenceOrBuilder.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/proto/UserTaskTriggerReferenceOrBuilder.java
@@ -79,8 +79,8 @@ public interface UserTaskTriggerReferenceOrBuilder extends
 
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>
@@ -89,8 +89,8 @@ public interface UserTaskTriggerReferenceOrBuilder extends
   boolean hasUserGroup();
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>
@@ -99,8 +99,8 @@ public interface UserTaskTriggerReferenceOrBuilder extends
   java.lang.String getUserGroup();
   /**
    * <pre>
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    * </pre>
    *
    * <code>optional string user_group = 4;</code>

--- a/sdk-js/src/proto/user_tasks.ts
+++ b/sdk-js/src/proto/user_tasks.ts
@@ -347,8 +347,8 @@ export interface UserTaskTriggerReference {
     | string
     | undefined;
   /**
-   * Is the user_id that the UserTaskRun is assigned to. Unset if UserTaskRun is not
-   * asigned to a specific user_id.
+   * Is the user_group that the UserTaskRun is assigned to. Unset if UserTaskRun is not
+   * asigned to a specific user_group.
    */
   userGroup?: string | undefined;
 }

--- a/sdk-python/littlehorse/model/__init__.py
+++ b/sdk-python/littlehorse/model/__init__.py
@@ -5,8 +5,8 @@ from .external_event_pb2 import *
 from .node_run_pb2 import *
 from .object_id_pb2 import *
 from .scheduled_wf_run_pb2 import *
-from .service_pb2_grpc import *
 from .service_pb2 import *
+from .service_pb2_grpc import *
 from .task_def_pb2 import *
 from .task_run_pb2 import *
 from .user_tasks_pb2 import *

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/init/ServerVersionModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/init/ServerVersionModel.java
@@ -53,6 +53,8 @@ public class ServerVersionModel extends LHSerializable<ServerVersion> {
 
         if (serverVersion.hasPreReleaseIdentifier()) {
             this.preReleaseIdentifier = Optional.of(serverVersion.getPreReleaseIdentifier());
+        } else {
+            this.preReleaseIdentifier = Optional.empty();
         }
     }
 

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
@@ -21,8 +21,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
     private NodeRunIdModel nodeRunId;
     private int userTaskEventNumber;
 
-    private Optional<String> userId;
-    private Optional<String> userGroup;
+    private String userId;
+    private String userGroup;
 
     public UserTaskTriggerReferenceModel() {}
 
@@ -31,8 +31,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
         // Trust in the Force
         userTaskEventNumber = utr.getEvents().size();
 
-        this.userId = Optional.of(utr.getUserId());
-        this.userGroup = Optional.of(utr.getUserGroup());
+        this.userId = utr.getUserId();
+        this.userGroup = utr.getUserGroup();
     }
 
     @Override
@@ -46,12 +46,12 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
                 .setNodeRunId(nodeRunId.toProto())
                 .setUserTaskEventNumber(userTaskEventNumber);
 
-        if (userId.isPresent()) {
-            out.setUserId(this.userId.get());
+        if (userId != null) {
+            out.setUserId(this.userId);
         }
-        
-        if (userGroup.isPresent()) {
-            out.setUserGroup(this.userGroup.get());
+
+        if (userGroup != null) {
+            out.setUserGroup(this.userGroup);
         }
 
         return out;
@@ -62,8 +62,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
         UserTaskTriggerReference p = (UserTaskTriggerReference) proto;
         nodeRunId = LHSerializable.fromProto(p.getNodeRunId(), NodeRunIdModel.class, context);
         userTaskEventNumber = p.getUserTaskEventNumber();
-        userId = Optional.ofNullable(p.getUserId());
-        userGroup = Optional.ofNullable(p.getUserGroup());
+        userId = p.getUserId();
+        userGroup = p.getUserGroup();
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
@@ -1,5 +1,7 @@
 package io.littlehorse.common.model.getable.core.taskrun;
 
+import java.util.Optional;
+
 import com.google.protobuf.Message;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.model.getable.core.usertaskrun.UserTaskRunModel;
@@ -19,8 +21,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
     private NodeRunIdModel nodeRunId;
     private int userTaskEventNumber;
 
-    private String userId;
-    private String userGroup;
+    private Optional<String> userId;
+    private Optional<String> userGroup;
 
     public UserTaskTriggerReferenceModel() {}
 
@@ -29,8 +31,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
         // Trust in the Force
         userTaskEventNumber = utr.getEvents().size();
 
-        this.userId = utr.getUserId();
-        this.userGroup = utr.getUserGroup();
+        this.userId = Optional.of(utr.getUserId());
+        this.userGroup = Optional.of(utr.getUserGroup());
     }
 
     @Override
@@ -42,9 +44,15 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
     public UserTaskTriggerReference.Builder toProto() {
         UserTaskTriggerReference.Builder out = UserTaskTriggerReference.newBuilder()
                 .setNodeRunId(nodeRunId.toProto())
-                .setUserTaskEventNumber(userTaskEventNumber)
-                .setUserId(this.userId)
-                .setUserGroup(this.userGroup);
+                .setUserTaskEventNumber(userTaskEventNumber);
+
+        if (userId.isPresent()) {
+            out.setUserId(this.userId.get());
+        }
+        
+        if (userGroup.isPresent()) {
+            out.setUserGroup(this.userGroup.get());
+        }
 
         return out;
     }
@@ -54,8 +62,8 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
         UserTaskTriggerReference p = (UserTaskTriggerReference) proto;
         nodeRunId = LHSerializable.fromProto(p.getNodeRunId(), NodeRunIdModel.class, context);
         userTaskEventNumber = p.getUserTaskEventNumber();
-        userId = p.getUserId();
-        userGroup = p.getUserGroup();
+        userId = Optional.ofNullable(p.getUserId());
+        userGroup = Optional.ofNullable(p.getUserGroup());
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
@@ -1,7 +1,5 @@
 package io.littlehorse.common.model.getable.core.taskrun;
 
-import java.util.Optional;
-
 import com.google.protobuf.Message;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.model.getable.core.usertaskrun.UserTaskRunModel;

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/taskrun/UserTaskTriggerReferenceModel.java
@@ -60,8 +60,14 @@ public class UserTaskTriggerReferenceModel extends LHSerializable<UserTaskTrigge
         UserTaskTriggerReference p = (UserTaskTriggerReference) proto;
         nodeRunId = LHSerializable.fromProto(p.getNodeRunId(), NodeRunIdModel.class, context);
         userTaskEventNumber = p.getUserTaskEventNumber();
-        userId = p.getUserId();
-        userGroup = p.getUserGroup();
+
+        if (p.hasUserId()) {
+            userId = p.getUserId();
+        }
+
+        if (p.hasUserGroup()) {
+            userGroup = p.getUserGroup();
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR makes sure that UserTask User details are passed onto the WorkerContext when necessary by fixing a bug in the `UserTaskTriggerReferenceModel` where we failed to serialize the userId and userGroup.

This PR also adds 2 E2E tests:
- 1 covering functionality for Scheduled Reminder Tasks
- 1 covering functionality for passing UserTask User details to the WorkerContext. 