### PR TITLE
fix(sdk-python): Add missing `WorkflowThread.declare_str` method

### DIFF
--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1307,6 +1307,9 @@ class WorkflowThread:
     def declare_int(self, name: str) -> WfRunVariable:
         return self.add_variable(name, VariableType.INT)
     
+    def declare_str(self, name: str) -> WfRunVariable:
+        return self.add_variable(name, VariableType.STR)
+    
     def declare_double(self, name: str) -> WfRunVariable:
         return self.add_variable(name, VariableType.DOUBLE)
     


### PR DESCRIPTION
Adds the `WorkflowThread.declare_str` method which is missing from our latest batch of SDK changes.