### PR TITLE
chore(server): Change level compaction to universal

### DIFF
--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -63,7 +63,7 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         options.setTableFormatConfig(tableConfig);
 
         options.setOptimizeFiltersForHits(OPTIMIZE_FILTERS_FOR_HITS);
-        options.setCompactionStyle(CompactionStyle.LEVEL);
+        options.setCompactionStyle(CompactionStyle.UNIVERSAL);
 
         options.setIncreaseParallelism(serverConfig.getRocksDBCompactionThreads());
 


### PR DESCRIPTION
Universal compaction is the default on kafka streams for very good reasons. On my load test I have observed that level compactions improves reads while introducing some extra latency on writes. Level compaction makes us vulnerables to TransactionTimeouts when rocksdb instance is too big.