### PR TITLE
fix(server): Remove unused fields in `WfService`

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
@@ -221,7 +221,7 @@ public class CoreProcessorContext implements ExecutionContext {
         if (service != null) {
             return service;
         }
-        service = new WfService(this.metadataManager, metadataCache, this);
+        service = new WfService(this.metadataManager);
         return service;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
@@ -67,7 +67,7 @@ public class MetadataProcessorContext implements ExecutionContext {
 
     @Override
     public WfService service() {
-        return new WfService(this.metadataManager, metadataCache, this);
+        return new WfService(this.metadataManager);
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/RepartitionExecutionContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/RepartitionExecutionContext.java
@@ -48,7 +48,7 @@ public class RepartitionExecutionContext implements ExecutionContext {
 
     @Override
     public WfService service() {
-        return new WfService(metadataManager, metadataCache, this);
+        return new WfService(metadataManager);
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/RequestExecutionContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/RequestExecutionContext.java
@@ -62,7 +62,7 @@ public class RequestExecutionContext implements ExecutionContext {
 
         this.readOnlyGetableManager = new ReadOnlyGetableManager(tenantCoreStore);
         this.metadataManager = new ReadOnlyMetadataManager(clusterMetadataStore, tenantMetadataStore, metadataCache);
-        this.service = new WfService(this.metadataManager, metadataCache, this);
+        this.service = new WfService(this.metadataManager);
         if (!tenantId.getId().equals(LHConstants.DEFAULT_TENANT)) {
             TenantModel storedTenant = metadataManager.get(tenantId);
             if (storedTenant == null) {

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/WfService.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/WfService.java
@@ -21,7 +21,6 @@ import io.littlehorse.common.proto.GetableClassEnum;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
 import io.littlehorse.server.streams.storeinternals.index.Attribute;
 import io.littlehorse.server.streams.storeinternals.index.Tag;
-import io.littlehorse.server.streams.util.MetadataCache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -31,14 +30,9 @@ import lombok.extern.slf4j.Slf4j;
 public class WfService {
 
     private final ReadOnlyMetadataManager metadataManager;
-    private final MetadataCache metadataCache;
-    private final ExecutionContext executionContext;
 
-    public WfService(
-            ReadOnlyMetadataManager metadataManager, MetadataCache metadataCache, ExecutionContext executionContext) {
-        this.metadataCache = metadataCache;
+    public WfService(ReadOnlyMetadataManager metadataManager) {
         this.metadataManager = metadataManager;
-        this.executionContext = executionContext;
     }
 
     public WfSpecModel getWfSpec(String name, Integer majorVersion, Integer revision) {
@@ -56,7 +50,6 @@ public class WfService {
 
             return storedResult;
         };
-        // return metadataCache.getOrCache(name, majorVersion, findWfSpec);
         return findWfSpec.get();
     }
 
@@ -109,26 +102,6 @@ public class WfService {
     }
 
     public TaskDefModel getTaskDef(String name) {
-        /*TaskDefIdModel id = new TaskDefIdModel(name);
-        Supplier<TaskDef> findTaskDef = () -> {
-            TaskDefModel result = metadataManager.get(id);
-            if (result != null) {
-                return result.toProto().build();
-            }
-            return null;
-        };
-        StoredGetablePb result = (StoredGetablePb) metadataCache.getOrCache(id.toProto().build(), findTaskDef::get);
-
-        if(result != null) {
-            try {
-                TaskDef taskDef = TaskDef.parseFrom(result.getGetablePayload());
-                return LHSerializable.fromProto(taskDef, TaskDefModel.class, executionContext);
-            } catch (Exception ex){
-                return null;
-            }
-        }else {
-            return null;
-        }*/
         TaskDefIdModel id = new TaskDefIdModel(name);
         return metadataManager.get(id);
     }


### PR DESCRIPTION
Removes unused fields in `WfService`, making `ReadOnlyMetadataManager metadataManager` the only constructor parameter.