### PR TITLE
fix(standalone): use server dist binary

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -37,8 +37,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: server-jar
-          path: server/build/libs/server-*-all.jar
+          name: server-dist
+          path: ./server/build/install/server/
 
       - name: Build and Publish
         uses: littlehorse-enterprises/publish-image@v1
@@ -134,11 +134,11 @@ jobs:
           npm ci
           npm run build
 
-      - name: Dowload Server Jar artifact
+      - name: Download Server dist artifact
         uses: actions/download-artifact@v4
         with:
-          name: server-jar
-          path: server/build/libs/
+          name: server-dist
+          path: server/build/install/server/
 
       - name: Build and Publish
         uses: littlehorse-enterprises/publish-image@v1

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -61,12 +61,7 @@ jobs:
           java-version: 24
 
       - name: Tests and Build
-        run: ./gradlew canary:build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: canary-jar
-          path: canary/build/libs/canary-*-all.jar
+        run: ./gradlew canary:installDist
 
       - name: Build and Publish
         uses: littlehorse-enterprises/publish-image@v1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -72,12 +72,7 @@ jobs:
           java-version: 24
 
       - name: Tests and Build
-        run: ./gradlew canary:build
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: canary-jar
-          path: canary/build/libs/canary-*-all.jar
+        run: ./gradlew canary:installDist
 
       - name: Build and Publish
         uses: littlehorse-enterprises/publish-image@v1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -32,11 +32,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: server-jar
-          path: server/build/libs/server-*-all.jar
-
-      - uses: actions/upload-artifact@v4
-        with:
           name: server-dist
           path: server/build/install/server
 
@@ -181,11 +176,11 @@ jobs:
           npm ci
           npm run build
 
-      - name: Dowload Server Jar artifact
+      - name: Download Server dist artifact
         uses: actions/download-artifact@v4
         with:
-          name: server-jar
-          path: server/build/libs/
+          name: server-dist
+          path: server/build/install/server/
 
       - name: Build and Publish
         uses: littlehorse-enterprises/publish-image@v1
@@ -196,4 +191,3 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch
-

--- a/docker/canary/Dockerfile
+++ b/docker/canary/Dockerfile
@@ -1,6 +1,9 @@
-FROM amazoncorretto:25
+FROM amazoncorretto:24-alpine
 WORKDIR /lh
 COPY ./docker/canary/docker-entrypoint.sh /lh
-COPY ./canary/build/libs/canary-*-all.jar /lh/canary.jar
+COPY ./canary/build/install/canary/lib /lh/lib
+COPY ./canary/build/install/canary/bin /lh/bin
+
+RUN apk add --no-cache libstdc++ 
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]
 CMD ["canary"]

--- a/docker/canary/docker-entrypoint.sh
+++ b/docker/canary/docker-entrypoint.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 if [ "$1" = 'canary' ]; then
     shift
-    exec java $JAVA_OPTS -jar /lh/canary.jar "$@"
+    exec /lh/bin/canary "$@"
 fi
 
 exec "$@"

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -24,6 +24,7 @@ COPY ./docker/standalone/dashboard-entrypoint.sh /lh
 COPY ./docker/standalone/docker-entrypoint.sh /lh
 COPY ./dashboard/.next/standalone /lh/dashboard
 COPY ./dashboard/.next/static /lh/dashboard/.next/static
-COPY ./server/build/libs/server-*-all.jar /lh/server.jar
+COPY ./server/build/install/server/lib /lh/lib
+COPY ./server/build/install/server/server /lh/bin
 
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]

--- a/docker/standalone/littlehorse-entrypoint.sh
+++ b/docker/standalone/littlehorse-entrypoint.sh
@@ -7,4 +7,4 @@ export LHS_CLUSTER_PARTITIONS=${LHS_CLUSTER_PARTITIONS:-12}
 export LHS_STATE_DIR=${LHS_STATE_DIR:-/data/lh}
 export LHS_SHOULD_CREATE_TOPICS=${LHS_SHOULD_CREATE_TOPICS:-true}
 
-exec java -jar /lh/server.jar
+exec /lh/bin/server

--- a/local-dev/build.sh
+++ b/local-dev/build.sh
@@ -65,6 +65,6 @@ if [[ ${standalone} = true ]]; then
     npm install
     npm run build
     cd ..
-    ./gradlew server:shadowJar -x test -x spotlessJavaCheck
+    ./gradlew server:installDist -x test -x spotlessJavaCheck
     docker build -t littlehorse/lh-standalone:latest -f docker/standalone/Dockerfile .
 fi

--- a/local-dev/build.sh
+++ b/local-dev/build.sh
@@ -49,7 +49,7 @@ fi
 
 if [[ ${canary} = true ]]; then
     echo "Building lh-canary"
-    ./gradlew canary:shadowJar -x test -x spotlessJavaCheck
+    ./gradlew canary:installDist -x test -x spotlessJavaCheck
     docker build -t littlehorse/lh-canary:latest -f docker/canary/Dockerfile .
 fi
 


### PR DESCRIPTION
ShadowJar is broken since the Java upgrade. This makes the standalone image to use the built binary.