### PR TITLE
fix(sdk-go): trim space on boolean on StrToVarVal

### DIFF
--- a/sdk-go/littlehorse/lh_variables.go
+++ b/sdk-go/littlehorse/lh_variables.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 )
@@ -49,7 +50,7 @@ func StrToVarVal(input string, varType lhproto.VariableType) (*lhproto.VariableV
 
 	case lhproto.VariableType_BOOL:
 		var tmp bool
-		tmp, err = strconv.ParseBool(input)
+		tmp, err = strconv.ParseBool(strings.TrimSpace(input))
 		if err == nil {
 			out.Value = &lhproto.VariableValue_Bool{Bool: tmp}
 		}


### PR DESCRIPTION
resolves #1035
