### PR TITLE
feat(server): Control output topic auto creation with LHS_SHOULD_CREATE_TOPICS config

### DIFF
--- a/server/src/test/resources/test.properties
+++ b/server/src/test/resources/test.properties
@@ -1,1 +1,1 @@
-bootstrapper.class = e2e.ExternalTestBootstrapper
+bootstrapper.class = e2e.StandaloneTestBootstrapper


### PR DESCRIPTION
This PR proposes a way to control output topics auto creation when `LHS_SHOULD_CREATE_TOPICS` is set to false. The goal here is to avoid sending create topic requests to the kafka clusters when this config is set to false.

Usually, Littlehorse operators set this config to false when to productions like staging or production.