### PR TITLE
feat(dashboard): display taskdef usage by wfspecs

### DIFF
--- a/dashboard/src/app/[tenantId]/page.tsx
+++ b/dashboard/src/app/[tenantId]/page.tsx
@@ -1,5 +1,7 @@
+import { lhClient } from '../lhClient'
 import { Search } from './components/Search'
 
-export default function Home() {
+export default async function Home() {
+
   return <Search />
 }

--- a/dashboard/src/app/[tenantId]/page.tsx
+++ b/dashboard/src/app/[tenantId]/page.tsx
@@ -2,6 +2,5 @@ import { lhClient } from '../lhClient'
 import { Search } from './components/Search'
 
 export default async function Home() {
-
   return <Search />
 }

--- a/dashboard/src/app/[tenantId]/taskDef/[name]/components/TaskDef.tsx
+++ b/dashboard/src/app/[tenantId]/taskDef/[name]/components/TaskDef.tsx
@@ -7,24 +7,40 @@ import { concatWfRunIds, localDateTimeToUTCIsoString, utcToLocalDateTime } from 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { useInfiniteQuery } from '@tanstack/react-query'
-import { TaskDef as TaskDefProto, TaskStatus } from 'littlehorse-client/proto'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { TaskDef as TaskDefProto, TaskStatus, WfSpecIdList } from 'littlehorse-client/proto'
 import { RefreshCwIcon } from 'lucide-react'
 import { useParams } from 'next/navigation'
 import { FC, Fragment, useState } from 'react'
 import { PaginatedTaskRunList, searchTaskRun } from '../actions/searchTaskRun'
 import { Details } from './Details'
 import { InputVars } from './InputVars'
+import { getWfSpecsByTaskDef } from '@/app/actions/getWfSpecsByTaskDef'
+import { WfSpecData } from '@/types'
+import { TagIcon } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
+import { SelectionLink } from '@/app/[tenantId]/components/SelectionLink'
 
 type Props = {
   spec: TaskDefProto
 }
+
 export const TaskDef: FC<Props> = ({ spec }) => {
   const [selectedStatus, setSelectedStatus] = useState<TaskStatus | 'ALL'>('ALL')
   const [createdAfter, setCreatedAfter] = useState('')
   const [createdBefore, setCreatedBefore] = useState('')
   const tenantId = useParams().tenantId as string
   const [limit, setLimit] = useState<number>(SEARCH_DEFAULT_LIMIT)
+  const taskDefName = spec.id?.name || ''
+
+  const { data: wfSpecs } = useQuery({
+    queryKey: ['wfSpecs', tenantId, taskDefName],
+    queryFn: async () => {
+      if (!tenantId || !taskDefName) return
+      return await getWfSpecsByTaskDef(tenantId, taskDefName)
+    },
+    enabled: !!tenantId && !!taskDefName,
+  })
 
   const { isPending, data, hasNextPage, fetchNextPage } = useInfiniteQuery({
     queryKey: ['taskRun', selectedStatus, tenantId, limit, createdAfter, createdBefore],
@@ -42,12 +58,30 @@ export const TaskDef: FC<Props> = ({ spec }) => {
       })
     },
   })
