### PR TITLE
fix(dashboard): retrieve parent wf variables

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
@@ -2,19 +2,29 @@
 import { Diagram } from '@/app/(authenticated)/[tenantId]/(diagram)/components/Diagram'
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
 import { useSearchParams } from 'next/navigation'
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 import { Details } from './Details'
 import { Variables } from './Variables'
 import { useWfRun } from '@/app/hooks/useWfRun'
+import { WfRunVariableAccessLevel } from 'littlehorse-client/proto'
+import { isExternal } from 'util/types'
+
 export const WfRun: FC<{ id: string, tenantId: string }> = ({ id, tenantId }) => {
   const searchParams = useSearchParams()
   const threadRunNumber = Number(searchParams.get('threadRunNumber'))
   const { wfRunData, isLoading, isError } = useWfRun({ id: id, tenantId })
+  const { wfRunData: parentWfRunData } = useWfRun({ id: wfRunData?.wfRun?.id?.parentWfRunId?.id ?? '', tenantId })
 
   if (!wfRunData) return null
   const { wfRun, wfSpec, nodeRuns, variables } = wfRunData;
 
   if (!wfRun) return null
+  if (!wfRun.id?.parentWfRunId || !parentWfRunData) return null
+
+  const variableDefs = wfSpec.threadSpecs[wfRun.threadRuns[threadRunNumber].threadSpecName].variableDefs;
+  const inheritedVariables = variableDefs.filter(vD => vD.accessLevel === WfRunVariableAccessLevel.INHERITED_VAR).map(vD => {
+    return parentWfRunData.variables.find(v => v.id?.name === vD.varDef?.name)!
+  });
 
   return (
     <div className="mb-16">
@@ -27,7 +37,7 @@ export const WfRun: FC<{ id: string, tenantId: string }> = ({ id, tenantId }) =>
 
       <Variables
         variableDefs={wfSpec.threadSpecs[wfRun.threadRuns[threadRunNumber].threadSpecName].variableDefs}
-        variables={variables.filter(v => v.id?.threadRunNumber == Number(searchParams.get('threadRunNumber')))}
+        variables={variables.filter(v => v.id?.threadRunNumber == Number(searchParams.get('threadRunNumber'))).concat(inheritedVariables)}
       />
     </div>
   )

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/page.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/page.tsx
@@ -7,7 +7,7 @@ import { getWfRun } from '../../../../../actions/getWfRun'
 type Props = { params: { ids: string[]; tenantId: string } }
 
 export default async function Page({ params: { ids, tenantId } }: Props) {
-  const id = ids[0];
+  const id = ids.join('_');
   try {
     return <WfRun id={id} tenantId={tenantId} />
   } catch (error) {


### PR DESCRIPTION
resolves #890 

### Description
- Fixed url param accessing for child workflows
- If parent workflow exists, retrieve its variables and display them

### Screenshot
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/882dbf1d-f46d-4f85-8881-dfc3a63026df" />