### PR TITLE
chore(server): unify metrics configurations

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/config/ConfigBase.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/config/ConfigBase.java
@@ -1,6 +1,7 @@
 package io.littlehorse.sdk.common.config;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
@@ -14,35 +15,41 @@ public abstract class ConfigBase {
         this.props = ConfigSource.newSource(getEnvKeyPrefixes())
                 .loadFromConfigSource(configSource)
                 .toProperties();
+        initialize();
     }
 
     public ConfigBase(String propLocation) {
         this.props = ConfigSource.newSource(getEnvKeyPrefixes())
                 .loadFromPropertiesFile(propLocation)
                 .toProperties();
+        initialize();
     }
 
     public ConfigBase(Path propLocation) {
         this.props = ConfigSource.newSource(getEnvKeyPrefixes())
                 .loadFromPropertiesFile(propLocation)
                 .toProperties();
+        initialize();
     }
 
     public ConfigBase(Properties props) {
         this.props = ConfigSource.newSource(getEnvKeyPrefixes())
                 .loadFromProperties(props)
                 .toProperties();
+        initialize();
     }
 
     public ConfigBase(Map<String, Object> configs) {
         this.props =
                 ConfigSource.newSource(getEnvKeyPrefixes()).loadFromMap(configs).toProperties();
+        initialize();
     }
 
     public ConfigBase() {
         this.props = ConfigSource.newSource(getEnvKeyPrefixes())
                 .loadFromEnvVariables()
                 .toProperties();
+        initialize();
     }
 
     protected abstract String[] getEnvKeyPrefixes();
@@ -56,6 +63,27 @@ public abstract class ConfigBase {
             return defaultVal;
         } else {
             return String.valueOf(props.get(key));
+        }
+    }
+
+    /**
+     * Override this to do setup in the constructor.
+     */
+    protected void doSetup() {}
+
+    /**
+     * Override this to allow warning for deprecated or removed configs.
+     */
+    protected List<String> deprecatedConfigs() {
+        return List.of();
+    }
+
+    private void initialize() {
+        doSetup();
+        for (String config : deprecatedConfigs()) {
+            if (props.containsKey(config)) {
+                log.warn("Detected deprecated or removed config {}.", config);
+            }
         }
     }
 }

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -51,7 +51,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.rocksdb.Cache;
-import org.rocksdb.InfoLogLevel;
 import org.rocksdb.LRUCache;
 import org.rocksdb.RocksDB;
 import org.rocksdb.WriteBufferManager;
