### PR TITLE
Remove deprecated configs

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -781,6 +781,8 @@ public class LHServerConfig extends ConfigBase {
         Properties conf = new Properties();
         conf.put("client.id", this.getClientId(component));
         conf.put(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG, "rebootstrap");
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "zstd");
+        props.put(ProducerConfig.COMPRESSION_ZSTD_LEVEL_CONFIG, 8);
         conf.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
         conf.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         conf.put(
@@ -988,6 +990,8 @@ public class LHServerConfig extends ConfigBase {
     private Properties getBaseStreamsConfig() {
         Properties props = new Properties();
 
+        props.put(StreamsConfig.producerPrefix(ProducerConfig.COMPRESSION_TYPE_CONFIG), "zstd");
+        props.put(StreamsConfig.producerPrefix(ProducerConfig.COMPRESSION_ZSTD_LEVEL_CONFIG), 8);
         props.put(StreamsConfig.producerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
         props.put(StreamsConfig.consumerPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
         props.put(

--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -8,6 +8,7 @@ import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.internals.BlockBasedTableConfigWithAccessibleCache;
 import org.rocksdb.Cache;
 import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
 import org.rocksdb.InfoLogLevel;
 import org.rocksdb.Options;
 import org.rocksdb.RateLimiter;
@@ -64,6 +65,9 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         tableConfig.setOptimizeFiltersForMemory(OPTIMIZE_FILTERS_FOR_MEMORY);
         tableConfig.setBlockSize(BLOCK_SIZE);
         options.setTableFormatConfig(tableConfig);
+
+        // Compression
+        options.setCompressionType(CompressionType.ZSTD_COMPRESSION);
 
         options.setUseDirectIoForFlushAndCompaction(serverConfig.useDirectIOForRocksDB());
         options.setUseDirectReads(serverConfig.useDirectIOForRocksDB());


### PR DESCRIPTION
- LHS_X_USE_AT_LEAST_ONCE: removed since it is unadvisable.
- LHS_X_USE_STATE_UPDATER: removed since State Updater is now GA in Kafka Streams.
- LHS_X_LEAVE_GROUP_ON_SHUTDOWN: removed since we have functionality that relies on this being true.
- LHS_X_USE_STATIC_MEMBERSHIP: removed because it does not help and is no longer the recommended way to go in Kafka Streams.