### PR TITLE
fix(server): continue processing on abortable exceptions

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHProductionExceptionHandler.java
+++ b/server/src/main/java/io/littlehorse/common/LHProductionExceptionHandler.java
@@ -1,0 +1,25 @@
+package io.littlehorse.common;
+
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.TransactionAbortedException;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+
+public class LHProductionExceptionHandler implements ProductionExceptionHandler {
+
+    public LHProductionExceptionHandler() {}
+
+    @Override
+    public ProductionExceptionHandlerResponse handle(ProducerRecord<byte[], byte[]> record, Exception exception) {
+        if (exception instanceof TransactionAbortedException) {
+            // It is safe to continue on abortable exceptions caused inside the Kafka Streams TransactionManager
+            return ProductionExceptionHandlerResponse.CONTINUE;
+        }
+        return ProductionExceptionHandlerResponse.FAIL;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // nothing to do
+    }
+}

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -45,7 +45,6 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.jetbrains.annotations.Nullable;
 import org.rocksdb.Cache;
@@ -958,7 +957,7 @@ public class LHServerConfig extends ConfigBase {
 
         // Configs required by KafkaStreams. Some of these are overriden by the application logic itself.
         props.put("default.deserialization.exception.handler", LogAndContinueExceptionHandler.class);
-        props.put("default.production.exception.handler", DefaultProductionExceptionHandler.class);
+        props.put("default.production.exception.handler", LHProductionExceptionHandler.class);
         props.put("default.value.serde", Serdes.StringSerde.class.getName());
         props.put("default.key.serde", Serdes.StringSerde.class.getName());
 


### PR DESCRIPTION
This PR adds a custom production exception handler that prevents the application instance to crash when there is an abortable exception in the transaction manager.