### PR TITLE
feat(sdk-python): Add `WorkflowThread#complete()`

### DIFF
--- a/sdk-python/examples/parallel_approvals/parallel_approvals.py
+++ b/sdk-python/examples/parallel_approvals/parallel_approvals.py
@@ -7,7 +7,9 @@ from littlehorse.config import LHConfig
 from littlehorse.model import (
     VariableType,
     Comparator,
-    VariableMutationType, PutUserTaskDefRequest, UserTaskField,
+    VariableMutationType,
+    PutUserTaskDefRequest,
+    UserTaskField,
 )
 from littlehorse.workflow import WorkflowThread, Workflow
 
@@ -67,6 +69,7 @@ def get_workflow() -> Workflow:
 
     return Workflow("parallel-approvals-v2", my_entrypoint)
 
+
 def get_user_task_approval_def() -> PutUserTaskDefRequest:
     return PutUserTaskDefRequest(
         name="approve-task",
@@ -76,9 +79,9 @@ def get_user_task_approval_def() -> PutUserTaskDefRequest:
                 description="Is the status completed for approval?",
                 display_name="Approval",
                 required=True,
-                type=VariableType.BOOL
+                type=VariableType.BOOL,
             )
-        ]
+        ],
     )
 
 

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1874,7 +1874,7 @@ class WorkflowThread:
                 self._last_node_condition = None
             elif node_type != NodeCase.NOP:
                 raise TypeError(
-                    f"You cannot add a Node in a given thread after the thread has completed."
+                    "You cannot add a Node in a given thread after the thread has completed."
                 )
 
         self._nodes.append(WorkflowNode(next_node_name, node_type, sub_node))

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -1528,7 +1528,7 @@ class WorkflowThread:
             ),
         )
 
-    def complete(self):
+    def complete(self) -> None:
         """Adds an Exit Node, returning from the WorkflowThread early"""
         self._check_if_active()
         self.add_node("complete", ExitNode())

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -667,8 +667,10 @@ class WfRunVariable:
         if last_thread.is_active:
             active_thread = last_thread
 
-        if last_thread._last_node().node_case == NodeCase.EXIT: 
-            raise TypeError("You cannot assign a variable in a given thread after the thread has completed.")
+        if last_thread._last_node().node_case == NodeCase.EXIT:
+            raise TypeError(
+                "You cannot assign a variable in a given thread after the thread has completed."
+            )
 
         active_thread.mutate(self, VariableMutationType.ASSIGN, rhs)
 
@@ -1799,8 +1801,10 @@ class WorkflowThread:
         """
         self._check_if_active()
 
-        if (len(self._nodes) > 0 and self._last_node().node_case == NodeCase.EXIT):
-            raise TypeError("You cannot add a variable in a given thread after the thread has completed.")
+        if len(self._nodes) > 0 and self._last_node().node_case == NodeCase.EXIT:
+            raise TypeError(
+                "You cannot add a variable in a given thread after the thread has completed."
+            )
 
         for var in self._wf_run_variables:
             if var.name == variable_name:
@@ -1854,7 +1858,7 @@ class WorkflowThread:
 
         if len(self._nodes) == 0 and node_type != NodeCase.ENTRYPOINT:
             raise TypeError("The first node should be a EntrypointNode")
-        
+
         if len(self._nodes) > 0:
             last_node = self._last_node()
 
@@ -1868,7 +1872,9 @@ class WorkflowThread:
                 )
                 self._last_node_condition = None
             elif node_type != NodeCase.NOP:
-                raise TypeError(f"You cannot add a Node in a given thread after the thread has completed.")
+                raise TypeError(
+                    f"You cannot add a Node in a given thread after the thread has completed."
+                )
 
         self._nodes.append(WorkflowNode(next_node_name, node_type, sub_node))
         self._last_node_name = next_node_name

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -667,6 +667,9 @@ class WfRunVariable:
         if last_thread.is_active:
             active_thread = last_thread
 
+        if last_thread._last_node().node_case == NodeCase.EXIT: 
+            raise TypeError("You cannot assign a variable in a given thread after the thread has completed.")
+
         active_thread.mutate(self, VariableMutationType.ASSIGN, rhs)
 
     def add(self, other: Any) -> LHExpression:
@@ -1795,6 +1798,10 @@ class WorkflowThread:
             WfRunVariable: A handle to the created WfRunVariable.
         """
         self._check_if_active()
