### PR TITLE
fix(server): loosen ACL restrictions on `getScheduledWfRun` endpoint

### DIFF
--- a/server/src/main/java/io/littlehorse/server/LHServerListener.java
+++ b/server/src/main/java/io/littlehorse/server/LHServerListener.java
@@ -259,6 +259,7 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
     }
 
     @Override
+    @Authorize(resources = ACLResource.ACL_WORKFLOW, actions = ACLAction.READ)
     public void getScheduledWfRun(ScheduledWfRunId req, StreamObserver<ScheduledWfRun> ctx) {
         ScheduledWfRunIdModel scheduledWfId =
                 LHSerializable.fromProto(req, ScheduledWfRunIdModel.class, requestContext());


### PR DESCRIPTION
This PR loosens the ACL restrictions on calling the `getScheduledWfRun` endpoint, which previously were set to the default of requiring Admin ACL permissions.