### PR TITLE
perf(server): shorten UserTaskRunId and TaskRunId

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/ScheduledTaskModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/ScheduledTaskModel.java
@@ -54,7 +54,7 @@ public class ScheduledTaskModel extends Storeable<ScheduledTask> {
         this.attemptNumber = 0;
 
         // This is just the wfRunId.
-        this.taskRunId = new TaskRunIdModel(userTaskRun.getNodeRunId().getWfRunId(), processorContext);
+        this.taskRunId = new TaskRunIdModel(userTaskRun);
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/TriggeredTaskRun.java
+++ b/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/TriggeredTaskRun.java
@@ -105,7 +105,7 @@ public class TriggeredTaskRun extends CoreSubCommand<TriggeredTaskRunPb> {
 
         try {
             List<VarNameAndValModel> inputVars = taskToSchedule.assignInputVars(thread, executionContext);
-            TaskRunIdModel taskRunId = new TaskRunIdModel(wfRunId, executionContext);
+            TaskRunIdModel taskRunId = new TaskRunIdModel(userTaskRun);
             TaskDefModel taskDef = taskToSchedule.getTaskDef(thread, executionContext);
             TaskDefIdModel id = taskDef.getId();
 

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/usertaskrun/UserTaskRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/usertaskrun/UserTaskRunModel.java
@@ -103,7 +103,7 @@ public class UserTaskRunModel extends CoreGetable<UserTaskRun> implements CoreOu
             CoreProcessorContext processorContext) {
         this.userTaskDefId = utd.getObjectId();
         this.nodeRunId = nodeRunModel.getObjectId();
-        this.id = new UserTaskRunIdModel(nodeRunId.getWfRunId());
+        this.id = new UserTaskRunIdModel(nodeRunId);
         this.scheduledTime = new Date();
         this.epoch = 0;
         this.userTaskNode = userTaskNode;

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/TaskNodeRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/TaskNodeRunModel.java
@@ -119,7 +119,7 @@ public class TaskNodeRunModel extends SubNodeRun<TaskNodeRun> {
         // Create a TaskRun
         TaskNodeReferenceModel source = new TaskNodeReferenceModel(nodeRun.getObjectId(), nodeRun.getWfSpecId());
 
-        this.taskRunId = new TaskRunIdModel(nodeRun.getId().getWfRunId(), processorContext);
+        this.taskRunId = new TaskRunIdModel(nodeRun.getId(), processorContext);
         TaskRunModel task = new TaskRunModel(
                 inputVariables,
                 new TaskRunSourceModel(source, processorContext),

--- a/server/src/main/java/io/littlehorse/common/model/getable/objectId/TaskRunIdModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/objectId/TaskRunIdModel.java
@@ -5,6 +5,7 @@ import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.model.getable.CoreObjectId;
 import io.littlehorse.common.model.getable.ObjectIdModel;
 import io.littlehorse.common.model.getable.core.taskrun.TaskRunModel;
+import io.littlehorse.common.model.getable.core.usertaskrun.UserTaskRunModel;
 import io.littlehorse.common.proto.GetableClassEnum;
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.TaskRun;
@@ -25,8 +26,16 @@ public class TaskRunIdModel extends CoreObjectId<TaskRunId, TaskRun, TaskRunMode
         this.taskGuid = guid;
     }
 
-    public TaskRunIdModel(WfRunIdModel wfRunId, CoreProcessorContext processorContext) {
-        this(wfRunId, LHUtil.generateGuid());
+    public TaskRunIdModel(NodeRunIdModel nodeRunId, CoreProcessorContext processorContext) {
+        this(nodeRunId.getWfRunId(), nodeRunId.getThreadRunNumber() + "-" + nodeRunId.getPosition());
+    }
+
+    public TaskRunIdModel(UserTaskRunModel userTaskRun) {
+        this(
+                userTaskRun.getId().getWfRunId(),
+                "ut-" + userTaskRun.getNodeRunId().getThreadRunNumber() + "-"
+                        + userTaskRun.getNodeRunId().getPosition() + "-"
+                        + userTaskRun.getEvents().size());
     }
 
     @Override

--- a/server/src/main/java/io/littlehorse/common/model/getable/objectId/UserTaskRunIdModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/objectId/UserTaskRunIdModel.java
@@ -28,12 +28,8 @@ public class UserTaskRunIdModel extends CoreObjectId<UserTaskRunId, UserTaskRun,
         this.userTaskGuid = guid;
     }
 
-    public UserTaskRunIdModel(WfRunIdModel wfRunId) {
-        this(wfRunId, LHUtil.generateGuid());
-    }
-
-    public UserTaskRunIdModel(String wfRunId) {
-        this(new WfRunIdModel(wfRunId));
+    public UserTaskRunIdModel(NodeRunIdModel nodeRunId) {
+        this(nodeRunId.getWfRunId(), nodeRunId.getThreadRunNumber() + "-" + nodeRunId.getPosition());
     }
 
     @Override

--- a/server/src/test/java/io/littlehorse/common/model/wfrun/subnoderun/TaskRunModelTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/wfrun/subnoderun/TaskRunModelTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import io.littlehorse.common.AuthorizationContext;
 import io.littlehorse.common.model.corecommand.subcommand.TaskClaimEvent;
 import io.littlehorse.common.model.getable.core.taskrun.TaskRunModel;
+import io.littlehorse.common.model.getable.objectId.NodeRunIdModel;
 import io.littlehorse.common.model.getable.objectId.TaskRunIdModel;
 import io.littlehorse.common.model.getable.objectId.TenantIdModel;
 import io.littlehorse.common.model.getable.objectId.WfRunIdModel;
@@ -31,7 +32,8 @@ public class TaskRunModelTest {
     void setTaskWorkerVersionAndIdToTaskRun() {
         // arrange. Complex because all the dependencies needed
         TaskRun taskRunProto = TaskRun.newBuilder()
-                .setId(new TaskRunIdModel(new WfRunIdModel("asdf"), processorContext).toProto())
+                .setId(new TaskRunIdModel(new NodeRunIdModel(new WfRunIdModel("asdf"), 0, 1), processorContext)
+                        .toProto())
                 .addAttempts(TaskAttempt.newBuilder().setStatus(TaskStatus.TASK_PENDING))
                 .build();
         when(executionContext.castOnSupport(CoreProcessorContext.class)).thenReturn(processorContext);


### PR DESCRIPTION
- UserTaskRun's can be uniquely identified by the NodeRun that they belong to.
- For TaskNode's, a TaskRun can also be uniquely identified by the NodeRun that it belongs to.
- Reminder TaskRun's can be uniquely identified by the NodeRun that they came from plus their position in the USerTaskEvents list.

This will have a few benefits:
- shortens TaskRunId and UserTaskRunId's which reduces strain on rocksdb
- make it easier to lhctl get taskRun with only one copy-n-paste
- make lhctl list taskRun print tasks in order