### PR TITLE
fix(test-utils): Cleans up the worker from the context after each execution

### DIFF
--- a/server/src/test/java/e2e/BasicTest.java
+++ b/server/src/test/java/e2e/BasicTest.java
@@ -1,11 +1,13 @@
 package e2e;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.WfRunId;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import io.littlehorse.sdk.wfsdk.Workflow;
 import io.littlehorse.sdk.wfsdk.internal.WorkflowImpl;
 import io.littlehorse.sdk.worker.LHTaskMethod;
@@ -13,7 +15,6 @@ import io.littlehorse.test.LHTest;
 import io.littlehorse.test.LHWorkflow;
 import io.littlehorse.test.WithWorkers;
 import io.littlehorse.test.WorkflowVerifier;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @LHTest
@@ -23,6 +24,9 @@ public class BasicTest {
 
     @LHWorkflow("test-basic")
     private Workflow basicWf;
+
+    @LHWorkflow("test-reused-tasks")
+    private Workflow reusedWorkerWf;
 
     private WorkflowVerifier verifier;
 
@@ -43,6 +47,14 @@ public class BasicTest {
         });
     }
 
+    @LHWorkflow("test-reused-tasks")
+    public Workflow getPepe() {
+        return new WorkflowImpl("test-reused-tasks", thread -> {
+            WfRunVariable output = thread.declareStr("output");
+            output.assign(thread.execute("reused-task"));
+        });
+    }
+
     @Test
     public void runWfShouldFailWithInvalidId() {
         StatusRuntimeException caught = assertThrows(StatusRuntimeException.class, () -> {
@@ -51,7 +63,7 @@ public class BasicTest {
                     .start(WfRunId.newBuilder().setId("my_workflow").build());
         });
 
-        Assertions.assertThat(caught.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+        assertThat(caught.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
     }
 
     public Object basicWorker() {
@@ -64,6 +76,44 @@ public class BasicTest {
 
     public Object basicWorker3() {
         return new BasicWorker3();
+    }
+
+    public Object reusedWorker() {
+        return new ReusedWorker();
+    }
+
+    /**
+     * The test-utils library was not cleaning the context when @WithWorkers annotation was placed
+     * at the method level. As a result, if the same task was used in two different tests, then the
+     * second test would fail. Do not remove this test, it's testing that the bug got fixed and is not
+     * introduced again
+     */
+    @Test
+    @WithWorkers("reusedWorker")
+    public void shouldCompleteWithReusedTask() {
+        verifier.prepareRun(reusedWorkerWf)
+                .waitForStatus(LHStatus.COMPLETED)
+                .thenVerifyVariable(0, "output", variableValue -> {
+                    assertThat(variableValue.getStr()).isEqualTo("something");
+                })
+                .start();
+    }
+
+    /**
+     * The test-utils library was not cleaning the context when @WithWorkers annotation was placed
+     * at the method level. As a result, if the same task was used in two different tests, then the
+     * second test would fail. Do not remove this test, it's testing that the bug got fixed and is not
+     * introduced again
+     */
+    @Test
+    @WithWorkers("reusedWorker")
+    public void shouldCompleteWithReusedTask2() {
+        verifier.prepareRun(reusedWorkerWf)
+                .waitForStatus(LHStatus.COMPLETED)
+                .thenVerifyVariable(0, "output", variableValue -> {
+                    assertThat(variableValue.getStr()).isEqualTo("something");
+                })
+                .start();
     }
 
     public class BasicWorker {
@@ -107,6 +157,14 @@ public class BasicTest {
         @LHTaskMethod("seven")
         public boolean one() {
             return true;
+        }
+    }
+
+    public class ReusedWorker {
+
+        @LHTaskMethod("reused-task")
+        public String reusedTask() {
+            return "something";
         }
     }
 }

--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -285,6 +285,7 @@ public class LHExtension
         for (String taskDefName : taskDefNames) {
             LHTaskWorker taskWorker = (LHTaskWorker) store.get(taskDefName);
             taskWorker.close();
+            store.remove(taskDefName);
         }
     }
 }


### PR DESCRIPTION
The test-utils library is closing the worker after each test execution but it's not removing it from the test context store. When another test uses the same worker, it cannot because it's closed and it cannot recreate it one because it's in the test context store.

<img width="2100" height="808" alt="image" src="https://github.com/user-attachments/assets/77cc8c6d-d45e-487b-928a-28a117de8000" />

<img width="1712" height="988" alt="image" src="https://github.com/user-attachments/assets/3d53fd40-7308-4588-895c-63ed6a1fa29b" />
