### PR TITLE
feat(server): allow using direct io for rocksdb

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -82,6 +82,7 @@ public class LHServerConfig extends ConfigBase {
     public static final String TIMER_STATESTORE_CACHE_BYTES_KEY = "LHS_TIMER_STATESTORE_CACHE_BYTES";
     public static final String ROCKSDB_TOTAL_BLOCK_CACHE_BYTES_KEY = "LHS_ROCKSDB_TOTAL_BLOCK_CACHE_BYTES";
     public static final String ROCKSDB_TOTAL_MEMTABLE_BYTES_KEY = "LHS_ROCKSDB_TOTAL_MEMTABLE_BYTES";
+    public static final String ROCKSDB_USE_DIRECT_IO_KEY = "LHS_ROCKSDB_USE_DIRECT_IO";
     public static final String ROCKSDB_RATE_LIMIT_BYTES_KEY = "LHS_ROCKSDB_RATE_LIMIT_BYTES";
     public static final String SESSION_TIMEOUT_KEY = "LHS_STREAMS_SESSION_TIMEOUT";
     public static final String KAFKA_STATE_DIR_KEY = "LHS_STATE_DIR";
@@ -736,6 +737,10 @@ public class LHServerConfig extends ConfigBase {
     public long getCoreMemtableSize() {
         // 64MB default
         return Long.valueOf(getOrSetDefault(CORE_MEMTABLE_SIZE_BYTES_KEY, String.valueOf(1024L * 1024L * 64)));
+    }
+
+    public boolean useDirectIOForRocksDB() {
+        return Boolean.valueOf(getOrSetDefault(ROCKSDB_USE_DIRECT_IO_KEY, "false"));
     }
 
     // Timer Topology generally has smaller values that are written. The majority of them

--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -62,6 +62,9 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         tableConfig.setBlockSize(BLOCK_SIZE);
         options.setTableFormatConfig(tableConfig);
 
+        options.setUseDirectIoForFlushAndCompaction(serverConfig.useDirectIOForRocksDB());
+        options.setUseDirectReads(serverConfig.useDirectIOForRocksDB());
+
         options.setOptimizeFiltersForHits(OPTIMIZE_FILTERS_FOR_HITS);
         options.setCompactionStyle(CompactionStyle.UNIVERSAL);
 


### PR DESCRIPTION
In certain resource-constrained configurations in our soak tests, we have seen runaway page cache usage. In containerized environments we cannot limit page-cache memory (either via the application or via the container configuration). We can only limit total memory.

If page cache usage grows unbounded then we can encounter OOMKilled (137) as the container runtime enforces the overall memory limit on the container.

This commit introduces LHS_ROCKSDB_USE_DIRECT_IO which allows users to specify whether to bypass the page cache in rocksdb, relying instead on the Block Cache for performance. The Block Cache serves an equivalent purpose to the page cache except that it allows users to control the size via LHS_ROCKSDB_TOTAL_BLOCK_CACHE_BYTES.