### PR TITLE
fix(server): properly configure flush threads

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -90,7 +90,6 @@ public class LHServerConfig extends ConfigBase {
     public static final String NUM_WARMUP_REPLICAS_KEY = "LHS_STREAMS_NUM_WARMUP_REPLICAS";
     public static final String NUM_STANDBY_REPLICAS_KEY = "LHS_STREAMS_NUM_STANDBY_REPLICAS";
     public static final String ROCKSDB_COMPACTION_THREADS_KEY = "LHS_ROCKSDB_COMPACTION_THREADS";
-    public static final String ROCKSDB_FLUSH_THREADS_KEY = "LHS_ROCKSDB_FLUSH_THREADS";
     public static final String STREAMS_METRICS_LEVEL_KEY = "LHS_STREAMS_METRICS_LEVEL";
     public static final String LHS_METRICS_LEVEL_KEY = "LHS_METRICS_LEVEL";
     public static final String LINGER_MS_KEY = "LHS_KAFKA_LINGER_MS";
@@ -154,6 +153,8 @@ public class LHServerConfig extends ConfigBase {
     public static final String X_USE_STATIC_MEMBERSHIP_KEY = "LHS_X_USE_STATIC_MEMBERSHIP";
     public static final String ROCKSDB_USE_LEVEL_COMPACTION_KEY = "LHS_X_ROCKSDB_USE_LEVEL_COMPACTION";
     public static final String ROCKSDB_LOG_LEVEL_KEY = "LHS_X_ROCKSDB_LOG_LEVEL";
+    public static final String ROCKSDB_FLUSH_THREADS_KEY = "LHS_X_ROCKSDB_FLUSH_THREADS";
+    
 
     public static final String X_ENABLE_STRUCT_DEFS_KEY = "LHS_X_ENABLE_STRUCT_DEFS";
 

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -148,7 +148,6 @@ public class LHServerConfig extends ConfigBase {
 
     // EXPERIMENTAL Internal configs. Should not be used by real users; only for testing.
     public static final String X_USE_AT_LEAST_ONCE_KEY = "LHS_X_USE_AT_LEAST_ONCE";
-    public static final String X_USE_STATE_UPDATER_KEY = "LHS_X_USE_STATE_UPDATER";
     public static final String X_LEAVE_GROUP_ON_SHUTDOWN_KEY = "LHS_X_LEAVE_GROUP_ON_SHUTDOWN";
     public static final String X_USE_STATIC_MEMBERSHIP_KEY = "LHS_X_USE_STATIC_MEMBERSHIP";
     public static final String ROCKSDB_USE_LEVEL_COMPACTION_KEY = "LHS_X_ROCKSDB_USE_LEVEL_COMPACTION";
@@ -1012,11 +1011,6 @@ public class LHServerConfig extends ConfigBase {
             props.put(StreamsConfig.consumerPrefix("internal.leave.group.on.close"), false);
         } else {
             props.put(StreamsConfig.consumerPrefix("internal.leave.group.on.close"), true);
-        }
-
-        if (getOrSetDefault(X_USE_STATE_UPDATER_KEY, "false").equals("true")) {
-            log.warn("Using experimental internal config to use State Updater!");
-            props.put(StreamsConfig.InternalConfig.STATE_UPDATER_ENABLED, true);
         }
 
         if (getOrSetDefault(X_USE_STATIC_MEMBERSHIP_KEY, "false").equals("true")) {

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -739,9 +739,7 @@ public class LHServerConfig extends ConfigBase {
     }
 
     public int getRocksDBFlushThreads() {
-        // Defaults to whatever the compaction threads is set to
-        return Integer.valueOf(
-                getOrSetDefault(ROCKSDB_FLUSH_THREADS_KEY, String.valueOf(getRocksDBCompactionThreads())));
+        return Integer.valueOf(getOrSetDefault(ROCKSDB_FLUSH_THREADS_KEY, "1"));
     }
 
     public boolean getRocksDBUseLevelCompaction() {

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -90,6 +90,7 @@ public class LHServerConfig extends ConfigBase {
     public static final String NUM_WARMUP_REPLICAS_KEY = "LHS_STREAMS_NUM_WARMUP_REPLICAS";
     public static final String NUM_STANDBY_REPLICAS_KEY = "LHS_STREAMS_NUM_STANDBY_REPLICAS";
     public static final String ROCKSDB_COMPACTION_THREADS_KEY = "LHS_ROCKSDB_COMPACTION_THREADS";
+    public static final String ROCKSDB_FLUSH_THREADS_KEY = "LHS_ROCKSDB_FLUSH_THREADS";
     public static final String STREAMS_METRICS_LEVEL_KEY = "LHS_STREAMS_METRICS_LEVEL";
     public static final String LHS_METRICS_LEVEL_KEY = "LHS_METRICS_LEVEL";
     public static final String LINGER_MS_KEY = "LHS_KAFKA_LINGER_MS";
@@ -735,6 +736,12 @@ public class LHServerConfig extends ConfigBase {
 
     public int getRocksDBCompactionThreads() {
         return Integer.valueOf(getOrSetDefault(ROCKSDB_COMPACTION_THREADS_KEY, "1"));
+    }
+
+    public int getRocksDBFlushThreads() {
+        // Defaults to whatever the compaction threads is set to
+        return Integer.valueOf(
+                getOrSetDefault(ROCKSDB_FLUSH_THREADS_KEY, String.valueOf(getRocksDBCompactionThreads())));
     }
 
     public boolean getRocksDBUseLevelCompaction() {

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -153,7 +153,6 @@ public class LHServerConfig extends ConfigBase {
     public static final String ROCKSDB_USE_LEVEL_COMPACTION_KEY = "LHS_X_ROCKSDB_USE_LEVEL_COMPACTION";
     public static final String ROCKSDB_LOG_LEVEL_KEY = "LHS_X_ROCKSDB_LOG_LEVEL";
     public static final String ROCKSDB_FLUSH_THREADS_KEY = "LHS_X_ROCKSDB_FLUSH_THREADS";
-    
 
     public static final String X_ENABLE_STRUCT_DEFS_KEY = "LHS_X_ENABLE_STRUCT_DEFS";
 


### PR DESCRIPTION
- Introduces LHS_ROCKSDB_FLUSH_THREADS which defaults to value of LHS_ROCKSDB_COMPACTION_THREADS
- Properly uses the RocksDB Env object to configure the value of the low (compaction) and high (flush) priority thread pools.
- Fixes the issue where options.setIncreaseParallelism() actually set the flush threads to only 1 whereas we thought it set flush AND compaction to the same value.