### PR TITLE
fix(sdk-go): Change `NodeOutput.Timeout` arg to `int64`

### DIFF
--- a/sdk-go/littlehorse/wf_lib_internal.go
+++ b/sdk-go/littlehorse/wf_lib_internal.go
@@ -1054,7 +1054,7 @@ func (t *WorkflowThread) overrideTaskExponentialBackoffPolicy(taskNodeOutput *Ta
 	node.GetTask().ExponentialBackoff = policy
 }
 
-func (t *WorkflowThread) addTimeoutToExtEvt(nodeOutput *NodeOutput, timeoutSeconds int) {
+func (t *WorkflowThread) addTimeoutToExtEvt(nodeOutput *NodeOutput, timeoutSeconds int64) {
 	t.checkIfIsActive()
 
 	node := t.spec.Nodes[nodeOutput.nodeName]

--- a/sdk-go/littlehorse/wf_lib_public.go
+++ b/sdk-go/littlehorse/wf_lib_public.go
@@ -104,7 +104,7 @@ func (n *NodeOutput) JsonPath(path string) NodeOutput {
 	return n.jsonPathImpl(path)
 }
 
-func (n *NodeOutput) Timeout(timeout int) *NodeOutput {
+func (n *NodeOutput) Timeout(timeout int64) *NodeOutput {
 	n.thread.addTimeoutToExtEvt(n, timeout)
 	return n
 }


### PR DESCRIPTION
We should use the same type of `int` in our public SDK methods as is used at the `proto` level for transparency purposes.