### PR TITLE
fix(docker): fix execution permissions for canary and standalone

### DIFF
--- a/docker/canary/Dockerfile
+++ b/docker/canary/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /lh
 COPY ./docker/canary/docker-entrypoint.sh /lh
 COPY ./canary/build/install/canary/lib /lh/lib
 COPY ./canary/build/install/canary/bin /lh/bin
-
-RUN apk add --no-cache libstdc++ 
+RUN ["chmod", "+x", "/lh/bin/canary"]
+RUN apk add --no-cache libstdc++
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]
 CMD ["canary"]

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -26,5 +26,6 @@ COPY ./dashboard/.next/standalone /lh/dashboard
 COPY ./dashboard/.next/static /lh/dashboard/.next/static
 COPY ./server/build/install/server/lib /lh/lib
 COPY ./server/build/install/server/server /lh/bin
+RUN ["chmod", "+x", "/lh/bin/server"]
 
 ENTRYPOINT ["/lh/docker-entrypoint.sh"]


### PR DESCRIPTION
While running in docker desktop this permission is important. 