### PR TITLE
perf(server): Async processing for command producer callbacks

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -243,7 +243,8 @@ public class BackendInternalComms implements Closeable {
             RequestExecutionContext requestCtx) {
         Function<KeyQueryMetadata, LHInternalsStub> internalStub =
                 (meta) -> getInternalAsyncClient(meta.activeHost(), InternalCallCredentials.forContext(requestCtx));
-        return new ProducerCommandCallback(observer, command, coreStreams, thisHost, internalStub, asyncWaiters);
+        return new ProducerCommandCallback(
+                observer, command, coreStreams, thisHost, internalStub, asyncWaiters, networkThreadPool);
     }
 
     public void waitForCommand(

--- a/server/src/test/java/io/littlehorse/server/streams/ProducerCommandCallbackTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/ProducerCommandCallbackTest.java
@@ -15,6 +15,7 @@ import io.littlehorse.server.streams.util.AsyncWaiters;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -38,8 +39,8 @@ class ProducerCommandCallbackTest {
     private final HostInfo hostInfo = new HostInfo("localhost", 2023);
     private final LHInternalsGrpc.LHInternalsStub stub = mock();
     private final Function<KeyQueryMetadata, LHInternalsGrpc.LHInternalsStub> stubProvider = (meta) -> stub;
-    private final ProducerCommandCallback producerCallback =
-            new ProducerCommandCallback(responseObserver, command, coreStreams, hostInfo, stubProvider, commandWaiters);
+    private final ProducerCommandCallback producerCallback = new ProducerCommandCallback(
+            responseObserver, command, coreStreams, hostInfo, stubProvider, commandWaiters, executor);
     private final RecordMetadata metadata = new RecordMetadata(new TopicPartition("my-topic", 2), 0L, 0, 0L, 0, 0);
     private final WaitForCommandResponse response = mock();
     private final KeyQueryMetadata keyQueryMetadata = new KeyQueryMetadata(hostInfo, Collections.emptySet(), 2);
@@ -54,20 +55,24 @@ class ProducerCommandCallbackTest {
 
     @ParameterizedTest
     @EnumSource(value = LHStoreType.class, mode = EnumSource.Mode.EXCLUDE, names = "UNRECOGNIZED")
-    public void shouldWaitForCommandAfterCompletion(LHStoreType storeType) {
+    public void shouldWaitForCommandAfterCompletion(LHStoreType storeType) throws InterruptedException {
         when(command.getStore()).thenReturn(storeType);
         producerCallback.onCompletion(metadata, null);
+        executor.shutdown();
+        executor.awaitTermination(2, TimeUnit.SECONDS);
         commandWaiters.registerCommandProcessed("123", response);
         verify(responseObserver).onNext(response);
         verify(responseObserver).onCompleted();
     }
 
     @Test
-    public void shouldHandleTransientErrorsFromKafkaStreamsMetadata() {
+    public void shouldHandleTransientErrorsFromKafkaStreamsMetadata() throws InterruptedException {
         when(command.getStore()).thenReturn(LHStoreType.CORE);
         when(coreStreams.queryMetadataForKey(anyString(), anyString(), any(Serializer.class)))
                 .thenThrow(new IllegalStateException("invalid state store"));
         producerCallback.onCompletion(metadata, null);
+        executor.shutdown();
+        executor.awaitTermination(2, TimeUnit.SECONDS);
         ArgumentCaptor<LHApiException> errorCaptor = ArgumentCaptor.forClass(LHApiException.class);
         verify(responseObserver).onError(errorCaptor.capture());
         LHApiException apiException = errorCaptor.getValue();


### PR DESCRIPTION
As per the documentation, Kafka producer callbacks should not execute heavy operation on the `onCompletion` because they run in the producer network thread [More details here](https://kafka.apache.org/39/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send(org.apache.kafka.clients.producer.ProducerRecord,org.apache.kafka.clients.producer.Callback))