@@ -89,7 +88,6 @@ public class LHServerConfig extends ConfigBase {
     public static final String NUM_WARMUP_REPLICAS_KEY = "LHS_STREAMS_NUM_WARMUP_REPLICAS";
     public static final String NUM_STANDBY_REPLICAS_KEY = "LHS_STREAMS_NUM_STANDBY_REPLICAS";
     public static final String ROCKSDB_COMPACTION_THREADS_KEY = "LHS_ROCKSDB_COMPACTION_THREADS";
-    public static final String STREAMS_METRICS_LEVEL_KEY = "LHS_STREAMS_METRICS_LEVEL";
     public static final String LHS_METRICS_LEVEL_KEY = "LHS_METRICS_LEVEL";
     public static final String LINGER_MS_KEY = "LHS_KAFKA_LINGER_MS";
     public static final String TRANSACTION_TIMEOUT_MS_KEY = "LHS_STREAMS_TRANSACTION_TIMEOUT_MS";
@@ -147,12 +145,11 @@ public class LHServerConfig extends ConfigBase {
 
     // EXPERIMENTAL Internal configs. Should not be used by real users; only for testing.
     public static final String ROCKSDB_USE_LEVEL_COMPACTION_KEY = "LHS_X_ROCKSDB_USE_LEVEL_COMPACTION";
-    public static final String ROCKSDB_LOG_LEVEL_KEY = "LHS_X_ROCKSDB_LOG_LEVEL";
 
     public static final String X_ENABLE_STRUCT_DEFS_KEY = "LHS_X_ENABLE_STRUCT_DEFS";
 
     // Instance configs
-    private final String lhsMetricsLevel;
+    private String lhsMetricsLevel;
 
     // Singletons for RocksConfigSetter
     @Getter
@@ -161,27 +158,19 @@ public class LHServerConfig extends ConfigBase {
     @Getter
     private WriteBufferManager globalRocksdbWriteBufferManager;
 
-    public LHServerConfig() {
-        super();
+    @Override
+    protected void doSetup() {
         initKafkaAdmin();
         initRocksdbSingletons();
-        lhsMetricsLevel = getServerMetricLevel();
+        this.lhsMetricsLevel = getServerMetricLevel();
     }
 
-    public LHServerConfig(String propertiesPath) {
-        super(propertiesPath);
-        initKafkaAdmin();
-        initRocksdbSingletons();
-        lhsMetricsLevel = getServerMetricLevel();
+    @Override
+    protected List<String> deprecatedConfigs() {
+        return List.of("LHS_STREAMS_METRICS_LEVEL", "LHS_X_ROCKSDB_LOG_LEVEL");
     }
 
-    public LHServerConfig(Properties props) {
-        super(props);
-        initKafkaAdmin();
-        initRocksdbSingletons();
-        lhsMetricsLevel = getServerMetricLevel();
-    }
-
+    @Override
     protected String[] getEnvKeyPrefixes() {
         return new String[] {"LHS_"};
     }
@@ -735,27 +724,6 @@ public class LHServerConfig extends ConfigBase {
         return Boolean.valueOf(getOrSetDefault(ROCKSDB_USE_LEVEL_COMPACTION_KEY, "false"));
     }
 
-    public Optional<InfoLogLevel> getRocksDBLogLevel() {
-        String logLevel = getOrSetDefault(ROCKSDB_LOG_LEVEL_KEY, "NONE");
-        if (logLevel.equals("NONE")) {
-            return Optional.empty();
-        }
-        switch (logLevel) {
-            case "INFO":
-                return Optional.of(InfoLogLevel.INFO_LEVEL);
-            case "DEBUG":
-                return Optional.of(InfoLogLevel.DEBUG_LEVEL);
-            case "ERROR":
-                return Optional.of(InfoLogLevel.ERROR_LEVEL);
-            case "WARN":
-                return Optional.of(InfoLogLevel.WARN_LEVEL);
-            case "FATAL":
-                return Optional.of(InfoLogLevel.FATAL_LEVEL);
-        }
-        throw new LHMisconfigurationException(
-                "Unrecognized rocksdb log level: " + logLevel + "; allowed: INFO|DEBUG|WARN|ERROR|FATAL|NONE");
-    }
-
     public long getCoreMemtableSize() {
         // 64MB default
         return Long.valueOf(getOrSetDefault(CORE_MEMTABLE_SIZE_BYTES_KEY, String.valueOf(1024L * 1024L * 64)));
@@ -1015,9 +983,7 @@ public class LHServerConfig extends ConfigBase {
         props.put("num.standby.replicas", Integer.valueOf(getOrSetDefault(NUM_STANDBY_REPLICAS_KEY, "0")));
         props.put("max.warmup.replicas", Integer.valueOf(getOrSetDefault(NUM_WARMUP_REPLICAS_KEY, "4")));
         props.put("probing.rebalance.interval.ms", 60 * 1000);
-        props.put(
-                "metrics.recording.level",
-                getOrSetDefault(STREAMS_METRICS_LEVEL_KEY, "info").toUpperCase());
+        props.put("metrics.recording.level", getServerMetricLevel());
         props.put(StreamsConfig.producerPrefix(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG), getTransactionTimeoutMs());
 
         // Configs required by KafkaStreams. Some of these are overriden by the application logic itself.


### PR DESCRIPTION
- removes LHS_X_ROCKSDB_LOG_LEVEL
- removes LHS_STREAMS_METRICS_LEVEL
- relies on LHS_METRICS_LEVEL to configure all types of metrics. LHS_METRICS_LEVEL now translates exactly to kafka streams metrics level, and is translated one down to rocksdb.