### PR TITLE
fix(server): Mark wfrun as halted when processing stop wfrun requests

### DIFF
--- a/examples/basic/src/main/java/io/littlehorse/examples/BasicExample.java
+++ b/examples/basic/src/main/java/io/littlehorse/examples/BasicExample.java
@@ -23,6 +23,7 @@ public class BasicExample {
         return new WorkflowImpl(
             "example-basic",
             wf -> {
+                wf.sleepSeconds(120);
                 WfRunVariable theName = wf.addVariable("input-name", VariableType.STR).searchable();
                 wf.execute("greet", theName);
             }

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadHaltReasonModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadHaltReasonModel.java
@@ -118,6 +118,12 @@ public class ThreadHaltReasonModel extends LHSerializable<ThreadHaltReason> {
         }
     }
 
+    public boolean isTransitioningHaltState() {
+        return type == ReasonCase.HANDLING_FAILURE
+                || type == ReasonCase.PENDING_FAILURE
+                || type == ReasonCase.PENDING_INTERRUPT;
+    }
+
     public static ThreadHaltReasonModel fromProto(ThreadHaltReason p, ExecutionContext context) {
         ThreadHaltReasonModel out = new ThreadHaltReasonModel();
         out.initFrom(p, context);

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/ThreadRunModel.java
@@ -362,7 +362,6 @@ public class ThreadRunModel extends LHSerializable<ThreadRun> {
         pi.externalEventId = trigger.getObjectId();
         pi.interruptedThreadId = number;
         pi.handlerSpecName = idef.handlerSpecName;
-
         wfRun.pendingInterrupts.add(pi);
     }
 
@@ -457,7 +456,10 @@ public class ThreadRunModel extends LHSerializable<ThreadRun> {
         }
 
         getCurrentNodeRun().maybeHalt(processorContext);
-        maybeFinishHaltingProcess();
+        boolean halted = maybeFinishHaltingProcess();
+        if (number == 0 && halted && !reason.isTransitioningHaltState()) {
+            wfRun.transitionTo(LHStatus.HALTED);
+        }
     }
 
     public void setStatus(LHStatus status) {

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/UserTaskNodeRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/UserTaskNodeRunModel.java
@@ -114,6 +114,13 @@ public class UserTaskNodeRunModel extends SubNodeRun<UserTaskNodeRun> {
     }
 
     @Override
+    public boolean maybeHalt(CoreProcessorContext processorContext) {
+        UserTaskRunModel utr = processorContext.getableManager().get(userTaskRunId);
+        utr.cancel();
+        return true;
+    }
+
+    @Override
     public Optional<UserTaskRunIdModel> getCreatedSubGetableId() {
         return Optional.ofNullable(userTaskRunId);
     }

--- a/server/src/test/java/e2e/WaitForConditionTest.java
+++ b/server/src/test/java/e2e/WaitForConditionTest.java
@@ -25,11 +25,11 @@ public class WaitForConditionTest {
     void waitForConditionCompletesWhenChildMutatesParentVar() {
         verifier.prepareRun(waitForConditionWorkflow)
                 .thenVerifyWfRun(wfRun -> {
-                    Assertions.assertEquals(wfRun.getStatus(), LHStatus.RUNNING);
+                    Assertions.assertEquals(LHStatus.RUNNING, wfRun.getStatus());
                 })
                 .thenSendExternalEventWithContent(EVENT_NAME, null)
                 .thenVerifyWfRun(wfRun -> {
-                    Assertions.assertEquals(wfRun.getStatus(), LHStatus.RUNNING);
+                    Assertions.assertEquals(LHStatus.RUNNING, wfRun.getStatus());
                 })
                 .thenSendExternalEventWithContent(EVENT_NAME, null)
                 .waitForStatus(LHStatus.COMPLETED)


### PR DESCRIPTION
This PR fixes a problem when stoping wfrun requests, and makes UserTaskNodeRun stoppable. 