### PR TITLE
chore(server): clean up session and transaction timeout configs

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -1061,8 +1061,8 @@ public class LHServerConfig extends ConfigBase {
         // need to allow users to configure a shorter session timeout than transaction timeout. This
         // may one day be fixed by KIP-1071 follow up.
         //
-        // We use a 45-second default timeout.
-        return Integer.valueOf(getOrSetDefault(LHServerConfig.SESSION_TIMEOUT_KEY, "45000"));
+        // We use a 60-second default timeout.
+        return Integer.valueOf(getOrSetDefault(LHServerConfig.SESSION_TIMEOUT_KEY, "60000"));
     }
 
     public int getStreamsStateCleanupDelayMs() {


### PR DESCRIPTION
There is no use in allowing users to configure different transaction timeouts versus consumer session timeouts. This is because:
- We **want** to leave the group during shutdown (eg. rolling restart), because #838 relies on a rebalance in order to maintain availability of waitForCommand.
- Since we **want** to leave the group on shutdown, a longer session timeout won't help compared to transaction timeout.
- In the event of a crash, we need to wait for the transaction to time out anyways before the partitions can be re-claimed by another instance.

In other words, if session.timeout.ms > transaction.timeout.ms, our unavailability window will be equal to the larger of the two values.

Therefore, it's safe (and advisable) to remove one of them and use the same value for both configs. This commit removes LHS_TRANSACTION_TIMEOUT_MS and utilizes LHS_STREAMS_SESSION_TIMEOUT.