### PR TITLE
chore(server): Set ZGC as default java garbage collector

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /lh
 RUN amazon-linux-extras install epel -y && yum install jemalloc -y
 ENV LD_PRELOAD=/usr/lib64/libjemalloc.so.1
 COPY ./docker/server/docker-entrypoint.sh /lh
-COPY ./server/build/libs/server-*-all.jar /lh/server.jar
+COPY ./server/build/install/server/server /lh/bin
+COPY ./server/build/install/server/lib /lh/lib
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]
 CMD ["server"]

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "$1" = 'server' ]; then
     shift
-    exec java $JAVA_OPTS -jar /lh/server.jar "$@"
+    exec /lh/bin/server
 fi
 
 exec "$@"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -17,6 +17,11 @@ task javadocJar(type: Jar) {
     from javadoc
 }
 
+def defaultJvmArgs = [
+    '-XX:+UseZGC'
+]
+
+
 javadoc {
     excludes = [
         'io/littlehorse/common/model/**',
@@ -146,6 +151,7 @@ application {
     // Define the main class for the application.
     mainClass = 'io.littlehorse.App'
     executableDir = 'server'
+    applicationDefaultJvmArgs = defaultJvmArgs
 }
 
 compileJava {
@@ -154,6 +160,12 @@ compileJava {
 
 shadowJar {
     mergeServiceFiles()
+    manifest {
+        attributes(
+            'Main-Class': 'io.littlehorse.App',
+            'JVM-Args': defaultJvmArgs.join(' ')
+        )
+    }
 }
 
 test {


### PR DESCRIPTION
This PR aims to:
- Use ZGC as a default jvm argument for Lh-server. ZGC fits better in the context of littlehorse server as it extensively uses heap memory when processing gRPC requests.
- Reduce the size of docker image by using different layers for dependencies and application binaries. 