### PR TITLE
fix(canary): change wf status retryable conditions

### DIFF
--- a/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeGetWfRunExecutor.java
+++ b/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeGetWfRunExecutor.java
@@ -99,13 +99,15 @@ public class MetronomeGetWfRunExecutor {
         // send beat and exit
         sendBeat(id, status, latency);
 
-        if (status.equals(LHStatus.COMPLETED)) {
-            repository.delete(id);
-            return;
+        // for debug reasons
+        if (!status.equals(LHStatus.COMPLETED)) {
+            log.error("GetWfRun returns workflow error {} {}", id, status);
         }
 
-        // log in case of error
-        log.error("GetWfRun returns workflow error {} {}", id, status);
+        // only running WFs are retryable, the others are deleted
+        if (!status.equals(LHStatus.RUNNING)) {
+            repository.delete(id);
+        }
     }
 
     private void sendBeat(final String id, final LHStatus status, final Duration latency) {
@@ -167,5 +169,6 @@ public class MetronomeGetWfRunExecutor {
                 .build();
 
         producer.send(beat);
+        repository.delete(id);
     }
 }


### PR DESCRIPTION
### Canary Retryable WfRuns

With this only WfRuns with status `RUNNING` are retryable. 

When the metronome registers an error it sends a beat with status error, the aggregator adds the total count of error. With this metric we can know how many error we detected in a period of time. But, workflows with status running could change the status so they need to be checked again until they change to any other status.


Co-authored-by: Mateo Rojas <mateo@littlehorse.io>