### PR TITLE
fix(dashboard): '.' replacement & conversions in form

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/WfRunForm.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/WfRunForm.tsx
@@ -2,7 +2,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ThreadVarDef } from 'littlehorse-client/proto'
 import { forwardRef } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FormProvider, useForm, UseFormRegister, FieldValues, FieldPath } from 'react-hook-form'
 import { FormFields } from './components/FormFields'
 
 export type FormValues = {
@@ -16,7 +16,7 @@ type Prop = {
 
 // eslint-disable-next-line react/display-name
 export const WfRunForm = forwardRef<HTMLFormElement, Prop>(({ wfSpecVariables, onSubmit }, ref) => {
-  const methods = useForm()
+  const methods = useForm<FormValues>()
   const { register, handleSubmit, formState } = methods
 
   const onSubmitForm = (data: FormValues) => {

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/BaseFormField.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/BaseFormField.tsx
@@ -5,6 +5,7 @@ import { FC, ReactNode } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { accessLevels } from '../../../wfSpec/[...props]/components/Variables'
 import { Button } from '@/components/ui/button'
+import { DOT_REPLACEMENT_PATTERN } from '../../Modals/ExecuteWorkflowRun'
 
 type BaseFormFieldProps = FormFieldProp & {
   children: ReactNode
@@ -43,7 +44,7 @@ export const BaseFormField: FC<BaseFormFieldProps> = ({
     <div>
       <div className="mb-2 flex justify-between">
         <Label htmlFor={name} className="flex items-center gap-2">
-          {name}
+          {name.replace(DOT_REPLACEMENT_PATTERN, ".")}
           <span className="rounded bg-green-300 p-1 text-xs">{accessLevels[accessLevel]}</span>
           {required ? (
             <span className="rounded bg-red-300 p-1 text-xs">Required</span>


### PR DESCRIPTION
resolves #1451

- Replace dots with a constant and unique string value

## Problem:

The issue was that `react-hook-form`'s naming conventions converts registered names with `.`'s in them to nested paths. The variable example in the original issue had a `.` in it, resulting in a weird incompatible object structure for the variable. This PR enables compatibility with `.`'s
![image](https://github.com/user-attachments/assets/64279397-5ca5-444b-806c-39fbbdb0c9ed)