### PR TITLE
fix(dotnet-sdk): Downgrades examples from .NET 8 to .NET 6

### DIFF
--- a/sdk-dotnet/Examples/AwaitWorkflowEventExample/AwaitWorkflowEventExample.csproj
+++ b/sdk-dotnet/Examples/AwaitWorkflowEventExample/AwaitWorkflowEventExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/BasicExample/BasicExample.csproj
+++ b/sdk-dotnet/Examples/BasicExample/BasicExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ChildThreadExample/ChildThreadExample.csproj
+++ b/sdk-dotnet/Examples/ChildThreadExample/ChildThreadExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ChildThreadsForeachExample/ChildThreadsForeachExample.csproj
+++ b/sdk-dotnet/Examples/ChildThreadsForeachExample/ChildThreadsForeachExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ConditionalsExample/ConditionalsExample.csproj
+++ b/sdk-dotnet/Examples/ConditionalsExample/ConditionalsExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ConditionalsWhileExample/ConditionalsWhileExample.csproj
+++ b/sdk-dotnet/Examples/ConditionalsWhileExample/ConditionalsWhileExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ExceptionsHandlerExample/ExceptionsHandlerExample.csproj
+++ b/sdk-dotnet/Examples/ExceptionsHandlerExample/ExceptionsHandlerExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/ExternalEventExample/ExternalEventExample.csproj
+++ b/sdk-dotnet/Examples/ExternalEventExample/ExternalEventExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/InterruptHandlerExample/InterruptHandlerExample.csproj
+++ b/sdk-dotnet/Examples/InterruptHandlerExample/InterruptHandlerExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/MaskedFieldsExample/MaskedFieldsExample.csproj
+++ b/sdk-dotnet/Examples/MaskedFieldsExample/MaskedFieldsExample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/sdk-dotnet/Examples/MutationExample/MutationExample.csproj
+++ b/sdk-dotnet/Examples/MutationExample/MutationExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/UserTasksExample/UserTasksExample.csproj
+++ b/sdk-dotnet/Examples/UserTasksExample/UserTasksExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/sdk-dotnet/Examples/WorkerContextExample/WorkerContextExample.csproj
+++ b/sdk-dotnet/Examples/WorkerContextExample/WorkerContextExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
The SDK and the tests are using .NET 6, and even though .NET 8 should be compatible with .NET, there .NET Unit Test framework insist that test should be run with .NET 6. So to keep a single version of .NET when developing it's better if everything uses .NET 6 for now.