### PR TITLE
fix(lhctl): Fix TaskDef command arguments and descriptions

### DIFF
--- a/lhctl/internal/task_def.go
+++ b/lhctl/internal/task_def.go
@@ -70,10 +70,11 @@ var getTaskDefCmd = &cobra.Command{
 }
 
 var searchTaskDefCmd = &cobra.Command{
-	Use:   "taskDef <prefix>",
+	Use:   "taskDef [<prefix>]",
 	Short: "Search for TaskDefs",
 	Long: `Search for TaskDefs.
-
+	
+You can search for all TaskDefs or may optionally provide a prefix for your search.
 	`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
This fixes some issues with the `lhctl` `TaskDef` commands.

GetTaskDefCmd:
- Upgraded to Cobra argument validators

SearchTaskDefCmd:
- Upgraded to match style guide, using argument instead of flag

DeleteTaskDef:
- Upgraded to match style guide
- Removed reference to TaskDef version (those don't exist!)