### PR TITLE
fix(sdk-go): Catch nil interface early when converting to var val

### DIFF
--- a/sdk-go/littlehorse/lh_variables.go
+++ b/sdk-go/littlehorse/lh_variables.go
@@ -3,9 +3,10 @@ package littlehorse
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 	"reflect"
 	"strconv"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 )
 
 func StrToVarVal(input string, varType lhproto.VariableType) (*lhproto.VariableValue, error) {
@@ -143,6 +144,10 @@ func GetVarType(thing interface{}) *lhproto.VariableType {
 }
 
 func InterfaceToVarVal(someInterface interface{}) (*lhproto.VariableValue, error) {
+	if someInterface == nil {
+		return &lhproto.VariableValue{}, nil
+	}
+
 	out := &lhproto.VariableValue{}
 	var err error
 
@@ -152,9 +157,6 @@ func InterfaceToVarVal(someInterface interface{}) (*lhproto.VariableValue, error
 	}
 
 	isPtr, _ := GetIsPtrAndType(reflect.TypeOf(someInterface))
-	if someInterface == nil {
-		return &lhproto.VariableValue{}, nil
-	}
 
 	var actualThing interface{}
 	if isPtr {


### PR DESCRIPTION
We use the `InterfaceToVarVal` method to attempt to convert any value to a VariableValue, performing many steps along the way.

One of those steps checks if the value is a Pointer or not. When performing that step, if the value is `nil`, the program crashes with the following error message:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xa8 pc=0x1047e7dc0]
```

To solve this, we can return early if the value is `nil`.