+
   return (
     <>
       <Navigation href="/?type=TaskDef" title="Go back to TaskDefs" />
       <Details id={spec.id} />
       <InputVars inputVars={spec.inputVars} />
-      <hr className="mt-6" />
+
+      <h2 className="text-lg font-bold mt-2 mb-2">WfSpec Usage</h2>
+      {wfSpecs && <div className="flex max-h-[200px] flex-col overflow-auto">
+        {wfSpecs.results.map(wfSpec => (
+          <Fragment key={wfSpec.name}>
+            <SelectionLink href={`/wfSpec/${wfSpec.name}/${wfSpec.majorVersion}.${wfSpec.revision}`}>
+              <p className="group">{wfSpec.name}</p>
+              <div className="flex items-center gap-2 rounded bg-blue-200 px-2 font-mono text-sm text-gray-500">
+                <TagIcon className="h-4 w-4 fill-none stroke-gray-500 stroke-1" />
+                v{wfSpec.majorVersion}.{wfSpec.revision}
+              </div>
+            </SelectionLink>
+            <Separator />
+          </Fragment>
+        ))}
+      </div>}
+
+      < hr className="mt-6" />
       <div className="mb-4 mt-6 flex items-center justify-between">
         <h2 className="text-2xl font-bold">Related Task Run&apos;s:</h2>
         <select
@@ -86,55 +120,57 @@ export const TaskDef: FC<Props> = ({ spec }) => {
         </div>
       </div>
 
-      {isPending ? (
-        <div className="flex min-h-[360px] items-center justify-center text-center">
-          <RefreshCwIcon className="h-8 w-8 animate-spin text-blue-500" />
-        </div>
-      ) : (
-        <div className="flex min-h-[360px] flex-col gap-4">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead scope="col">WfRun Id</TableHead>
-                <TableHead scope="col">Task GUID</TableHead>
-                <TableHead scope="col">Creation Date</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data?.pages.map((page, i) => (
-                <Fragment key={i}>
-                  {page.resultsWithDetails.length > 0 ? (
-                    page.resultsWithDetails.map(({ taskRun }) => {
-                      return (
-                        <TableRow key={taskRun.id?.taskGuid}>
-                          <TableCell>
-                            <LinkWithTenant
-                              className="py-2 text-blue-500 hover:underline"
-                              target="_blank"
-                              href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber ?? taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeRunName=${taskRun.source?.taskNode?.nodeRunId?.position}-${spec.id?.name}-TASK`}
-                            >
-                              {concatWfRunIds(taskRun.id?.wfRunId!)}
-                            </LinkWithTenant>
-                          </TableCell>
-                          <TableCell>{taskRun.id?.taskGuid}</TableCell>
+      {
+        isPending ? (
+          <div className="flex min-h-[360px] items-center justify-center text-center">
+            <RefreshCwIcon className="h-8 w-8 animate-spin text-blue-500" />
+          </div>
+        ) : (
+          <div className="flex min-h-[360px] flex-col gap-4">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead scope="col">WfRun Id</TableHead>
+                  <TableHead scope="col">Task GUID</TableHead>
+                  <TableHead scope="col">Creation Date</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.pages.map((page, i) => (
+                  <Fragment key={i}>
+                    {page.resultsWithDetails.length > 0 ? (
+                      page.resultsWithDetails.map(({ taskRun }) => {
+                        return (
+                          <TableRow key={taskRun.id?.taskGuid}>
+                            <TableCell>
+                              <LinkWithTenant
+                                className="py-2 text-blue-500 hover:underline"
+                                target="_blank"
+                                href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber ?? taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeRunName=${taskRun.source?.taskNode?.nodeRunId?.position}-${spec.id?.name}-TASK`}
+                              >
+                                {concatWfRunIds(taskRun.id?.wfRunId!)}
+                              </LinkWithTenant>
+                            </TableCell>
+                            <TableCell>{taskRun.id?.taskGuid}</TableCell>
 
-                          <TableCell>{taskRun.scheduledAt ? utcToLocalDateTime(taskRun.scheduledAt) : 'N/A'}</TableCell>
-                        </TableRow>
-                      )
-                    })
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={3} className="text-center">
-                        No data
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </Fragment>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+                            <TableCell>{taskRun.scheduledAt ? utcToLocalDateTime(taskRun.scheduledAt) : 'N/A'}</TableCell>
+                          </TableRow>
+                        )
+                      })
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={3} className="text-center">
+                          No data
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </Fragment>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )
+      }
 
       <div className="mt-6">
         <SearchFooter

--- a/dashboard/src/app/[tenantId]/taskDef/[name]/components/TaskDef.tsx
+++ b/dashboard/src/app/[tenantId]/taskDef/[name]/components/TaskDef.tsx
@@ -65,23 +65,25 @@ export const TaskDef: FC<Props> = ({ spec }) => {
       <Details id={spec.id} />
       <InputVars inputVars={spec.inputVars} />
 
-      <h2 className="text-lg font-bold mt-2 mb-2">WfSpec Usage</h2>
-      {wfSpecs && <div className="flex max-h-[200px] flex-col overflow-auto">
-        {wfSpecs.results.map(wfSpec => (
-          <Fragment key={wfSpec.name}>
-            <SelectionLink href={`/wfSpec/${wfSpec.name}/${wfSpec.majorVersion}.${wfSpec.revision}`}>
-              <p className="group">{wfSpec.name}</p>
-              <div className="flex items-center gap-2 rounded bg-blue-200 px-2 font-mono text-sm text-gray-500">
-                <TagIcon className="h-4 w-4 fill-none stroke-gray-500 stroke-1" />
-                v{wfSpec.majorVersion}.{wfSpec.revision}
-              </div>
-            </SelectionLink>
-            <Separator />
-          </Fragment>
-        ))}
-      </div>}
+      <h2 className="mb-2 mt-2 text-lg font-bold">WfSpec Usage</h2>
+      {wfSpecs && (
+        <div className="flex max-h-[200px] flex-col overflow-auto">
+          {wfSpecs.results.map(wfSpec => (
+            <Fragment key={wfSpec.name}>
+              <SelectionLink href={`/wfSpec/${wfSpec.name}/${wfSpec.majorVersion}.${wfSpec.revision}`}>
+                <p className="group">{wfSpec.name}</p>
+                <div className="flex items-center gap-2 rounded bg-blue-200 px-2 font-mono text-sm text-gray-500">
+                  <TagIcon className="h-4 w-4 fill-none stroke-gray-500 stroke-1" />v{wfSpec.majorVersion}.
+                  {wfSpec.revision}
+                </div>
+              </SelectionLink>
+              <Separator />
+            </Fragment>
+          ))}
+        </div>
+      )}
 
-      < hr className="mt-6" />
+      <hr className="mt-6" />
       <div className="mb-4 mt-6 flex items-center justify-between">
         <h2 className="text-2xl font-bold">Related Task Run&apos;s:</h2>
         <select
@@ -120,57 +122,55 @@ export const TaskDef: FC<Props> = ({ spec }) => {
         </div>
       </div>
 
-      {
-        isPending ? (
-          <div className="flex min-h-[360px] items-center justify-center text-center">
-            <RefreshCwIcon className="h-8 w-8 animate-spin text-blue-500" />
-          </div>
-        ) : (
-          <div className="flex min-h-[360px] flex-col gap-4">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead scope="col">WfRun Id</TableHead>
-                  <TableHead scope="col">Task GUID</TableHead>
-                  <TableHead scope="col">Creation Date</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data?.pages.map((page, i) => (
-                  <Fragment key={i}>
-                    {page.resultsWithDetails.length > 0 ? (
-                      page.resultsWithDetails.map(({ taskRun }) => {
-                        return (
-                          <TableRow key={taskRun.id?.taskGuid}>
-                            <TableCell>
-                              <LinkWithTenant
-                                className="py-2 text-blue-500 hover:underline"
-                                target="_blank"
-                                href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber ?? taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeRunName=${taskRun.source?.taskNode?.nodeRunId?.position}-${spec.id?.name}-TASK`}
-                              >
-                                {concatWfRunIds(taskRun.id?.wfRunId!)}
-                              </LinkWithTenant>
-                            </TableCell>
-                            <TableCell>{taskRun.id?.taskGuid}</TableCell>
+      {isPending ? (
+        <div className="flex min-h-[360px] items-center justify-center text-center">
+          <RefreshCwIcon className="h-8 w-8 animate-spin text-blue-500" />
+        </div>
+      ) : (
+        <div className="flex min-h-[360px] flex-col gap-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead scope="col">WfRun Id</TableHead>
+                <TableHead scope="col">Task GUID</TableHead>
+                <TableHead scope="col">Creation Date</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data?.pages.map((page, i) => (
+                <Fragment key={i}>
+                  {page.resultsWithDetails.length > 0 ? (
+                    page.resultsWithDetails.map(({ taskRun }) => {
+                      return (
+                        <TableRow key={taskRun.id?.taskGuid}>
+                          <TableCell>
+                            <LinkWithTenant
+                              className="py-2 text-blue-500 hover:underline"
+                              target="_blank"
+                              href={`/wfRun/${concatWfRunIds(taskRun.id?.wfRunId!)}?threadRunNumber=${taskRun.source?.taskNode?.nodeRunId?.threadRunNumber ?? taskRun.source?.userTaskTrigger?.nodeRunId?.threadRunNumber}&nodeRunName=${taskRun.source?.taskNode?.nodeRunId?.position}-${spec.id?.name}-TASK`}
+                            >
+                              {concatWfRunIds(taskRun.id?.wfRunId!)}
+                            </LinkWithTenant>
+                          </TableCell>
+                          <TableCell>{taskRun.id?.taskGuid}</TableCell>
 
-                            <TableCell>{taskRun.scheduledAt ? utcToLocalDateTime(taskRun.scheduledAt) : 'N/A'}</TableCell>
-                          </TableRow>
-                        )
-                      })
-                    ) : (
-                      <TableRow>
-                        <TableCell colSpan={3} className="text-center">
-                          No data
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </Fragment>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )
-      }
+                          <TableCell>{taskRun.scheduledAt ? utcToLocalDateTime(taskRun.scheduledAt) : 'N/A'}</TableCell>
+                        </TableRow>
+                      )
+                    })
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={3} className="text-center">
+                        No data
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
 
       <div className="mt-6">
         <SearchFooter

--- a/dashboard/src/app/actions/getWfSpecsByTaskDef.tsx
+++ b/dashboard/src/app/actions/getWfSpecsByTaskDef.tsx
@@ -1,0 +1,8 @@
+"use server"
+import { lhClient } from "../lhClient"
+
+export const getWfSpecsByTaskDef = async (tenantId: string, taskDefName: string) => {
+    const client = await lhClient({ tenantId })
+    const wfSpecs = await client.searchWfSpec({ taskDefName })
+    return wfSpecs
+}

--- a/dashboard/src/app/actions/getWfSpecsByTaskDef.tsx
+++ b/dashboard/src/app/actions/getWfSpecsByTaskDef.tsx
@@ -1,8 +1,8 @@
-"use server"
-import { lhClient } from "../lhClient"
+'use server'
+import { lhClient } from '../lhClient'
 
 export const getWfSpecsByTaskDef = async (tenantId: string, taskDefName: string) => {
-    const client = await lhClient({ tenantId })
-    const wfSpecs = await client.searchWfSpec({ taskDefName })
-    return wfSpecs
+  const client = await lhClient({ tenantId })
+  const wfSpecs = await client.searchWfSpec({ taskDefName })
+  return wfSpecs
 }


### PR DESCRIPTION
## Description
- Allow the user to view a list of `WfSpecs` that are used by any particular `TaskDef`.
  - Via `WfSpec Usage` section under the `TaskDef` page. 
- Using same `WfSpec` display visuals as on the primary `WfSpecs` view to maintain consistency and usage expectations by the user

## Media
### Screenshot
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/bcdc348f-53c1-46aa-9aee-337fdf52c5d4" />

### Scroll Multiple WfSpecs Handling
https://github.com/user-attachments/assets/ef3c684d-4bcf-4604-941b-843e624d6e26


