### PR TITLE
fix(sdk-dotnet): add jsonpath to nodeoutput

### DIFF
--- a/sdk-dotnet/Examples/ExternalEventExample/README.md
+++ b/sdk-dotnet/Examples/ExternalEventExample/README.md
@@ -1,0 +1,33 @@
+## Running ExternalEventExample
+
+This example demonstrates the asynchronous ExternalEvent functionality.
+We will use "thread.waitForEvent" to wait for an external event, then when it arrives
+it executes the task "greet".
+
+Let's run the example in `ExternalEventExample`
+
+```
+dotnet build
+dotnet run
+```
+
+In another terminal, use `lhctl` to run the workflow:
+
+```
+# Start workflow
+lhctl run example-external-event
+
+# Take the resulting workflow ID, and do:
+lhctl get wfRun <wf run id>
+
+# Note that it is 'RUNNING'. Next, post an external event using the following:
+lhctl postEvent <wf run id> name-event STR Obi-Wan
+
+# Then inspect the wfRun:
+# Note it is 'COMPLETED'
+lhctl get wfRun <wf run id>
+
+# Then inspect the output of the ExternalEvent and how it completed the nodeRun:
+lhctl get nodeRun <wf run id> 0 1
+lhctl get taskRun <wf run id> <task runid>
+```

--- a/sdk-dotnet/LittleHorse.Sdk/Workflow/Spec/NodeOutput.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Workflow/Spec/NodeOutput.cs
@@ -19,6 +19,7 @@ public class NodeOutput
             throw new Exception("Cannot use jsonpath() twice on same node!");
         }
         var nodeOutput = new NodeOutput(NodeName, Parent);
+        nodeOutput.JsonPath = path;
         JsonPath = path;
         
         return nodeOutput;


### PR DESCRIPTION
- There were problems with a conditional thread, for a wrong variable was assigned when I used a JsonPath.

Variable assigment with problem: 

![image](https://github.com/user-attachments/assets/4c8b29a1-0aa3-4333-bb86-cf7d225d88ff)

Fixed:
![image](https://github.com/user-attachments/assets/43a6a5af-7db0-4e64-aa84-5fcc4209355f)
