### PR TITLE
fix(dashboard): fix TaskAttempt worker log output overflowing

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/TaskDetails.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/TaskDetails.tsx
@@ -103,12 +103,13 @@ export const TaskDetails: FC<{
                 </Entry>
               )}
               <Entry label="Worker Log Output:">
-                <div className={'min-h-5 w-full text-nowrap rounded-lg border border-black bg-gray-300 text-center'}>
-                  <OverflowText
-                    text={taskRunData.attempts[taskAttemptIndex].logOutput?.str ?? '-'}
-                    className="text-xs"
-                    variant={resultString === 'ERROR' ? 'error' : undefined}
-                  />
+                <div className="flex w-full text-nowrap items-center justify-center rounded-lg border border-black bg-gray-300 p-1">
+                  <div className="max-w-52">
+                    <OverflowText
+                      text={taskRunData.attempts[taskAttemptIndex].logOutput?.str ?? '-'}
+                      className="text-xs"
+                    />
+                  </div>
                 </div>
               </Entry>
               <Entry separator>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/TaskDetails.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/NodeTypes/Task/TaskDetails.tsx
@@ -103,7 +103,7 @@ export const TaskDetails: FC<{
                 </Entry>
               )}
               <Entry label="Worker Log Output:">
-                <div className="flex w-full text-nowrap items-center justify-center rounded-lg border border-black bg-gray-300 p-1">
+                <div className="flex w-full items-center justify-center text-nowrap rounded-lg border border-black bg-gray-300 p-1">
                   <div className="max-w-52">
                     <OverflowText
                       text={taskRunData.attempts[taskAttemptIndex].logOutput?.str ?? '-'}


### PR DESCRIPTION
- Added max-w to overflow component
- Changed styling of container so the style matches the rest of the sections
- Removed error varient on overflow component, because it doesn't make sense in this context.