### PR TITLE
fix(canary): sort dataplaneId parameter on BeatProducer

### DIFF
--- a/canary/src/main/java/io/littlehorse/canary/Main.java
+++ b/canary/src/main/java/io/littlehorse/canary/Main.java
@@ -67,8 +67,8 @@ public class Main {
                     lhConfig.getApiBootstrapHost(),
                     lhConfig.getApiBootstrapPort(),
                     lhClient.getServerVersion(),
-                    canaryConfig.getMetronomeServerDataplaneId(),
                     canaryConfig.getMetronomeServerId(),
+                    canaryConfig.getMetronomeServerDataplaneId(),
                     canaryConfig.getTopicName(),
                     canaryConfig.toKafkaConfig().toMap(),
                     canaryConfig.getMetronomeBeatExtraTags());


### PR DESCRIPTION
The change corrects the order of parameters in the `initialize` method to ensure `canaryConfig.getMetronomeServerDataplaneId()` is correctly placed after `canaryConfig.getMetronomeServerId()`.
