### PR TITLE
fix(server): Limit the number of concurrent calls per connection

### DIFF
--- a/server/src/main/java/io/littlehorse/server/LHServerListener.java
+++ b/server/src/main/java/io/littlehorse/server/LHServerListener.java
@@ -11,6 +11,7 @@ import io.grpc.ServerBuilder;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.littlehorse.common.AuthorizationContext;
 import io.littlehorse.common.LHConstants;
@@ -210,10 +211,11 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
 
         this.grpcListener = null;
 
-        ServerBuilder<?> builder = Grpc.newServerBuilderForPort(
+        NettyServerBuilder builder = NettyServerBuilder.forPort(
                         listenerConfig.getPort(), listenerConfig.getCredentials())
                 .permitKeepAliveTime(15, TimeUnit.SECONDS)
                 .permitKeepAliveWithoutCalls(true)
+                .maxConcurrentCallsPerConnection(100)
                 .addService(this)
                 .executor(networkThreads);
 


### PR DESCRIPTION
Having multiple worker instances with many different threads could lead to OutOfMemoryErrors on the server side. This PR proposes a limit for the number of concurrent call per connection, that limits the number of memory resources needed to handle large amount of concurrent calls. 

<img width="1138" height="628" alt="image" src="https://github.com/user-attachments/assets/60cd28dd-0488-4b40-a9af-42cea14f2ee6" />
The image above, shows the memory usage when running 100K stream observers for the Poll Task protocol, and it rapidly causes OOM errors. 

We observed a constant memory usage after applying a limit of 100 concurrent calls per connection
<img width="1160" height="650" alt="image" src="https://github.com/user-attachments/assets/af8ba50e-b789-43bb-b4d3-a92d4c48d2dc" />


This might impact the performance when having many clients sending concurrent calls, but it can be mitigated by scaling the number of grpc server listeners.