### PR TITLE
fix(server): revert kafka from 4.1.0 to 4.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.0.0-development
 group=io.littlehorse
-kafkaVersion=4.1.0
+kafkaVersion=4.0.0
 lombokVersion=1.18.42
 grpcVersion=1.75.0
 junitVersion=5.13.1


### PR DESCRIPTION
Our soak testing tools detected some memory leaks coming from some Kafka Streams classes. This leak is not present in 4.0.

I'm reverting kafkaesque 4.1 until we have more details about this potential bug. 