### PR TITLE
refactor(sdk-java): Relocate `isPrimitive` logic from `TypeDefinition`

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/ReturnTypeModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/ReturnTypeModel.java
@@ -44,10 +44,6 @@ public class ReturnTypeModel extends LHSerializable<ReturnType> {
         }
     }
 
-    public boolean isVoidOrPrimitive() {
-        return getOutputType().isEmpty() || getOutputType().get().isPrimitive();
-    }
-
     /**
      * Returns the output type of this ReturnTypeModel. Empty if this ReturnType is VOID.
      */

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/TypeDefinitionModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/TypeDefinitionModel.java
@@ -43,22 +43,6 @@ public class TypeDefinitionModel extends LHSerializable<TypeDefinition> {
         this.type = p.getType();
     }
 
-    public boolean isPrimitive() {
-        // TODO: Extend this when adding Struct and StructDef.
-        switch (type) {
-            case INT:
-            case BOOL:
-            case DOUBLE:
-            case STR:
-                return true;
-            case JSON_OBJ:
-            case JSON_ARR:
-            case BYTES:
-            case UNRECOGNIZED:
-        }
-        return false;
-    }
-
     public static TypeDefinitionModel fromProto(TypeDefinition proto, ExecutionContext context) {
         TypeDefinitionModel out = new TypeDefinitionModel();
         out.initFrom(proto, context);

--- a/server/src/main/java/io/littlehorse/common/util/LHUtil.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHUtil.java
@@ -16,9 +16,9 @@ import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.common.LHSerializable;
-import io.littlehorse.common.model.getable.global.wfspec.TypeDefinitionModel;
 import io.littlehorse.sdk.common.proto.MetricsWindowLength;
 import io.littlehorse.sdk.common.proto.VariableType;
+import io.littlehorse.server.streams.lhinternalscan.publicrequests.SearchVariableRequestModel;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -190,14 +190,6 @@ public class LHUtil {
         }
         return str;
     }
-
-    @Deprecated
-    public static boolean isPrimitive(VariableType variableType) {
-        TypeDefinitionModel temp = new TypeDefinitionModel();
-        temp.setType(variableType);
-        return temp.isPrimitive();
-    }
-
     /**
      * TODO: THis needs more thought. We want the double to be searchable both
      * positive and

--- a/server/src/main/java/io/littlehorse/common/util/LHUtil.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHUtil.java
@@ -17,8 +17,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.sdk.common.proto.MetricsWindowLength;
-import io.littlehorse.sdk.common.proto.VariableType;
-import io.littlehorse.server.streams.lhinternalscan.publicrequests.SearchVariableRequestModel;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchVariableRequestModel.java
+++ b/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchVariableRequestModel.java
@@ -18,6 +18,7 @@ import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.SearchVariableRequest;
 import io.littlehorse.sdk.common.proto.VariableId;
 import io.littlehorse.sdk.common.proto.VariableIdList;
+import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.VariableValue;
 import io.littlehorse.server.streams.lhinternalscan.PublicScanRequest;
 import io.littlehorse.server.streams.lhinternalscan.SearchScanBoundaryStrategy;
@@ -128,7 +129,7 @@ public class SearchVariableRequestModel
         // ONLY do this check if the Variable is a PRIMITIVE type.
         // TODO: Extend this when implementing Struct and StructDef.
         TypeDefinitionModel varType = varDef.getVarDef().getTypeDef();
-        if (varType.isPrimitive() && !varType.isCompatibleWith(value)) {
+        if (isTypeSearchable(varType.getType()) && !varType.isCompatibleWith(value)) {
             throw new LHApiException(
                     Status.INVALID_ARGUMENT,
                     "Specified Variable has type " + varDef.getVarDef().getTypeDef());
@@ -190,5 +191,23 @@ public class SearchVariableRequestModel
 
     private List<String> searchAttributesString() {
         return List.of("name", "value", "wfSpecName", "wfSpecVersion");
+    }
+
+    public static boolean isTypeSearchable(VariableType type) {
+        switch (type) {
+            case INT:
+            case BOOL:
+            case DOUBLE:
+            case STR:
+                return true;
+            case JSON_OBJ:
+            case JSON_ARR:
+            case BYTES:
+            case UNRECOGNIZED:
+            case WF_RUN_ID:
+            default:
+                break;
+        }
+        return false;
     }
 }

--- a/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchVariableRequestModel.java
+++ b/server/src/main/java/io/littlehorse/server/streams/lhinternalscan/publicrequests/SearchVariableRequestModel.java
@@ -193,7 +193,7 @@ public class SearchVariableRequestModel
         return List.of("name", "value", "wfSpecName", "wfSpecVersion");
     }
 
-    public static boolean isTypeSearchable(VariableType type) {
+    private static boolean isTypeSearchable(VariableType type) {
         switch (type) {
             case INT:
             case BOOL:


### PR DESCRIPTION
This refactor relocates the `isPrimitive()` method logic from the `TypeDefinition` class.

We did this because the method doesn't actually check if a type is primitive, it only serves for deciding whether a type is searchable or not. 

We also removed some unused methods with old references to this `isPrimitive` method.