### PR TITLE
feat(sdk-go): Throw error when `WorkerContext` used as param without ptr

### DIFF
--- a/sdk-go/littlehorse/task_func_signature.go
+++ b/sdk-go/littlehorse/task_func_signature.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 	"reflect"
 	"strings"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/lhproto"
 )
 
 type TaskFuncArg struct {
@@ -40,10 +41,14 @@ func NewTaskSignature(taskFunc interface{}) (*TaskFuncSignature, error) {
 	for i := 0; i < fnType.NumIn(); i++ {
 		argType := fnType.In(i)
 		argName := fnType.In(i).Name()
-		if argType.Kind() == reflect.Ptr && argType.Elem().Name() == "WorkerContext" {
+		if argType.Name() == "WorkerContext" {
+			if argType.Kind() != reflect.Ptr {
+				return nil, errors.New("worker context parameter must be a pointer")
+			}
+
 			if i+1 != fnType.NumIn() {
 				return nil, errors.New(
-					"Can only have WorkerContext as the last parameter.",
+					"can only have worker context as the last parameter",
 				)
 			} else {
 				out.hasWorkerContextAtEnd = true

--- a/sdk-go/littlehorse/task_func_signature_test.go
+++ b/sdk-go/littlehorse/task_func_signature_test.go
@@ -1,0 +1,57 @@
+package littlehorse_test
+
+import (
+	"errors"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/littlehorse-enterprises/littlehorse/sdk-go/littlehorse"
+	"github.com/stretchr/testify/assert"
+)
+
+func Task(name string) string {
+	return ""
+}
+
+func TaskUsesWorkerContext(name string, wc *littlehorse.WorkerContext) string {
+	return ""
+}
+
+func TaskUsesNonPointerWorkerContext(name string, wc littlehorse.WorkerContext) string {
+	return ""
+}
+
+func TestNewTaskSignature(t *testing.T) {
+	taskSig, err := littlehorse.NewTaskSignature(Task)
+
+	assert.Nil(t, err)
+	assert.Equal(t, littlehorse.TaskFuncArg{Name: "string", Type: reflect.TypeOf(""), Position: 0}, taskSig.Args[0])
+	assert.Equal(t, reflect.TypeOf(""), *taskSig.OutputType)
+}
+
+func TestNewTaskSignatureWithWorkerContext(t *testing.T) {
+	taskSig, err := littlehorse.NewTaskSignature(TaskUsesWorkerContext)
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(taskSig.Args), 1)
+	assert.Equal(t, littlehorse.TaskFuncArg{Name: "string", Type: reflect.TypeOf(""), Position: 0}, taskSig.Args[0])
+	assert.Equal(t, reflect.TypeOf(""), taskSig.OutputType)
+}
+
+func TestTaskSigThrowsErrorWithNonPointerWorkerContext(t *testing.T) {
+	_, err := littlehorse.NewTaskSignature(TaskUsesNonPointerWorkerContext)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, errors.New("worker context parameter must be a pointer").Error())
+}
+
+// Logs the Task Signature, useful for debugging
+func LogTaskSig(taskSig *littlehorse.TaskFuncSignature) {
+	for _, arg := range taskSig.Args {
+		log.Printf("Name: %s", arg.Name)
+		log.Printf("Type: %s", arg.Type.Name())
+		log.Printf("Type.PkgPath: %s", arg.Type.PkgPath())
+		log.Printf("Position: %d", arg.Position)
+	}
+}

--- a/sdk-go/littlehorse/task_func_signature_test.go
+++ b/sdk-go/littlehorse/task_func_signature_test.go
@@ -36,7 +36,7 @@ func TestNewTaskSignatureWithWorkerContext(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(taskSig.Args), 1)
 	assert.Equal(t, littlehorse.TaskFuncArg{Name: "string", Type: reflect.TypeOf(""), Position: 0}, taskSig.Args[0])
-	assert.Equal(t, reflect.TypeOf(""), taskSig.OutputType)
+	assert.Equal(t, reflect.TypeOf(""), *taskSig.OutputType)
 }
 
 func TestTaskSigThrowsErrorWithNonPointerWorkerContext(t *testing.T) {


### PR DESCRIPTION
@Jake brought up a good question in issue #1531:
> Why doesn't the `WorkerContext` parameter work in `sdk-go` when used like this:
>
> ```go
> func TaskUsesNonPointerWorkerContext(name string, wc littlehorse.WorkerContext) string {}
> ```

This is because we require the parameter to be a pointer to a `WorkerContext`. It needs to be a pointer to a `WorkerContext` so that the user can call `WorkerContext#Log()` from within a Task and we can handle those messages from up above in the Task Worker.

It can be confusing, however, that the sdk-go accepts `littlehorse.WorkerContext` without a pointer as a valid parameter, so I wrote this PR to add an error message and some test cases around this behavior.

-------------------------

Adds an error message for #1531