### PR TITLE
perf(server): reduce write amplification and upgrade kafka

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.16.0-SNAPSHOT
 group=io.littlehorse
-kafkaVersion=4.0.0
+kafkaVersion=4.0.1
 lombokVersion=1.18.42
 grpcVersion=1.75.0
 junitVersion=5.13.1

--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -979,6 +979,9 @@ public class LHServerConfig extends ConfigBase {
         props.put(
                 StreamsConfig.adminClientPrefix(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG), "rebootstrap");
 
+        // Reduce the chattiness of the logs to once every 15 minutes (Streams default 2 minutes).
+        props.put(StreamsConfig.LOG_SUMMARY_INTERVAL_MS_CONFIG, 1000 * 60 * 15);
+
         // Due to bug in Kafka Streams, the only way to get the server to leave the group on shutdown is to use this
         // internal flag. We actually want to leave the group when we close() so that tasks can be reassigned during
         // a rolling restart. Our optimization in this ticket #497 relies on leaving the group during a rolling bounce.

--- a/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
+++ b/server/src/main/java/io/littlehorse/common/util/RocksConfigSetter.java
@@ -87,12 +87,10 @@ public class RocksConfigSetter implements RocksDBConfigSetter {
         // Therefore, we use other configs to attempt to reduce WA.
         // Configurations to avoid the "many small L0 files" problem
         options.setCompactionStyle(CompactionStyle.LEVEL);
-        options.setMaxWriteBufferNumber(4);
-        options.setMinWriteBufferNumberToMerge(2);
+        options.setMaxWriteBufferNumber(3);
         options.setTargetFileSizeBase(128 * MB); // 64MB is default. We merge write buffers, so this is needed.
-        options.setLevel0FileNumCompactionTrigger(4);
+        options.setLevel0FileNumCompactionTrigger(12); // Default 4, higher means lower WA especially before KIP-1035
         options.setMaxBytesForLevelBase(128 * MB * 4); // Same as the compaction trigger
-        options.setMaxBytesForLevelMultiplier(12); // default 10; higher means lower Write Amp but bigger compactions
         options.setCompactionPriority(CompactionPriority.ByCompensatedSize); // Good for deletes / overwrites
         options.setBottommostCompressionType(CompressionType.LZ4_COMPRESSION);
 

--- a/server/src/main/java/io/littlehorse/server/monitoring/HealthService.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/HealthService.java
@@ -84,7 +84,7 @@ public class HealthService implements Closeable, StateRestoreListener, StandbyUp
 
         coreStreams.setStateListener(coreState);
         timerStreams.setStateListener((newState, oldState) -> {
-            log.info("New state for timer topology: {}", newState);
+            log.debug("New state for timer topology: {}", newState);
             timerState = newState;
         });
     }
@@ -100,7 +100,7 @@ public class HealthService implements Closeable, StateRestoreListener, StandbyUp
 
     @Override
     public void onRestoreStart(TopicPartition tp, String storeName, long startingOffset, long endingOffset) {
-        log.info("Starting restoration for store {} partition {}", storeName, tp.partition());
+        log.debug("Starting restoration for store {} partition {}", storeName, tp.partition());
         restorations.put(tp, new InProgressRestoration(tp, storeName, startingOffset, endingOffset, config));
     }
 
@@ -111,14 +111,14 @@ public class HealthService implements Closeable, StateRestoreListener, StandbyUp
 
     @Override
     public void onRestoreEnd(TopicPartition tp, String storeName, long totalRestored) {
-        log.info("Completed restoration for store {} partition {}", storeName, tp.partition());
+        log.debug("Completed restoration for store {} partition {}", storeName, tp.partition());
         restorations.remove(tp);
     }
 
     @Override
     public void onRestoreSuspended(TopicPartition tp, String storeName, long totalRestored) {
         // This is harmless; it means the Task was migrated to another instance.
-        log.info("Suspending restoration for store {} partition {}", storeName, tp.partition());
+        log.debug("Suspending restoration for store {} partition {}", storeName, tp.partition());
         restorations.remove(tp);
     }
 

--- a/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/metrics/InstanceState.java
@@ -84,7 +84,7 @@ public class InstanceState implements MeterBinder, KafkaStreams.StateListener, C
                 log.warn("Failed to handle async waiters reassignment: " + toIgnore.getMessage());
             }
         }
-        log.info("New state for core topology: {}", newState);
+        log.debug("New state for core topology: {}", newState);
     }
 
     @Override

--- a/server/src/main/resources/log4j2.properties
+++ b/server/src/main/resources/log4j2.properties
@@ -16,6 +16,12 @@ appender.kafka.name = kafka
 appender.kafka.layout.type = PatternLayout
 appender.kafka.layout.pattern = %d{HH:mm:ss} %highlight{%-5p} [KAFKA] %c{1} - %m%n
 
+# Console streams appender configuration
+appender.streams.type = Console
+appender.streams.name = streams
+appender.streams.layout.type = PatternLayout
+appender.streams.layout.pattern = %d{HH:mm:ss} %highlight{%-5p} [STREAMS] %c{1} - %m%n
+
 # Console server appender configuration
 appender.server.type = Console
 appender.server.name = server
@@ -31,10 +37,15 @@ appender.grpc.layout.pattern = %d{HH:mm:ss} %highlight{%-5p} [GRPC] %c{1} - %m%n
 # Root logger level
 rootLogger = ERROR, error
 
-# Kafka logger
+# Kafka Clients logger
 logger.kafka = ${env:KAFKA_LOG_LEVEL:-WARN}, kafka
 logger.kafka.name = org.apache.kafka
 logger.kafka.additivity = false
+
+# Kafka Streams logger
+logger.streams = ${env:LOG_LEVEL:-INFO}, streams
+logger.streams.name = org.apache.kafka.streams
+logger.streams.additivity = false
 
 # Server logger
 logger.server = ${env:LOG_LEVEL:-INFO}, server


### PR DESCRIPTION
- Kafka Streams logs at same level as Server
- Upgrade to Kafka 4.0.1
- Increase the num level 0 files compaction trigger to reduce write amplification