### PR TITLE
perf(server): Reduce the number of records in each poll request for main consumer

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -944,6 +944,10 @@ public class LHServerConfig extends ConfigBase {
                 result.put(kafkaKey, props.get(key));
             }
         }
+        result.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), "100");
+        result.put(StreamsConfig.consumerPrefix(ConsumerConfig.FETCH_MAX_BYTES_CONFIG), "1048576");
+        result.put(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), "50");
+        result.put(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.FETCH_MAX_BYTES_CONFIG), "1048576");
         return result;
     }
 

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -945,9 +945,6 @@ public class LHServerConfig extends ConfigBase {
             }
         }
         result.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), "100");
-        result.put(StreamsConfig.consumerPrefix(ConsumerConfig.FETCH_MAX_BYTES_CONFIG), "1048576");
-        result.put(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.MAX_POLL_RECORDS_CONFIG), "50");
-        result.put(StreamsConfig.restoreConsumerPrefix(ConsumerConfig.FETCH_MAX_BYTES_CONFIG), "1048576");
         return result;
     }
 


### PR DESCRIPTION
Kafka streams sets 1000 as default value for `max.poll.records`, but that value is high in the context of littlehorse server because littlehorse server performs logic, validations and many state store operations (get, put, scans), making the server vulnerable to transaction timeouts when processing 1000 records in a single transaction. 
This PR proposes to decrease this value to 100. It will cause more `poll` requests, but this won't affect the fetching behavior. 