### PR TITLE
feat(sdk-java): allow registration of workfloweventdef in dsl

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/ThrowEventNodeOutput.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/ThrowEventNodeOutput.java
@@ -1,0 +1,15 @@
+package io.littlehorse.sdk.wfsdk;
+
+/**
+ * Type for the output of a `THROW_EVENT` node.
+ */
+public interface ThrowEventNodeOutput {
+    /**
+     * Instructs the LH DSL to attempt to create the associated WorkflowEventDef with the
+     * provided class as the type definition. Allowed classes are String, Integer, Double,
+     * Boolean, Map, and List. If the provided class is `null`, then the WorkflowEventDef
+     * will have a null payload.
+     * @param payloadClass the class of the payload.
+     */
+    public void registeredAs(Class<?> payloadClass);
+}

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/Workflow.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/Workflow.java
@@ -15,6 +15,7 @@ import io.littlehorse.sdk.common.proto.ThreadRetentionPolicy;
 import io.littlehorse.sdk.common.proto.WfSpecId;
 import io.littlehorse.sdk.common.proto.WorkflowRetentionPolicy;
 import io.littlehorse.sdk.wfsdk.internal.ExternalEventNodeOutputImpl;
+import io.littlehorse.sdk.wfsdk.internal.ThrowEventNodeOutputImpl;
 import io.littlehorse.sdk.wfsdk.internal.WorkflowImpl;
 import java.io.File;
 import java.io.IOException;
