### PR TITLE
feat(dashboard): WfRun ids shown in fixed width font

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
@@ -101,7 +101,7 @@ export const WfRuns: FC<WfSpec> = spec => {
             <Fragment key={i}>
               {page.results.map(wfRunId => (
                 <SelectionLink key={wfRunId.id} href={`/wfRun/${wfRunIdToPath(wfRunId)}`}>
-                  <p className="font-code">{wfRunId.id}</p>
+                  <p className="font-mono">{wfRunId.id}</p>
                   <span className={cn('ml-2 rounded px-2', statusColors[resolvedWfRuns[wfRunId.id]?.wfRun.status])}>
                     {`${resolvedWfRuns[wfRunId.id]?.wfRun.status}`}
                   </span>


### PR DESCRIPTION
Run-ids are fixed width strings but the dashboard renders it in proportional fonts. Using fixed width fonts makes the table more readable