### PR TITLE
fix: stringify variable references

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           VERSION="${{ github.ref_name }}-$SHORT_SHA"
-          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.ts
+          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.mjs
 
       - name: Build Dashboard
         working-directory: ./dashboard
@@ -126,7 +126,7 @@ jobs:
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           VERSION="${{ github.ref_name }}-$SHORT_SHA"
-          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.ts
+          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.mjs
 
       - name: Build Dashboard
         working-directory: ./dashboard

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,7 +6,7 @@ on:
       tag:
         type: string
         required: false
-        default: ''
+        default: ""
 permissions:
   packages: write
   contents: read
@@ -128,7 +128,7 @@ jobs:
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
             VERSION="${{ github.ref_name }}-$SHORT_SHA"
           fi
-          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.ts
+          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.mjs
 
       - name: Build Dashboard
         working-directory: ./dashboard
@@ -168,7 +168,7 @@ jobs:
             SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
             VERSION="${{ github.ref_name }}-$SHORT_SHA"
           fi
-          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.ts
+          sed -i "s|NEXT_PUBLIC_VERSION: '.*'|NEXT_PUBLIC_VERSION: '$VERSION'|g" next.config.mjs
 
       - name: Build Dashboard
         working-directory: ./dashboard

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/formType.ts
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/formType.ts
@@ -9,6 +9,7 @@ export const FormComponent = {
   [VariableType.JSON_OBJ]: FormTextarea,
   [VariableType.JSON_ARR]: FormTextarea,
   [VariableType.BYTES]: FormInput,
+  [VariableType.WF_RUN_ID]: FormInput,
   [VariableType.UNRECOGNIZED]: FormInput,
 } as const
 

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/Edge.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/Edge.tsx
@@ -46,7 +46,9 @@ const RhsAssignment: FC<Pick<VariableMutation, 'rhsAssignment'>> = ({ rhsAssignm
   return (
     <>
       <span className="rounded bg-gray-200 p-1 text-xs">RHS Assignment</span>
-      <span className="rounded bg-gray-100 p-1 font-mono text-xs text-orange-500">{getVariable(rhsAssignment)}</span>
+      <span className="rounded bg-gray-100 p-1 font-mono text-xs text-orange-500">
+        {String(getVariable(rhsAssignment))}
+      </span>
     </>
   )
 }
@@ -57,7 +59,7 @@ const LiteralValue: FC<Pick<VariableMutation, 'literalValue'>> = ({ literalValue
     <>
       <span className="rounded bg-gray-200 p-1 text-xs">Literal Value</span>
       <span className="rounded bg-gray-100 p-1 font-mono text-xs text-orange-500">
-        {getVariableValue(literalValue)}
+        {String(getVariableValue(literalValue))}
       </span>
     </>
   )

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/ExternalEventDefDetail.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/ExternalEventDefDetail.tsx
@@ -60,7 +60,7 @@ export const ExternalEventDefDetail: FC<AccordionNode> = ({ nodeRun }) => {
 
       <div className={cn('flex w-full flex-col overflow-auto rounded p-1', 'bg-zinc-500 text-white')}>
         <h3 className="font-bold">Content</h3>
-        <pre className="overflow-auto">{getVariableValue(data.content)}</pre>
+        <pre className="overflow-auto">{String(getVariableValue(data.content))}</pre>
       </div>
     </>
   )

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/TaskDefDetail.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/TaskDefDetail.tsx
@@ -51,7 +51,7 @@ export const TaskDefDetail: FC<AccordionNode> = ({ nodeRun }) => {
               return (
                 <div key={varName} className="mb-1 flex items-center gap-1">
                   <div className="rounded bg-gray-100 px-2 py-1 font-mono text-fuchsia-500">{varName}</div>
-                  <div className="">= {getVariableValue(value)}</div>
+                  <div className="">= {String(getVariableValue(value))}</div>
                 </div>
               )
             })}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/UserTaskDefDetail.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/UserTaskDefDetail.tsx
@@ -84,7 +84,7 @@ export const UserTaskDefDetail: FC<AccordionNode> = ({ nodeRun, userTaskNode }) 
           <div className="ml-3">
             <span className="font-bold">Exception upon cancellation: </span>
             <span className="rounded bg-red-300 p-1 text-xs">
-              {getVariable(userTaskNode!?.onCancellationExceptionName)}
+              {String(getVariable(userTaskNode!?.onCancellationExceptionName))}
             </span>
           </div>
         )}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/WorkflowEventDefDetail.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/NodeRun/WorkflowEventDefDetail.tsx
@@ -59,7 +59,7 @@ export const WorkflowEventDefDetail: FC<{ nodeRun: NodeRun }> = ({ nodeRun }) =>
 
       <div className={cn('mt-2 flex w-full flex-col overflow-auto rounded p-1', 'bg-zinc-500 text-white')}>
         <h3 className="font-bold">Content</h3>
-        <pre className="overflow-auto">{getVariableValue(data.content)}</pre>
+        <pre className="overflow-auto">{String(getVariableValue(data.content))}</pre>
       </div>
     </div>
   )

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Sleep/SleepDetails.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Sleep/SleepDetails.tsx
@@ -15,10 +15,10 @@ export const SleepDetails: FC<{ sleepNode?: SleepNode; nodeRunsList: [NodeRun] }
           <div className="flex flex-col gap-1 text-nowrap">
             <div className="flex ">
               {sleepNode.rawSeconds && (
-                <div>Time: {typeof timeValue === 'number' ? formatTime(timeValue) : timeValue}</div>
+                <div>Time: {typeof timeValue === 'number' ? formatTime(timeValue) : String(timeValue)}</div>
               )}
