### PR TITLE
fix(sdk-go):jsonpath to return reference to wfRunVariable and return correct varType

### DIFF
--- a/sdk-go/littlehorse/wf_lib_internal.go
+++ b/sdk-go/littlehorse/wf_lib_internal.go
@@ -643,7 +643,7 @@ func (w *WfRunVariable) withAccessLevel(accessLevel lhproto.WfRunVariableAccessL
 	return *w
 }
 
-func (w *WfRunVariable) jsonPathImpl(path string) WfRunVariable {
+func (w *WfRunVariable) jsonPathImpl(path string) *WfRunVariable {
 	if w.jsonPath != nil {
 		w.thread.throwError(
 			errors.New("Variable " + w.Name + " was jsonpath'ed twice!"),
@@ -654,10 +654,10 @@ func (w *WfRunVariable) jsonPathImpl(path string) WfRunVariable {
 			"Cannot jsonpath on var of type " + w.VarType.String(),
 		))
 	}
-	return WfRunVariable{
+	return &WfRunVariable{
 		Name:     w.Name,
 		thread:   w.thread,
-		VarType:  nil,
+		VarType:  w.VarType,
 		jsonPath: &path,
 	}
 }

--- a/sdk-go/littlehorse/wf_lib_public.go
+++ b/sdk-go/littlehorse/wf_lib_public.go
@@ -2,6 +2,7 @@ package littlehorse
 
 import (
 	"errors"
+
 	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 )
 
@@ -214,7 +215,7 @@ func (w *WfRunVariable) WithDefault(defaultValue interface{}) *WfRunVariable {
 	return w.withDefaultImpl(defaultValue)
 }
 
-func (w *WfRunVariable) JsonPath(path string) WfRunVariable {
+func (w *WfRunVariable) JsonPath(path string) *WfRunVariable {
 	return w.jsonPathImpl(path)
 }
 


### PR DESCRIPTION
Fixes #1526 

Changes the return value of `*wfRunVariable.Jsonpath() ` to ` *wfRunVariable`  

Changes ` varType` return value from nil to `w.varType`