### PR TITLE
feat(sdk-go): Allow users to pass any content to LHTaskException

### DIFF
--- a/sdk-go/littlehorse/lh_errors.go
+++ b/sdk-go/littlehorse/lh_errors.go
@@ -1,9 +1,11 @@
 package littlehorse
 
-import "github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
-
 type LHTaskException struct {
 	Name    string
 	Message string
-	Content *lhproto.VariableValue
+	Content interface{}
+}
+
+func (e *LHTaskException) Error() string {
+	return e.Message
 }

--- a/sdk-go/littlehorse/lh_variables.go
+++ b/sdk-go/littlehorse/lh_variables.go
@@ -146,6 +146,11 @@ func InterfaceToVarVal(someInterface interface{}) (*lhproto.VariableValue, error
 	out := &lhproto.VariableValue{}
 	var err error
 
+	interfaceAsVarVal, isVarVal := someInterface.(*lhproto.VariableValue)
+	if isVarVal {
+		return interfaceAsVarVal, nil
+	}
+
 	isPtr, _ := GetIsPtrAndType(reflect.TypeOf(someInterface))
 	if someInterface == nil {
 		return &lhproto.VariableValue{}, nil

--- a/sdk-go/littlehorse/task_worker_internal.go
+++ b/sdk-go/littlehorse/task_worker_internal.go
@@ -431,12 +431,12 @@ func (m *serverConnectionManager) doTaskHelper(task *lhproto.ScheduledTask) *lhp
 		if errorReflect.Interface() != nil {
 			// Check if the error is an LHTaskException
 			if lhtErr, ok := errorReflect.Interface().(*LHTaskException); ok {
-				taskErrVarVal, err := InterfaceToVarVal(lhtErr.Content)
+				taskErrContent, err := InterfaceToVarVal(lhtErr.Content)
 
 				if err != nil {
-					msg := "Failed to serialize task error content: " + err.Error()
+					msg := "LH_SDK_GO_ERR: Failed to serialize task error content passed from task worker: " + err.Error()
 
-					taskErrVarVal = &lhproto.VariableValue{
+					taskErrContent = &lhproto.VariableValue{
 						Value: &lhproto.VariableValue_Str{
 							Str: msg,
 						},
@@ -447,7 +447,7 @@ func (m *serverConnectionManager) doTaskHelper(task *lhproto.ScheduledTask) *lhp
 					Exception: &lhproto.LHTaskException{
 						Name:    lhtErr.Name,
 						Message: lhtErr.Message,
-						Content: taskErrVarVal,
+						Content: taskErrContent,
 					},
 				}
 			} else {

--- a/sdk-go/littlehorse/task_worker_internal.go
+++ b/sdk-go/littlehorse/task_worker_internal.go
@@ -431,11 +431,23 @@ func (m *serverConnectionManager) doTaskHelper(task *lhproto.ScheduledTask) *lhp
 		if errorReflect.Interface() != nil {
 			// Check if the error is an LHTaskException
 			if lhtErr, ok := errorReflect.Interface().(*LHTaskException); ok {
+				taskErrVarVal, err := InterfaceToVarVal(lhtErr.Content)
+
+				if err != nil {
+					msg := "Failed to serialize task error content: " + err.Error()
+
+					taskErrVarVal = &lhproto.VariableValue{
+						Value: &lhproto.VariableValue_Str{
+							Str: msg,
+						},
+					}
+				}
+
 				taskResult.Result = &lhproto.ReportTaskRun_Exception{
 					Exception: &lhproto.LHTaskException{
 						Name:    lhtErr.Name,
 						Message: lhtErr.Message,
-						Content: lhtErr.Content,
+						Content: taskErrVarVal,
 					},
 				}
 			} else {


### PR DESCRIPTION
Allows users to pass content of any type to their LHTaskExceptions.

Users can now pass any type of content into the `Content interface{}` field of an SDK-Go `LHTaskException` and the SDK will use its internal `InterfaceToVarVal` method to convert the content into a protobuf compatible format.