### PR TITLE
feat(canary): Reduce noisy logs for canary when LHServer is not healthy

### DIFF
--- a/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeGetWfRunExecutor.java
+++ b/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeGetWfRunExecutor.java
@@ -60,7 +60,7 @@ public class MetronomeGetWfRunExecutor implements HealthStatusBinder {
                     try {
                         scheduledRun();
                     } catch (Exception e) {
-                        log.error("Error when executing workflow run", e);
+                        log.debug("Error when executing workflow run", e);
                     }
                 },
                 0,
@@ -114,7 +114,7 @@ public class MetronomeGetWfRunExecutor implements HealthStatusBinder {
     private void sendBeat(final String id, final LHStatus status, final Duration latency) {
         // for debug reasons
         if (!LHStatus.COMPLETED.equals(status)) {
-            log.error("GetWfRun returns workflow error {} {}", id, status);
+            log.debug("GetWfRun returns workflow error {} {}", id, status);
         }
 
         // only running WFs are retryable, the others are deleted
@@ -140,7 +140,7 @@ public class MetronomeGetWfRunExecutor implements HealthStatusBinder {
     }
 
     private void sendExhaustedRetries(final String id) {
-        log.error("Exhausted retries getWfRun {}", id);
+        log.debug("Exhausted retries getWfRun {}", id);
 
         // delete because it reaches the max attempt
         repository.delete(id);
@@ -158,7 +158,7 @@ public class MetronomeGetWfRunExecutor implements HealthStatusBinder {
     }
 
     private void sendError(final String id, final Exception e) {
-        log.error("Error executing getWfRun {}", id, e);
+        log.debug("Error executing getWfRun {}", id, e);
 
         // delete because error is not retryable
         repository.delete(id);

--- a/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeRunWfExecutor.java
+++ b/canary/src/main/java/io/littlehorse/canary/metronome/MetronomeRunWfExecutor.java
@@ -149,7 +149,7 @@ public class MetronomeRunWfExecutor implements HealthStatusBinder {
 
         @Override
         public void onFailure(final Throwable t) {
-            log.error("Error executing runWf {}", t.getMessage(), t);
+            log.debug("Error executing runWf {}", t.getMessage(), t);
 
             final BeatStatus.BeatStatusBuilder statusBuilder = BeatStatus.builder(BeatStatus.Code.ERROR)
                     .reason(t.getClass().getSimpleName());


### PR DESCRIPTION
LH Canary produces an endless error log entries when LHServer is not healthy (for example, a rebalance, or rolling restart.
I propose changing these errors logs to debug as these errors are expected to happen when LHServer is unhealthy. 