### PR TITLE
perf(server): avoid sending extra writes to rocksdb

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
+++ b/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
@@ -181,7 +181,7 @@ public class GetableManager extends ReadOnlyGetableManager {
             String storeableKey = entry.getKey();
             GetableToStore<?, ?> entity = entry.getValue();
 
-            if (entity.getObjectToStore() != null) {
+            if (entity.containsUpdate()) {
                 // Actually put it in the key-value store.
                 // Note: we know this is a CoreGetable, but no need to cast, so
                 // we use AbstractGetable here.
@@ -189,7 +189,7 @@ public class GetableManager extends ReadOnlyGetableManager {
                 store.put(new StoredGetable<>(getable));
                 tagStorageManager.store(getable.getIndexEntries(), entity.getTagsPresentBeforeUpdate());
 
-            } else {
+            } else if (entity.isDeletion()) {
                 // Do a deletion!
                 store.delete(storeableKey, StoreableType.STORED_GETABLE);
                 tagStorageManager.store(List.of(), entity.getTagsPresentBeforeUpdate());

--- a/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableToStore.java
+++ b/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableToStore.java
@@ -22,12 +22,25 @@ public class GetableToStore<U extends Message, T extends AbstractGetable<U>> {
 
     private T objectToStore;
 
+    private U previouslyStoredProto;
+
+    public boolean isDeletion() {
+        return objectToStore == null;
+    }
+
+    public boolean containsUpdate() {
+        return objectToStore != null && !objectToStore.toProto().build().equals(previouslyStoredProto);
+    }
+
+    @SuppressWarnings("unchecked")
     public GetableToStore(StoredGetable<U, T> thingInStore, Class<T> cls) {
         this.objectType = AbstractGetable.getTypeEnum(cls);
 
         if (thingInStore != null) {
             this.tagsPresentBeforeUpdate = thingInStore.getIndexCache();
             this.objectToStore = thingInStore.getStoredObject();
+            this.previouslyStoredProto =
+                    (U) (thingInStore.getStoredObject().toProto().build());
         } else {
             this.tagsPresentBeforeUpdate = new TagsCache(List.of());
         }

--- a/server/src/test/java/io/littlehorse/storeinternals/GetableManagerTest.java
+++ b/server/src/test/java/io/littlehorse/storeinternals/GetableManagerTest.java
@@ -452,4 +452,109 @@ public class GetableManagerTest {
                 Arguments.of(variable, 3),
                 Arguments.of(externalEvent, 4));
     }
+
+    @Test
+    void dontStoreGetableWhenNotModified() {
+        String varName = "my-str";
+        String wfRunId = "my-wf-run-id";
+        String valueBefore = "valueBefore";
+        String anotherValue = "anotherValue";
+        VariableModel actualVariable = TestUtil.variable(wfRunId);
+        actualVariable.getId().setName(varName);
+        actualVariable.setValue(new VariableValueModel(valueBefore));
+        actualVariable.getWfSpec().getThreadSpecs().forEach((s, threadSpec) -> {
+            VariableDefModel variableDef1 = new VariableDefModel();
+            variableDef1.setName(varName);
+            variableDef1.setType(VariableType.STR);
+            threadSpec.setVariableDefs(
+                    List.of(new ThreadVarDefModel(variableDef1, true, false, WfRunVariableAccessLevel.PRIVATE_VAR)));
+        });
+
+        VariableModel anotherVariable = TestUtil.variable(wfRunId);
+        anotherVariable.getId().setName(varName);
+        anotherVariable.setValue(new VariableValueModel(anotherValue));
+        anotherVariable.setWfSpec(actualVariable.getWfSpec());
+
+        // As setup, we store the actual variable.
+        getableManager.put(actualVariable);
+        getableManager.commit();
+
+        // Sanity check that the variable has the "valueBefore"
+        String key = new StoredGetable(actualVariable).getStoreKey();
+        StoredGetable storedVariable = localStoreWrapper.get(key, StoredGetable.class);
+        assertThat(storedVariable).isNotNull();
+        assertThat(((VariableModel) storedVariable.getStoredObject()).getValue().getStrVal())
+                .isEqualTo(valueBefore);
+
+        // Now we "process another command" that reads the variable but doesn't modify it
+        getableManager.get(actualVariable.getObjectId());
+
+        // bypass the security of the test by corrupting it
+        StoredGetable fakeOne = new StoredGetable(anotherVariable);
+        localStoreWrapper.put(fakeOne);
+
+        // Commit the getable manager. If everything goes well, it won't have called put() on the actualVariable,
+        // so we should still see the "anotherValue" which we put two lines above.
+        getableManager.commit();
+        StoredGetable storedVariableAfterCommit = localStoreWrapper.get(key, StoredGetable.class);
+        assertThat(storedVariableAfterCommit).isNotNull();
+        assertThat(((VariableModel) storedVariableAfterCommit.getStoredObject())
+                        .getValue()
+                        .getStrVal())
+                .isEqualTo(anotherValue);
+    }
+
+    @Test
+    void doStoreGetableWhenModified() {
+        String varName = "my-str";
+        String wfRunId = "my-wf-run-id";
+        String valueBefore = "valueBefore";
+        String valueAfterModify = "valueAfterModify";
+        String anotherValue = "anotherValue";
+        VariableModel actualVariable = TestUtil.variable(wfRunId);
+        actualVariable.getId().setName(varName);
+        actualVariable.setValue(new VariableValueModel(valueBefore));
+        actualVariable.getWfSpec().getThreadSpecs().forEach((s, threadSpec) -> {
+            VariableDefModel variableDef1 = new VariableDefModel();
+            variableDef1.setName(varName);
+            variableDef1.setType(VariableType.STR);
+            threadSpec.setVariableDefs(
+                    List.of(new ThreadVarDefModel(variableDef1, true, false, WfRunVariableAccessLevel.PRIVATE_VAR)));
+        });
+
+        VariableModel anotherVariable = TestUtil.variable(wfRunId);
+        anotherVariable.getId().setName(varName);
+        anotherVariable.setValue(new VariableValueModel(anotherValue));
+        anotherVariable.setWfSpec(actualVariable.getWfSpec());
+
+        // As setup, we store the actual variable.
+        getableManager.put(actualVariable);
+        getableManager.commit();
+
+        // Sanity check that the variable has the "valueBefore"
+        String key = new StoredGetable(actualVariable).getStoreKey();
+        StoredGetable storedVariable = localStoreWrapper.get(key, StoredGetable.class);
+        assertThat(storedVariable).isNotNull();
+        assertThat(((VariableModel) storedVariable.getStoredObject()).getValue().getStrVal())
+                .isEqualTo(valueBefore);
+
+        // Now we "process another command" that reads the variable and do modify the value
+        VariableModel variableDuringProcess = getableManager.get(actualVariable.getObjectId());
+        variableDuringProcess.setWfSpec(actualVariable.getWfSpec());
+        variableDuringProcess.setValue(new VariableValueModel(valueAfterModify));
+
+        // bypass the security of the test by corrupting it
+        StoredGetable fakeOne = new StoredGetable(anotherVariable);
+        localStoreWrapper.put(fakeOne);
+
+        // Commit the getable manager. If everything goes well, it will notice that we modified the variable
+        // and will save it.
+        getableManager.commit();
+        StoredGetable storedVariableAfterCommit = localStoreWrapper.get(key, StoredGetable.class);
+        assertThat(storedVariableAfterCommit).isNotNull();
+        assertThat(((VariableModel) storedVariableAfterCommit.getStoredObject())
+                        .getValue()
+                        .getStrVal())
+                .isEqualTo(valueAfterModify);
+    }
 }


### PR DESCRIPTION
In the GetableManager#commit() method, we previously put every single GetableToStore into rocksdb. THat's problematic because when we *read* a getable without modifying it, it ends up inside the buffer. This PR reduces the writes to RocksDB by saving the previous protobuf and comparing to the protobuf at the time of commit. This costs a bit more CPU at the server-side but reduces the number of writes to rocksdb.