+
+        if (len(self._nodes) > 0 and self._last_node().node_case == NodeCase.EXIT):
+            raise TypeError("You cannot add a variable in a given thread after the thread has completed.")
+
         for var in self._wf_run_variables:
             if var.name == variable_name:
                 raise ValueError(f"Variable {variable_name} already added")
@@ -1847,7 +1854,7 @@ class WorkflowThread:
 
         if len(self._nodes) == 0 and node_type != NodeCase.ENTRYPOINT:
             raise TypeError("The first node should be a EntrypointNode")
-
+        
         if len(self._nodes) > 0:
             last_node = self._last_node()
 
@@ -1860,6 +1867,8 @@ class WorkflowThread:
                     )
                 )
                 self._last_node_condition = None
+            elif node_type != NodeCase.NOP:
+                raise TypeError(f"You cannot add a Node in a given thread after the thread has completed.")
 
         self._nodes.append(WorkflowNode(next_node_name, node_type, sub_node))
         self._last_node_name = next_node_name

--- a/sdk-python/littlehorse/workflow.py
+++ b/sdk-python/littlehorse/workflow.py
@@ -667,11 +667,6 @@ class WfRunVariable:
         if last_thread.is_active:
             active_thread = last_thread
 
-        if last_thread._last_node().node_case == NodeCase.EXIT:
-            raise TypeError(
-                "You cannot assign a variable in a given thread after the thread has completed."
-            )
-
         active_thread.mutate(self, VariableMutationType.ASSIGN, rhs)
 
     def add(self, other: Any) -> LHExpression:
