### PR TITLE
fix(github): Revise issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/03-documentation.yml
@@ -1,4 +1,4 @@
-name: 📖 Documentation
+name: 📚 Documentation
 description: Suggest an improvement or report an issue relating to our documentation.
 type: "task"
 labels: ["documentation"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: 🌍 Community Slack
     url: https://launchpass.com/littlehorsecommunity/free
     about: Join our Community Slack to get real time support and connect with other LittleHorse users!
-  - name: 💬 Discussions
-    url: https://github.com/littlehorse-enterprises/littlehorse/discussions
-    about: Open a discussion! Useful for open-ended conversations and community engagement.


### PR DESCRIPTION
Quick PR to revise the issue templates.

- Removes a link to discussions that made the menu look bloated
- Replaces documentation emoji for better contrast