### PR TITLE
fix(server): fix gradle e2e task

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/TypeDefinitionModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/TypeDefinitionModel.java
@@ -11,7 +11,6 @@ import io.littlehorse.common.model.getable.global.wfspec.variable.expression.Int
 import io.littlehorse.common.model.getable.global.wfspec.variable.expression.JsonArrReturnTypeStrategy;
 import io.littlehorse.common.model.getable.global.wfspec.variable.expression.JsonObjReturnTypeStrategy;
 import io.littlehorse.common.model.getable.global.wfspec.variable.expression.LHTypeStrategy;
-import io.littlehorse.common.model.getable.global.wfspec.variable.expression.NullReturnTypeStrategy;
 import io.littlehorse.common.model.getable.global.wfspec.variable.expression.StrReturnTypeStrategy;
 import io.littlehorse.common.model.getable.global.wfspec.variable.expression.WfRunIdReturnTypeStrategy;
 import io.littlehorse.sdk.common.proto.TypeDefinition;


### PR DESCRIPTION
E2E tests task broke after upgrading to Java 24, this is AI's best attempt at fixing it. Needs a closer look, but works on my local machine.