@@ -44,6 +45,7 @@ public abstract class Workflow {
     protected ExponentialBackoffRetryPolicy defaultExponentialBackoff;
     protected int defaultSimpleRetries;
     protected Set<ExternalEventNodeOutputImpl> externalEventsToRegister;
+    protected Set<ThrowEventNodeOutputImpl> workflowEventsToRegister;
 
     /**
      * Internal constructor used by WorkflowImpl.
@@ -57,6 +59,7 @@ public abstract class Workflow {
         this.name = name;
         this.spec = PutWfSpecRequest.newBuilder().setName(name);
         this.externalEventsToRegister = new HashSet<>();
+        this.workflowEventsToRegister = new HashSet<>();
     }
 
     /**

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/WorkflowThread.java
@@ -445,7 +445,7 @@ public interface WorkflowThread {
      * @param workflowEventDefName is the name of the WorkflowEvent to throw.
      * @param content is the content of the WorkflowEvent that is thrown.
      */
-    void throwEvent(String workflowEventDefName, Serializable content);
+    ThrowEventNodeOutput throwEvent(String workflowEventDefName, Serializable content);
 
     /**
      * Given a WfRunVariable of type JSON_ARR, this function iterates over each object in that list

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/BuilderUtil.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/BuilderUtil.java
@@ -2,10 +2,15 @@ package io.littlehorse.sdk.wfsdk.internal;
 
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.exception.LHSerdeException;
+import io.littlehorse.sdk.common.proto.ReturnType;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
 import io.littlehorse.sdk.common.proto.VariableAssignment;
 import io.littlehorse.sdk.common.proto.VariableAssignment.Expression;
 import io.littlehorse.sdk.common.proto.VariableAssignment.NodeOutputReference;
+import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.VariableValue;
+import java.util.List;
+import java.util.Map;
 
 class BuilderUtil {
 
@@ -53,5 +58,30 @@ class BuilderUtil {
         }
 
         return builder.build();
+    }
+
+    static ReturnType javaTypeToReturnType(Class<?> payloadClass) {
+        if (payloadClass == null) {
+            // We don't set the typeDef: the event has no payload
+            return ReturnType.newBuilder().build();
+        }
+        TypeDefinition.Builder typeDef = TypeDefinition.newBuilder();
+        if (String.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.STR);
+        } else if (Double.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.DOUBLE);
+        } else if (Integer.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.INT);
+        } else if (Boolean.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.BOOL);
+        } else if (Map.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.JSON_OBJ);
+        } else if (List.class.isAssignableFrom(payloadClass)) {
+            typeDef.setType(VariableType.JSON_ARR);
+        } else {
+            throw new IllegalArgumentException(
+                    "ExternalEventDef payload class must be one of String, Double, Integer or Boolean");
+        }
+        return ReturnType.newBuilder().setReturnType(typeDef).build();
     }
 }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/ExternalEventNodeOutputImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/ExternalEventNodeOutputImpl.java
@@ -2,9 +2,6 @@ package io.littlehorse.sdk.wfsdk.internal;
 
 import io.littlehorse.sdk.common.proto.CorrelatedEventConfig;
 import io.littlehorse.sdk.common.proto.PutExternalEventDefRequest;
-import io.littlehorse.sdk.common.proto.ReturnType;
-import io.littlehorse.sdk.common.proto.TypeDefinition;
-import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.wfsdk.ExternalEventNodeOutput;
 import java.io.Serializable;
 
@@ -54,30 +51,9 @@ public class ExternalEventNodeOutputImpl extends NodeOutputImpl implements Exter
     }
 
     public PutExternalEventDefRequest toPutExtDefRequest() {
-        PutExternalEventDefRequest.Builder builder;
-        if (payloadClass == null) {
-            // We don't set the typeDef: the event has no payload
-            builder = PutExternalEventDefRequest.newBuilder()
-                    .setName(externalEventDefName)
-                    .setContentType(ReturnType.newBuilder());
-        } else {
-            TypeDefinition.Builder typeDef = TypeDefinition.newBuilder();
-            if (String.class.isAssignableFrom(payloadClass)) {
-                typeDef.setType(VariableType.STR);
-            } else if (Double.class.isAssignableFrom(payloadClass)) {
-                typeDef.setType(VariableType.DOUBLE);
-            } else if (Integer.class.isAssignableFrom(payloadClass)) {
-                typeDef.setType(VariableType.INT);
-            } else if (Boolean.class.isAssignableFrom(payloadClass)) {
-                typeDef.setType(VariableType.BOOL);
-            } else {
-                throw new IllegalArgumentException(
-                        "ExternalEventDef payload class must be one of String, Double, Integer or Boolean");
-            }
-            builder = PutExternalEventDefRequest.newBuilder()
-                    .setContentType(ReturnType.newBuilder().setReturnType(typeDef))
-                    .setName(externalEventDefName);
-        }
+        PutExternalEventDefRequest.Builder builder = PutExternalEventDefRequest.newBuilder()
+                .setName(externalEventDefName)
+                .setContentType(BuilderUtil.javaTypeToReturnType(payloadClass));
 
         if (correlatedEventConfig != null) {
             builder.setCorrelatedEventConfig(correlatedEventConfig);

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/ThrowEventNodeOutputImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/ThrowEventNodeOutputImpl.java
@@ -1,0 +1,29 @@
+package io.littlehorse.sdk.wfsdk.internal;
+
+import io.littlehorse.sdk.common.proto.PutWorkflowEventDefRequest;
+import io.littlehorse.sdk.wfsdk.ThrowEventNodeOutput;
+
+public class ThrowEventNodeOutputImpl implements ThrowEventNodeOutput {
+
+    private final WorkflowThreadImpl parent;
+    private final String workflowEventDefName;
+    private Class<?> payloadClass;
+
+    public ThrowEventNodeOutputImpl(String workflowEventDefName, WorkflowThreadImpl parent) {
+        this.workflowEventDefName = workflowEventDefName;
+        this.parent = parent;
+    }
+
+    @Override
+    public void registeredAs(Class<?> payloadClass) {
+        this.payloadClass = payloadClass;
+        parent.registerWorkflowEventDef(this);
+    }
+
+    public PutWorkflowEventDefRequest toPutWorkflowEventDefRequest() {
+        return PutWorkflowEventDefRequest.newBuilder()
+                .setName(workflowEventDefName)
+                .setContentType(BuilderUtil.javaTypeToReturnType(payloadClass))
+                .build();
+    }
+}

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowImpl.java
@@ -48,12 +48,22 @@ public class WorkflowImpl extends Workflow {
         // Create externalEventDef's that the user wanted us to create
         for (ExternalEventNodeOutputImpl node : externalEventsToRegister) {
             log.info(
-                    "Creating externalEventDef:\n {}",
+                    "Creating ExternalEventDef:\n {}",
                     LHLibUtil.protoToJson(client.putExternalEventDef(node.toPutExtDefRequest())));
+        }
+
+        for (ThrowEventNodeOutputImpl node : workflowEventsToRegister) {
+            log.info(
+                    "Creating WorkflowEventDef:\n {}",
+                    LHLibUtil.protoToJson(client.putWorkflowEventDef(node.toPutWorkflowEventDefRequest())));
         }
 
         // Now we do the dancin'
         log.info("Creating wfSpec:\n {}", LHLibUtil.protoToJson(client.putWfSpec(wfRequest)));
+    }
+
+    public void addWorkflowEventDefToRegister(ThrowEventNodeOutputImpl node) {
+        workflowEventsToRegister.add(node);
     }
 
     public void addExternalEventDefToRegister(ExternalEventNodeOutputImpl node) {

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowThreadImpl.java
@@ -271,6 +271,10 @@ final class WorkflowThreadImpl implements WorkflowThread {
         parent.addExternalEventDefToRegister(nodeOutputImpl);
     }
 
+    public void registerWorkflowEventDef(ThrowEventNodeOutputImpl nodeOutputImpl) {
+        parent.addWorkflowEventDefToRegister(nodeOutputImpl);
+    }
+
     @Override
     public void cancelUserTaskRunAfter(UserTaskOutput userTask, Serializable delaySeconds) {
         checkIfIsActive();
@@ -794,7 +798,7 @@ final class WorkflowThreadImpl implements WorkflowThread {
     }
 
     @Override
-    public void throwEvent(String workflowEventDefName, Serializable content) {
+    public ThrowEventNodeOutputImpl throwEvent(String workflowEventDefName, Serializable content) {
         checkIfIsActive();
         parent.addWorkflowEventDefName(workflowEventDefName);
         ThrowEventNode node = ThrowEventNode.newBuilder()
@@ -804,6 +808,7 @@ final class WorkflowThreadImpl implements WorkflowThread {
                 .setContent(assignVariable(content))
                 .build();
         addNode("throw-" + workflowEventDefName, NodeCase.THROW_EVENT, node);
+        return new ThrowEventNodeOutputImpl(workflowEventDefName, this);
     }
 
     @Override

--- a/server/src/test/java/e2e/WorkflowEventsTest.java
+++ b/server/src/test/java/e2e/WorkflowEventsTest.java
@@ -3,10 +3,6 @@ package e2e;
 import io.littlehorse.sdk.common.proto.AwaitWorkflowEventRequest;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
-import io.littlehorse.sdk.common.proto.PutWorkflowEventDefRequest;
-import io.littlehorse.sdk.common.proto.ReturnType;
-import io.littlehorse.sdk.common.proto.TypeDefinition;
-import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.WorkflowEvent;
 import io.littlehorse.sdk.common.proto.WorkflowEventDefId;
 import io.littlehorse.sdk.common.util.Arg;
@@ -15,7 +11,6 @@ import io.littlehorse.sdk.wfsdk.Workflow;
 import io.littlehorse.sdk.wfsdk.internal.WorkflowImpl;
 import io.littlehorse.test.LHTest;
 import io.littlehorse.test.LHWorkflow;
-import io.littlehorse.test.LHWorkflowEvent;
 import io.littlehorse.test.WorkflowVerifier;
 import java.time.Duration;
 import org.assertj.core.api.Assertions;
@@ -67,14 +62,7 @@ public class WorkflowEventsTest {
             WfRunVariable sleepTime = entrypoint.addVariable("sleep-time", 0);
             WfRunVariable input = entrypoint.addVariable("input", "hello there");
             entrypoint.sleepSeconds(sleepTime);
-            entrypoint.throwEvent("user-created", input);
+            entrypoint.throwEvent("user-created", input).registeredAs(String.class);
         });
     }
-
-    @LHWorkflowEvent
-    public final PutWorkflowEventDefRequest eventDef = PutWorkflowEventDefRequest.newBuilder()
-            .setContentType(ReturnType.newBuilder()
-                    .setReturnType(TypeDefinition.newBuilder().setType(VariableType.STR)))
-            .setName("user-created")
-            .build();
 }


### PR DESCRIPTION
- Adds .registeredAs() to return of throwEvent()
- Allows List and Map for ExternalEventDefs
- Not implemented in python/go/dotnet