@@ -1752,6 +1747,12 @@ class WorkflowThread:
             use the output of a Node Run to mutate variables).
         """
         self._check_if_active()
+
+        if self._last_node().node_case == NodeCase.EXIT:
+            raise TypeError(
+                "You cannot mutate a variable in a given thread after the thread has completed."
+            )
+
         node_output: Optional[VariableMutation.NodeOutputSource] = None
         literal_value: Optional[VariableValue] = None
         rhs_assignment = to_variable_assignment(right_hand)

--- a/sdk-python/tests/test_worker.py
+++ b/sdk-python/tests/test_worker.py
@@ -171,7 +171,14 @@ class TestLHTask(unittest.TestCase):
 
         task = LHTask(
             my_method,
-            TaskDef(input_vars=[VariableDef(name="param", type_def=TypeDefinition(type=VariableType.STR, masked=False))]),
+            TaskDef(
+                input_vars=[
+                    VariableDef(
+                        name="param",
+                        type_def=TypeDefinition(type=VariableType.STR, masked=False),
+                    )
+                ]
+            ),
         )
 
         self.assertFalse(task.has_context())
@@ -215,8 +222,14 @@ class TestLHTask(unittest.TestCase):
 
         task_def = TaskDef(
             input_vars=[
-                VariableDef(name="paramA", type_def=TypeDefinition(type=VariableType.STR, masked=False)),
-                VariableDef(name="paramB", type_def=TypeDefinition(type=VariableType.INT, masked=False)),
+                VariableDef(
+                    name="paramA",
+                    type_def=TypeDefinition(type=VariableType.STR, masked=False),
+                ),
+                VariableDef(
+                    name="paramB",
+                    type_def=TypeDefinition(type=VariableType.INT, masked=False),
+                ),
             ]
         )
 
@@ -231,8 +244,14 @@ class TestLHTask(unittest.TestCase):
 
         task_def = TaskDef(
             input_vars=[
-                VariableDef(name="param2", type_def=TypeDefinition(type=VariableType.INT, masked=False)),
-                VariableDef(name="param1", type_def=TypeDefinition(type=VariableType.STR, masked=False)),
+                VariableDef(
+                    name="param2",
+                    type_def=TypeDefinition(type=VariableType.INT, masked=False),
+                ),
+                VariableDef(
+                    name="param1",
+                    type_def=TypeDefinition(type=VariableType.STR, masked=False),
+                ),
             ]
         )
 
@@ -250,8 +269,14 @@ class TestLHTask(unittest.TestCase):
 
         task_def = TaskDef(
             input_vars=[
-                VariableDef(name="param1", type_def=TypeDefinition(type=VariableType.STR, masked=False)),
-                VariableDef(name="param2", type_def=TypeDefinition(type=VariableType.INT, masked=False)),
+                VariableDef(
+                    name="param1",
+                    type_def=TypeDefinition(type=VariableType.STR, masked=False),
+                ),
+                VariableDef(
+                    name="param2",
+                    type_def=TypeDefinition(type=VariableType.INT, masked=False),
+                ),
             ]
         )
 
@@ -269,8 +294,14 @@ class TestLHTask(unittest.TestCase):
 
         task_def = TaskDef(
             input_vars=[
-                VariableDef(name="param1", type_def=TypeDefinition(type=VariableType.STR, masked=False)),
-                VariableDef(name="param2", type_def=TypeDefinition(type=VariableType.INT, masked=False)),
+                VariableDef(
+                    name="param1",
+                    type_def=TypeDefinition(type=VariableType.STR, masked=False),
+                ),
+                VariableDef(
+                    name="param2",
+                    type_def=TypeDefinition(type=VariableType.INT, masked=False),
+                ),
             ]
         )
 
@@ -288,7 +319,12 @@ class TestLHTask(unittest.TestCase):
                 pass
 
             task_def = TaskDef(
-                input_vars=[VariableDef(name="param", type_def=TypeDefinition(type=variable_type, masked=False))]
+                input_vars=[
+                    VariableDef(
+                        name="param",
+                        type_def=TypeDefinition(type=variable_type, masked=False),
+                    )
+                ]
             )
 
             with self.assertRaises(TaskSchemaMismatchException):
@@ -312,7 +348,10 @@ class TestLHTask(unittest.TestCase):
 
             task_def = TaskDef(
                 input_vars=[
-                    VariableDef(name="param", type_def=TypeDefinition(type=variable_type, masked=False)),
+                    VariableDef(
+                        name="param",
+                        type_def=TypeDefinition(type=variable_type, masked=False),
+                    ),
                 ]
             )
 

--- a/sdk-python/tests/test_workflow.py
+++ b/sdk-python/tests/test_workflow.py
@@ -1508,8 +1508,6 @@ class TestThreadBuilder(unittest.TestCase):
 
     def test_wf_raises_error_when_adding_variable_after_completing_thread(self):
         def my_entrypoint(wf: WorkflowThread) -> None:
-            my_var = wf.declare_str("name")
-
             def if_body_a(body: WorkflowThread) -> None:
                 body.complete()
                 body.declare_str("test-var")
@@ -2079,41 +2077,59 @@ class TestThreadBuilder(unittest.TestCase):
     def test_should_compile_a_wf_with_does_contain_condition_comparing_variables(self):
         def my_entrypoint(thread: WorkflowThread) -> None:
             my_var = thread.declare_str("my-var")
-            thread.do_if(my_var.does_contain("this-value"), lambda wf: wf.execute("task"))
-
+            thread.do_if(
+                my_var.does_contain("this-value"), lambda wf: wf.execute("task")
+            )
 
         wf_spec = Workflow("test", my_entrypoint).compile()
         entrypoint = wf_spec.thread_specs[wf_spec.entrypoint_thread_name]
         actual_node = entrypoint.nodes["1-nop-NOP"]
         expected_node = Node(
             nop=NopNode(),
-            outgoing_edges=[Edge(sink_node_name="2-task-TASK",
-                                 condition=EdgeCondition(comparator=Comparator.IN,
-                                                         left=VariableAssignment(
-                                                             literal_value=VariableValue(str="this-value")),
-                                                         right=VariableAssignment(variable_name="my-var"))),
-                            Edge(sink_node_name="3-nop-NOP")],
+            outgoing_edges=[
+                Edge(
+                    sink_node_name="2-task-TASK",
+                    condition=EdgeCondition(
+                        comparator=Comparator.IN,
+                        left=VariableAssignment(
+                            literal_value=VariableValue(str="this-value")
+                        ),
+                        right=VariableAssignment(variable_name="my-var"),
+                    ),
+                ),
+                Edge(sink_node_name="3-nop-NOP"),
+            ],
         )
 
         self.assertEqual(expected_node, actual_node)
 
-    def test_should_compile_a_wf_with_does_not_contain_condition_comparing_variables(self):
+    def test_should_compile_a_wf_with_does_not_contain_condition_comparing_variables(
+        self,
+    ):
         def my_entrypoint(thread: WorkflowThread) -> None:
             my_var = thread.declare_str("my-var")
-            thread.do_if(my_var.does_not_contain("this-value"), lambda wf: wf.execute("task"))
-
+            thread.do_if(
+                my_var.does_not_contain("this-value"), lambda wf: wf.execute("task")
+            )
 
         wf_spec = Workflow("test", my_entrypoint).compile()
         entrypoint = wf_spec.thread_specs[wf_spec.entrypoint_thread_name]
         actual_node = entrypoint.nodes["1-nop-NOP"]
         expected_node = Node(
             nop=NopNode(),
-            outgoing_edges=[Edge(sink_node_name="2-task-TASK",
-                                 condition=EdgeCondition(comparator=Comparator.NOT_IN,
-                                                         left=VariableAssignment(
-                                                             literal_value=VariableValue(str="this-value")),
-                                                         right=VariableAssignment(variable_name="my-var"))),
-                            Edge(sink_node_name="3-nop-NOP")],
+            outgoing_edges=[
+                Edge(
+                    sink_node_name="2-task-TASK",
+                    condition=EdgeCondition(
+                        comparator=Comparator.NOT_IN,
+                        left=VariableAssignment(
+                            literal_value=VariableValue(str="this-value")
+                        ),
+                        right=VariableAssignment(variable_name="my-var"),
+                    ),
+                ),
+                Edge(sink_node_name="3-nop-NOP"),
+            ],
         )
 
         self.assertEqual(expected_node, actual_node)
@@ -2123,18 +2139,24 @@ class TestThreadBuilder(unittest.TestCase):
             my_var = thread.declare_str("my-var")
             thread.do_if(my_var.is_in(["A", "B", "C"]), lambda wf: wf.execute("task"))
 
-
         wf_spec = Workflow("test", my_entrypoint).compile()
         entrypoint = wf_spec.thread_specs[wf_spec.entrypoint_thread_name]
         actual_node = entrypoint.nodes["1-nop-NOP"]
         expected_node = Node(
             nop=NopNode(),
-            outgoing_edges=[Edge(sink_node_name="2-task-TASK",
-                                 condition=EdgeCondition(comparator=Comparator.IN,
-                                                         left=VariableAssignment(variable_name="my-var"),
-                                                         right=VariableAssignment(
-                                                             literal_value=VariableValue(json_arr="[\"A\", \"B\", \"C\"]"))),),
-                            Edge(sink_node_name="3-nop-NOP")],
+            outgoing_edges=[
+                Edge(
+                    sink_node_name="2-task-TASK",
+                    condition=EdgeCondition(
+                        comparator=Comparator.IN,
+                        left=VariableAssignment(variable_name="my-var"),
+                        right=VariableAssignment(
+                            literal_value=VariableValue(json_arr='["A", "B", "C"]')
+                        ),
+                    ),
+                ),
+                Edge(sink_node_name="3-nop-NOP"),
+            ],
         )
 
         self.assertEqual(expected_node, actual_node)
@@ -2142,20 +2164,28 @@ class TestThreadBuilder(unittest.TestCase):
     def test_should_compile_a_wf_with_not_in_condition_comparing_variables(self):
         def my_entrypoint(thread: WorkflowThread) -> None:
             my_var = thread.declare_str("my-var")
-            thread.do_if(my_var.is_not_in(["A", "B", "C"]), lambda wf: wf.execute("task"))
+            thread.do_if(
+                my_var.is_not_in(["A", "B", "C"]), lambda wf: wf.execute("task")
+            )
 
         wf_spec = Workflow("test", my_entrypoint).compile()
         entrypoint = wf_spec.thread_specs[wf_spec.entrypoint_thread_name]
         actual_node = entrypoint.nodes["1-nop-NOP"]
         expected_node = Node(
             nop=NopNode(),
-            outgoing_edges=[Edge(sink_node_name="2-task-TASK",
-                                 condition=EdgeCondition(comparator=Comparator.NOT_IN,
-                                                         left=VariableAssignment(variable_name="my-var"),
-                                                         right=VariableAssignment(
-                                                             literal_value=VariableValue(
-                                                                 json_arr="[\"A\", \"B\", \"C\"]"))), ),
-                            Edge(sink_node_name="3-nop-NOP")],
+            outgoing_edges=[
+                Edge(
+                    sink_node_name="2-task-TASK",
+                    condition=EdgeCondition(
+                        comparator=Comparator.NOT_IN,
+                        left=VariableAssignment(variable_name="my-var"),
+                        right=VariableAssignment(
+                            literal_value=VariableValue(json_arr='["A", "B", "C"]')
+                        ),
+                    ),
+                ),
+                Edge(sink_node_name="3-nop-NOP"),
+            ],
         )
 
         self.assertEqual(expected_node, actual_node)

--- a/server/src/test/java/e2e/ExternalEventTypingTest.java
+++ b/server/src/test/java/e2e/ExternalEventTypingTest.java
@@ -45,7 +45,7 @@ public class ExternalEventTypingTest {
         assertThatThrownBy(() -> {
                     client.putExternalEvent(PutExternalEventRequest.newBuilder()
                             .setExternalEventDefId(
-                                    ExternalEventDefId.newBuilder().setName("typed-external-event"))
+                                    ExternalEventDefId.newBuilder().setName("typed-as-int"))
                             .setWfRunId(id)
                             .setContent(LHLibUtil.objToVarVal("not-an-integer"))
                             .build());
@@ -53,7 +53,8 @@ public class ExternalEventTypingTest {
                 .matches(exn -> {
                     return exn instanceof StatusRuntimeException
                             && ((StatusRuntimeException) exn).getStatus().getCode() == Code.INVALID_ARGUMENT
-                            && exn.getMessage().toLowerCase().contains("typed-external-event");
+                            && exn.getMessage().toLowerCase().contains("typed-as-int")
+                            && exn.getMessage().toLowerCase().contains("invalid type");
                 });
     }
 


### PR DESCRIPTION
This PR adds the `complete()` method to `sdk-python`, which adds an ExitNode wherever it is used, allowing users to return early from a Workflow.

The previous implementation of `Do_If` and `Do_Else_If` code heavily depended on the idea that each Workflow has a singular sink vertex in the form of the last ExitNode (a Node with no OutgoingEdges). Therefore, that code had to be updated and the tests had to be expanded along with this PR.

You'll also notice from formatting changes to otherwise unchanged files from the linter.

