### PR TITLE
feat(server): Core store rate limiter

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -78,6 +78,7 @@ public class LHServerConfig extends ConfigBase {
     public static final String TIMER_STATESTORE_CACHE_BYTES_KEY = "LHS_TIMER_STATESTORE_CACHE_BYTES";
     public static final String ROCKSDB_TOTAL_BLOCK_CACHE_BYTES_KEY = "LHS_ROCKSDB_TOTAL_BLOCK_CACHE_BYTES";
     public static final String ROCKSDB_TOTAL_MEMTABLE_BYTES_KEY = "LHS_ROCKSDB_TOTAL_MEMTABLE_BYTES";
+    public static final String ROCKSDB_RATE_LIMIT_BYTES_KEY = "LHS_ROCKSDB_RATE_LIMIT_BYTES";
     public static final String SESSION_TIMEOUT_KEY = "LHS_STREAMS_SESSION_TIMEOUT";
     public static final String KAFKA_STATE_DIR_KEY = "LHS_STATE_DIR";
     public static final String NUM_WARMUP_REPLICAS_KEY = "LHS_STREAMS_NUM_WARMUP_REPLICAS";
@@ -421,6 +422,10 @@ public class LHServerConfig extends ConfigBase {
 
     public String getStatusPath() {
         return getOrSetDefault(LHServerConfig.HEALTH_PATH_STATUS_KEY, "/status");
+    }
+
+    public long getCoreStoreRateLimitBytes() {
+        return Long.valueOf(getOrSetDefault(LHServerConfig.ROCKSDB_RATE_LIMIT_BYTES_KEY, "-1"));
     }
 
     public String getDiskUsagePath() {

--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -8,6 +8,7 @@ import org.apache.kafka.streams.state.internals.BlockBasedTableConfigWithAccessi
 import org.rocksdb.Cache;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.Options;
+import org.rocksdb.RateLimiter;
 
 @Slf4j
 public class RocksConfigSetter implements RocksDBConfigSetter {
@@ -75,7 +76,15 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         }
         // Streams default is 3
         options.setMaxWriteBufferNumber(5);
-
+        long rateLimit = serverConfig.getCoreStoreRateLimitBytes();
+        if (rateLimit > 0) {
+            options.setRateLimiter(new RateLimiter(
+                    rateLimit,
+                    RateLimiter.DEFAULT_REFILL_PERIOD_MICROS,
+                    RateLimiter.DEFAULT_FAIRNESS,
+                    RateLimiter.DEFAULT_MODE,
+                    false));
+        }
         // Future Work: Enable larger scaling by using Partitioned Index Filters
         // https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters
         //


### PR DESCRIPTION
This PR adds a server config that allows users to limit the write rate to the stores inside the core topology. 
see [Rocksdb rate limiter](https://github.com/facebook/rocksdb/wiki/rate-limiter)