-              {sleepNode.timestamp && <div>{getVariable(sleepNode.timestamp)}</div>}
-              {sleepNode.isoDate && <div>{getVariable(sleepNode.isoDate)}</div>}
+              {sleepNode.timestamp && <div>{String(getVariable(sleepNode.timestamp))}</div>}
+              {sleepNode.isoDate && <div>{String(getVariable(sleepNode.isoDate))}</div>}
             </div>
 
             <NodeRunsList nodeRuns={nodeRunsList} />

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/StartMultipleThreads.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/StartMultipleThreads.tsx
@@ -40,7 +40,7 @@ const Node: FC<NodeProps> = ({ data }) => {
             )}
           </div>
           <div className="">
-            <span className="font-bold">Iterable:</span> {getVariable(data.startMultipleThreads.iterable)}
+            <span className="font-bold">Iterable:</span> {String(getVariable(data.startMultipleThreads.iterable))}
           </div>
           {variables.length > 0 && (
             <div className="mt-2">
@@ -48,7 +48,7 @@ const Node: FC<NodeProps> = ({ data }) => {
               <ul>
                 {variables.map(([name, value]) => (
                   <li key={name}>
-                    {`{${name}}`} {getVariable(value)}
+                    {`{${name}}`} {String(getVariable(value))}
                   </li>
                 ))}
               </ul>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/StartThread.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/StartThread.tsx
@@ -31,7 +31,7 @@ const Node: FC<NodeProps> = ({ data }) => {
             <ul>
               {variables.map(([name, value]) => (
                 <li key={name}>
-                  {`{${name}}`} = {getVariable(value)}
+                  {`{${name}}`} = {String(getVariable(value))}
                 </li>
               ))}
             </ul>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/Task.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/Task.tsx
@@ -25,7 +25,7 @@ const Node: FC<NodeProps> = ({ selected, data }) => {
       >
         <SettingsIcon className="h-4 w-4 fill-orange-500" />
         {task.taskDefId?.name}
-        {getVariable(task.dynamicTask)}
+        {String(getVariable(task.dynamicTask))}
         <Handle type="source" position={Position.Right} className="bg-transparent" />
         <Handle type="target" position={Position.Left} className="bg-transparent" />
       </div>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/UserTask/UserAndGroupAssignmentInfo.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/UserTask/UserAndGroupAssignmentInfo.tsx
@@ -1,13 +1,14 @@
+import { WfRunId } from 'littlehorse-client/proto'
 import { FC } from 'react'
 interface UserTaskRunDetailsProps {
-  userGroup: string | number | boolean | Buffer | undefined
-  userId: string | number | boolean | Buffer | undefined
+  userGroup: string | number | boolean | Buffer | undefined | WfRunId
+  userId: string | number | boolean | Buffer | undefined | WfRunId
 }
 export const UserAndGroupAssignmentInfo: FC<UserTaskRunDetailsProps> = ({ userGroup, userId }) => {
   return (
     <>
-      {userGroup && <div>Group: {userGroup}</div>}
-      {userId && <div>User: {userId}</div>}
+      {userGroup && <div>Group: {String(userGroup)}</div>}
+      {userId && <div>User: {String(userId)}</div>}
     </>
   )
 }

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/UserTask/UserTaskNotes.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/UserTask/UserTaskNotes.tsx
@@ -1,12 +1,13 @@
+import { WfRunId } from 'littlehorse-client/proto'
 import { FC } from 'react'
 interface UserTaskNotesProps {
-  notes: string | number | boolean | Buffer | undefined
+  notes: string | number | boolean | Buffer | undefined | WfRunId
 }
 export const UserTaskNotes: FC<UserTaskNotesProps> = ({ notes }) => {
   return (
     <div className="rounded bg-gray-200 p-1">
       <h3 className="mb-1 font-bold">Notes</h3>
-      <pre className="overflow-x-auto">{notes}</pre>
+      <pre className="overflow-x-auto">{String(notes)}</pre>
     </div>
   )
 }

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/WaitForThreads.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/WaitForThreads.tsx
@@ -14,14 +14,14 @@ const Node: FC<NodeProps> = ({ data }) => {
       <NodeDetails nodeRunList={nodeRunsList}>
         <DiagramDataGroup label="WaitForThreads">
           {data.waitForThreads?.threadList && (
-            <div className="whitespace-nowrap">{getVariable(data.waitForThreads?.threadList)}</div>
+            <div className="whitespace-nowrap">{String(getVariable(data.waitForThreads?.threadList))}</div>
           )}
           {data.waitForThreads?.threads?.threads.map(thread => (
             <div
               key={`${getVariable(thread.threadRunNumber)}`}
               className="flex items-center justify-center whitespace-nowrap"
             >
-              {getVariable(thread.threadRunNumber)}
+              {String(getVariable(thread.threadRunNumber))}
             </div>
           ))}
           {data.nodeRun && data.nodeRun.errorMessage && (

--- a/dashboard/src/app/constants.ts
+++ b/dashboard/src/app/constants.ts
@@ -12,6 +12,7 @@ export const VARIABLE_TYPES: { [key in VariableType]: string } = {
   STR: 'String',
   INT: 'Integer',
   BYTES: 'Bytes',
+  WF_RUN_ID: 'Workflow Run ID',
   UNRECOGNIZED: 'Unrecognized',
 }
 

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.mjs"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- The addition of `WfRunId` into `VariableValue` broke a lot of the code for rendering. This is because the previous type of `VariableValue` included built-in types that ReactNode supported for rendering, but since `WfRunId` is a custom type, it doesn't know how to render it. The solution is to stringify every result from the functions. This PR converts all UI renders of the returned value from the `getVariable...` functions into strings.