### PR TITLE
perf(rocksdb): compress only bottom level

### DIFF
--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -7,6 +7,7 @@ import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.internals.BlockBasedTableConfigWithAccessibleCache;
 import org.rocksdb.Cache;
 import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionOptions;
 import org.rocksdb.CompressionType;
 import org.rocksdb.InfoLogLevel;
 import org.rocksdb.Options;
@@ -83,6 +84,11 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         // Compress the bottom level only, which contains about 90% of the database,
         // but shouldn't be involved in most of the write paths and I/O.
         options.setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
+        CompressionOptions compressionOptions = new CompressionOptions();
+        // Reduce ZSTD compression level to be faster at the cost of less disk savings.
+        compressionOptions.setLevel(1);
+        options.setCompressionOptions(compressionOptions);
+        compressionOptions.close();
 
         options.setUseDirectIoForFlushAndCompaction(serverConfig.useDirectIOForRocksDB());
         options.setUseDirectReads(serverConfig.useDirectIOForRocksDB());

--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -80,8 +80,9 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         tableConfig.setBlockSize(BLOCK_SIZE);
         options.setTableFormatConfig(tableConfig);
 
-        // Compression
-        options.setCompressionType(CompressionType.ZSTD_COMPRESSION);
+        // Compress the bottom level only, which contains about 90% of the database,
+        // but shouldn't be involved in most of the write paths and I/O.
+        options.setBottommostCompressionType(CompressionType.ZSTD_COMPRESSION);
 
         options.setUseDirectIoForFlushAndCompaction(serverConfig.useDirectIOForRocksDB());
         options.setUseDirectReads(serverConfig.useDirectIOForRocksDB());


### PR DESCRIPTION
Should reduce cpu utilization of compression.