### PR TITLE
feat(dashboard): get the latest `WfSpec` version

### DIFF
--- a/dashboard/src/components/metadata/metadata-search-client.tsx
+++ b/dashboard/src/components/metadata/metadata-search-client.tsx
@@ -1,9 +1,11 @@
 'use client'
+import { executeRpc } from '@/actions/executeRPC'
 import { search, SearchResponse } from '@/actions/search'
 import { Pagination } from '@/components/ui/load-more-pagination'
 import { SearchType } from '@/types/search'
 import { SEARCH_ENTITIES, SEARCH_LIMIT_DEFAULT, SEARCH_LIMITS } from '@/utils/ui/constants'
 import { Tabs, TabsList, TabsTrigger } from '@littlehorse-enterprises/ui-library/tabs'
+import { WfSpecId } from 'littlehorse-client/proto'
 import { useParams } from 'next/navigation'
 import { useState } from 'react'
 import useSWRInfinite from 'swr/infinite'
@@ -28,7 +30,21 @@ export function MetadataSearchClient() {
     isLoading: isDataLoading,
   } = useSWRInfinite<SearchResponse>(getKey, async key => {
     const [, type, tenantId, limit, prefix, bookmark] = key
-    return search({ type, limit, prefix, bookmark, tenantId })
+    const response = await search({ type, limit, prefix, bookmark, tenantId })
+    if (response.type === 'WfSpec') {
+      const uniqueWfSpecs: WfSpecId[] = []
+      response.results.forEach((result: WfSpecId) => {
+        if (!uniqueWfSpecs.some(wfSpec => wfSpec.name === result.name)) uniqueWfSpecs.push(result)
+      })
+
+      response.results = await Promise.all(uniqueWfSpecs.map(async (wfSpec) => {
+        const wfSpecResponse = await executeRpc("getLatestWfSpec", {
+          name: wfSpec.name,
+        }, tenantId)
+        return wfSpecResponse.id
+      }))
+    }
+    return response
   })
 
   return (

--- a/dashboard/src/components/metadata/metadata-table.tsx
+++ b/dashboard/src/components/metadata/metadata-table.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { SearchResponse } from '@/actions/search'
-import { Badge } from '@littlehorse-enterprises/ui-library/badge'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@littlehorse-enterprises/ui-library/table'
 import { SearchType } from '@/types/search'
+import { Badge } from '@littlehorse-enterprises/ui-library/badge'
 import { Button } from '@littlehorse-enterprises/ui-library/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@littlehorse-enterprises/ui-library/table'
 import { UserTaskDefId, WfSpecId } from 'littlehorse-client/proto'
 import { Eye } from 'lucide-react'
 import { useParams, useRouter } from 'next/navigation'
@@ -24,7 +24,7 @@ export function MetadataTable({ data, activeTab, isLoading }: MetadataTableProps
     else if (activeTab === 'ExternalEventDef') router.push(`/${tenantId}/ExternalEventDefs/${name}`)
     else if (activeTab === 'WorkflowEventDef') router.push(`/${tenantId}/WorkflowEventDefs/${name}`)
   }
-
+  
   return (
     <Table>
       <TableHeader>
@@ -51,7 +51,7 @@ export function MetadataTable({ data, activeTab, isLoading }: MetadataTableProps
           data?.map(item =>
             item.results.map((result: SearchResponse['results'][number]) => (
               <TableRow
-                key={result}
+                key={JSON.stringify(result)}
                 className="hover:bg-muted/50 cursor-pointer"
                 onClick={() =>
                   isOfType<WfSpecId>(activeTab === 'WfSpec', result)

--- a/dashboard/src/utils/ui/constants.tsx
+++ b/dashboard/src/utils/ui/constants.tsx
@@ -5,7 +5,7 @@ import { AlertCircle, CheckCircle, Clock, Loader2, XCircle } from 'lucide-react'
 /* --------------------------------- Search --------------------------------- */
 export const SEARCH_LIMITS = [10, 20, 30, 60, 100] as const
 
-export const SEARCH_LIMIT_DEFAULT: (typeof SEARCH_LIMITS)[number] = 10
+export const SEARCH_LIMIT_DEFAULT: (typeof SEARCH_LIMITS)[number] = 20
 export const SEARCH_ENTITIES = [
   'WfSpec',
   'TaskDef',


### PR DESCRIPTION
- Added unique workflow specification handling in the search client to prevent duplicates.
- Integrated RPC call to fetch the latest workflow specifications.
- Updated default search limit from 10 to 20 for improved user experience.
- Adjusted key handling in the metadata table for better uniqueness.

Before:
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/828a75a8-abd8-4370-97b8-8575af7fd877" />

After: 
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/3cbf785e-716c-4077-b34e-67c9f8b84e0d" />
