### PR TITLE
feat(server): Add Experimental Feature Flag for `StructDef`s

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -150,6 +150,8 @@ public class LHServerConfig extends ConfigBase {
     public static final String X_LEAVE_GROUP_ON_SHUTDOWN_KEY = "LHS_X_LEAVE_GROUP_ON_SHUTDOWN";
     public static final String X_USE_STATIC_MEMBERSHIP_KEY = "LHS_X_USE_STATIC_MEMBERSHIP";
 
+    public static final String X_ENABLE_STRUCT_DEFS_KEY = "LHS_X_ENABLE_STRUCT_DEFS";
+
     // Instance configs
     private final String lhsMetricsLevel;
 
@@ -1058,6 +1060,10 @@ public class LHServerConfig extends ConfigBase {
 
     public int getStreamsSessionTimeout() {
         return Integer.valueOf(getOrSetDefault(LHServerConfig.SESSION_TIMEOUT_KEY, "40000"));
+    }
+
+    public boolean areStructDefsEnabled() {
+        return Boolean.valueOf(getOrSetDefault(LHServerConfig.X_ENABLE_STRUCT_DEFS_KEY, "false"));
     }
 
     public int getNumNetworkThreads() {

--- a/server/src/main/java/io/littlehorse/server/LHServerListener.java
+++ b/server/src/main/java/io/littlehorse/server/LHServerListener.java
@@ -460,6 +460,9 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
     @Override
     @Authorize(resources = ACLResource.ACL_STRUCT, actions = ACLAction.READ)
     public void getStructDef(StructDefId req, StreamObserver<StructDef> ctx) {
+        if (serverConfig.areStructDefsEnabled() == false) {
+            throw new StatusRuntimeException(Status.UNIMPLEMENTED);
+        }
         StructDefModel sd = getServiceFromContext().getStructDef(req.getName(), req.getVersion());
 
         if (sd == null) {
@@ -517,6 +520,10 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
     @Override
     @Authorize(resources = ACLResource.ACL_STRUCT, actions = ACLAction.WRITE_METADATA)
     public void putStructDef(PutStructDefRequest req, StreamObserver<StructDef> ctx) {
+        if (serverConfig.areStructDefsEnabled() == false) {
+            throw new StatusRuntimeException(Status.UNIMPLEMENTED);
+        }
+
         PutStructDefRequestModel reqModel =
                 LHSerializable.fromProto(req, PutStructDefRequestModel.class, requestContext());
         processCommand(new MetadataCommandModel(reqModel), ctx, StructDef.class, true);
@@ -526,6 +533,10 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
     @Authorize(resources = ACLResource.ACL_STRUCT, actions = ACLAction.READ)
     public void validateStructDefEvolution(
             ValidateStructDefEvolutionRequest req, StreamObserver<ValidateStructDefEvolutionResponse> ctx) {
+        if (serverConfig.areStructDefsEnabled() == false) {
+            throw new StatusRuntimeException(Status.UNIMPLEMENTED);
+        }
+        
         InlineStructDefModel newInlineStructDef =
                 LHSerializable.fromProto(req.getStructDef(), InlineStructDefModel.class, requestContext());
         newInlineStructDef.validate();
@@ -1102,6 +1113,9 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
     @Override
     @Authorize(resources = ACLResource.ACL_STRUCT, actions = ACLAction.WRITE_METADATA)
     public void deleteStructDef(DeleteStructDefRequest req, StreamObserver<Empty> ctx) {
+        if (serverConfig.areStructDefsEnabled() == false) {
+            throw new StatusRuntimeException(Status.UNIMPLEMENTED);
+        }
         DeleteStructDefRequestModel dsdr =
                 LHSerializable.fromProto(req, DeleteStructDefRequestModel.class, requestContext());
         processCommand(new MetadataCommandModel(dsdr), ctx, Empty.class, true);

--- a/server/src/test/java/e2e/StandaloneTestBootstrapper.java
+++ b/server/src/test/java/e2e/StandaloneTestBootstrapper.java
@@ -101,6 +101,7 @@ public class StandaloneTestBootstrapper implements TestBootstrapper {
         serverProperties.put(LHServerConfig.CORE_MEMTABLE_SIZE_BYTES_KEY, String.valueOf(1024L * 1024L * 8));
         serverProperties.put(LHServerConfig.ROCKSDB_TOTAL_MEMTABLE_BYTES_KEY, String.valueOf(1024L * 1024L * 100));
         serverProperties.put(LHServerConfig.ROCKSDB_TOTAL_BLOCK_CACHE_BYTES_KEY, String.valueOf(1024L * 1024L * 100));
+        serverProperties.put(LHServerConfig.X_ENABLE_STRUCT_DEFS_KEY, "true");
         return serverProperties;
     }
 


### PR DESCRIPTION
Adds a feature flag `LHS_X_ENABLE_STRUCT_DEFS` to the environment variables in `LHServerConfig` that takes in a true/false value to enable StructDef functionality in the Server. This will prevent clients from relying or trying to build upon the `StructDef` RPCs while they are in development.