### PR TITLE
fix(dashboard): Don't enforce `JSON_ARR` to include objects

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/validation.ts
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/validation.ts
@@ -16,7 +16,7 @@ export const getValidation = (type: string) => {
       if (!value) return true
       try {
         const parsed = JSON.parse(value)
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'object')) {
+        if (Array.isArray(parsed)) {
           return true
         }
         return 'Input must be an array of objects'

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/validation.ts
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/validation.ts
@@ -19,7 +19,7 @@ export const getValidation = (type: string) => {
         if (Array.isArray(parsed)) {
           return true
         }
-        return 'Input must be an array of objects'
+        return 'Input must be an array'
       } catch {
         return 'Input must be valid JSON'
       }


### PR DESCRIPTION
Removes condition placed on `JSON_ARR` inputs in the `Execute` `WfRun` form because not all Array items are guaranteed to be objects. 

For instance, the following JSON_ARR would fail the input validation because it has items of `String`s and not `Object`s:

```
["hello", "world"]
```