### PR TITLE
fix(dashboard): disallow negative durations

### DIFF
--- a/dashboard/src/app/utils/dateTime.ts
+++ b/dashboard/src/app/utils/dateTime.ts
@@ -42,6 +42,9 @@ export const formatTime = (seconds: number | undefined): string => {
 }
 
 export function formatDuration(durationMs: number) {
+  // Negative durations don't make sense, so we clamp them at 0
+  durationMs = Math.max(durationMs, 0)
+
   let durationDisplay
   if (durationMs < 1000) {
     durationDisplay = `${durationMs} ms`


### PR DESCRIPTION
- Make `0` the minimum value for durations
<img width="316" alt="image" src="https://github.com/user-attachments/assets/81e796e9-cf7c-430a-99cc-e104b6fb6965" />
