### PR TITLE
fix(server): Strict limit for the global block cache

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -1145,7 +1145,9 @@ public class LHServerConfig extends ConfigBase {
         RocksDB.loadLibrary();
         long cacheSize = Long.valueOf(getOrSetDefault(ROCKSDB_TOTAL_BLOCK_CACHE_BYTES_KEY, "-1"));
         if (cacheSize != -1) {
-            this.globalRocksdbBlockCache = new LRUCache(cacheSize);
+            // The global RocksDB cache is shared across multiple state stores, requiring strict size limits to prevent
+            // unexpected out-of-memory errors
+            this.globalRocksdbBlockCache = new LRUCache(cacheSize, -1, true);
         }
 
         long totalWriteBufferSize = Long.valueOf(getOrSetDefault(ROCKSDB_TOTAL_MEMTABLE_BYTES_KEY, "-1"));


### PR DESCRIPTION
LH Server should use global LRU Cache with strict limits, so we avoid out-of-memory errors during runtime.
This is a problem identified when using relative smalls block cache in soak tests. This problem is also present when using bigger block cache limits