### PR TITLE
feat(dashboard): Fix finishing date when the node is not done yet

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/NodeRunInfo.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/NodeRunInfo.tsx
@@ -23,7 +23,7 @@ export const NodeRunInfo: FC<{ nodeRunIndex: number }> = ({ nodeRunIndex }) => {
       <NodeVariable label="Workflow Spec :" text={nodeRun.wfSpecId?.name ?? 'N/A'} />
       <NodeVariable label="Threat name :" text={nodeRun.threadSpecName} />
       <NodeVariable label="Started :" text={nodeRun.arrivalTime} type={'date'} />
-      <NodeVariable label="Finished :" text={nodeRun.endTime} type={'date'} />
+      {nodeRun.status !== 'RUNNING' && <NodeVariable label="Finished :" text={nodeRun.endTime} type={'date'} />}
     </div>
   )
 }


### PR DESCRIPTION
It should not show the finishing date when the node is not done yet.
running
<img width="441" height="415" alt="image" src="https://github.com/user-attachments/assets/3b1a17cd-faa3-488d-ae28-1d8e55c48cf0" />

done
<img width="385" height="332" alt="image" src="https://github.com/user-attachments/assets/ffef9db0-f5e3-4a71-a21f-a6f9ffce1df4" />
