### PR TITLE
chore(dashboard): pins nginx-nodejs image to version v1

### DIFF
--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/littlehorse-enterprises/alpine-nginx-nodejs/nginx-nodejs:main as runner
+FROM ghcr.io/littlehorse-enterprises/alpine-nginx-nodejs/nginx-nodejs:v1 as runner
 ENV NODE_ENV production
 
 RUN apk add --no-cache uuidgen


### PR DESCRIPTION
Pins `ghcr.io/littlehorse-enterprises/alpine-nginx-nodejs/nginx-nodejs` to version `v1`. It's a good practice to pin the version of the artifacts to avoid unintentionally using a recently released version that might contain errors. It helps to keep builds consistent.