### PR TITLE
fix(sdk-go, sdk-python): Remove dangling exit nodes on early returned WorkflowThreads

### DIFF
--- a/sdk-go/littlehorse/wf_lib_internal.go
+++ b/sdk-go/littlehorse/wf_lib_internal.go
@@ -72,9 +72,11 @@ func (l *LHWorkflow) compile() (*lhproto.PutWfSpecRequest, error) {
 				function(&thr)
 
 				// Now add exit node to make a sandwich
-				_, exitNode := thr.createBlankNode("exit", "EXIT")
-				exitNode.Node = &lhproto.Node_Exit{
-					Exit: &lhproto.ExitNode{},
+				if thr.spec.Nodes[*thr.lastNodeName].GetExit() == nil {
+					_, exitNode := thr.createBlankNode("exit", "EXIT")
+					exitNode.Node = &lhproto.Node_Exit{
+						Exit: &lhproto.ExitNode{},
+					}
 				}
 				thr.isActive = false
 				// Now save the thread to the protobuf

--- a/sdk-go/littlehorse/wf_lib_internal_test.go
+++ b/sdk-go/littlehorse/wf_lib_internal_test.go
@@ -9,7 +9,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCanMakeSearcjableVariable(t *testing.T) {
+func TestEarlyReturnOnExitNode(t *testing.T) {
+	wf := littlehorse.NewWorkflow(func(t *littlehorse.WorkflowThread) {
+		t.Execute("some-task")
+		t.Fail("failure message", "my-failure", nil)
+	}, "my-workflow")
+
+	putWf, err := wf.Compile()
+	if err != nil {
+		t.Error(err)
+	}
+
+	entrypoint := putWf.ThreadSpecs[putWf.EntrypointThreadName]
+
+	exitNodeCount := 0
+
+	for _, value := range entrypoint.Nodes {
+		if value.GetExit() != nil {
+			exitNodeCount += 1
+		}
+	}
+
+	assert.Equal(t, exitNodeCount, 1)
+}
+
+func TestCanMakeSearchableVariable(t *testing.T) {
 	wf := littlehorse.NewWorkflow(func(t *littlehorse.WorkflowThread) {
 		t.AddVariable(
 			"my-var", lhproto.VariableType_BOOL,

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -951,7 +951,9 @@ class WorkflowThread:
         self.is_active = True
         self.add_node("entrypoint", EntrypointNode())
         initializer(self)
-        self.add_node("exit", ExitNode())
+        node = self._last_node()
+        if node.node_case != NodeCase.EXIT:
+            self.add_node("exit", ExitNode())
         self.is_active = False
 
     def spawn_thread(

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -238,9 +238,7 @@ class TestThreadBuilder(unittest.TestCase):
                                 failure_name="my_failure_name", message="my_message"
                             )
                         ),
-                        outgoing_edges=[Edge(sink_node_name="2-exit-EXIT")],
                     ),
-                    "2-exit-EXIT": Node(exit=ExitNode()),
                 },
             ),
         )
@@ -268,9 +266,7 @@ class TestThreadBuilder(unittest.TestCase):
                                 ),
                             )
                         ),
-                        outgoing_edges=[Edge(sink_node_name="2-exit-EXIT")],
                     ),
-                    "2-exit-EXIT": Node(exit=ExitNode()),
                 },
             ),
         )


### PR DESCRIPTION
This PR removes the dangling exit node left on WorkflowThreads that return early using the `WorkflowThread.fail()` method in `sdk-python` and `sdk-go`.

**Resolves Issue #473.**

**Applies the changes in #142 to `sdk-python` and `sdk-go`.**

## Before
A WorkflowThread that reads as follows:
```
wf.execute("some-task")
wf.fail("my-failure", "failure_message)
```
Would effectively stop at the Node created by `wf.fail()`. But the WorkflowThread builder in the SDK would add an additional ExitNode anyways, resulting in this dangling node:

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/5102a52e-d03d-4d95-a179-ad0ce956ae1e" />

## After
The Python and Go SDKs will now check if the last node in a WorkflowThread is an exit node before adding another one.
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/5a9f82ee-8706-4387-9e07-b26e4ccae196" />
