### PR TITLE
feat(dashboard): sort WfSpec threads with entrypoint first, then branches, then handlers

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/ThreadPanel.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/ThreadPanel.tsx
@@ -72,10 +72,7 @@ export const ThreadPanel: FC<{ spec: WfSpec; wfRun?: WfRun }> = ({ spec, wfRun }
 
   const threads = useMemo((): { name: string; number: number }[] => {
     if (!wfRun) {
-      const sorted = sortThreadNames(
-        Object.keys(spec.threadSpecs),
-        spec.entrypointThreadName
-      )
+      const sorted = sortThreadNames(spec)
       return sorted.map(name => ({ name, number: 0 }))
     }
 

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/ThreadPanel.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/ThreadPanel.tsx
@@ -9,6 +9,7 @@ import { useDiagram } from '../hooks/useDiagram'
 import { useReplaceQueryValue } from '../hooks/useReplaceQueryValue'
 import { useScrollbar } from '../hooks/useScrollbar'
 import { useThreadRunPagination } from '../hooks/useThreadRunPagination'
+import { sortThreadNames } from '../utils/sortThreadNames'
 
 export const ThreadPanel: FC<{ spec: WfSpec; wfRun?: WfRun }> = ({ spec, wfRun }) => {
   const { thread, setThread } = useDiagram()
@@ -71,7 +72,11 @@ export const ThreadPanel: FC<{ spec: WfSpec; wfRun?: WfRun }> = ({ spec, wfRun }
 
   const threads = useMemo((): { name: string; number: number }[] => {
     if (!wfRun) {
-      return Object.keys(spec.threadSpecs).map(name => ({ name, number: 0 }))
+      const sorted = sortThreadNames(
+        Object.keys(spec.threadSpecs),
+        spec.entrypointThreadName
+      )
+      return sorted.map(name => ({ name, number: 0 }))
     }
 
     return threadRuns.map(threadRun => ({

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/utils/sortThreadNames.ts
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/utils/sortThreadNames.ts
@@ -1,0 +1,16 @@
+/**
+ * Sorts WfSpec thread names for display: entrypoint first, then user-named
+ * threads (e.g. fetch-docs-branch, index-branch), then exception handlers
+ * (exn-handler-*) alphabetically.
+ */
+export function sortThreadNames(names: string[], entrypointThreadName: string): string[] {
+  const entrypoint = entrypointThreadName
+  const rest = names.filter(n => n !== entrypoint)
+  const userThreads = rest.filter(n => !n.startsWith('exn-handler-')).sort((a, b) => a.localeCompare(b))
+  const exnHandlers = rest.filter(n => n.startsWith('exn-handler-')).sort((a, b) => a.localeCompare(b))
+  return [
+    ...(names.includes(entrypoint) ? [entrypoint] : []),
+    ...userThreads,
+    ...exnHandlers,
+  ]
+}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/utils/sortThreadNames.ts
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/utils/sortThreadNames.ts
@@ -1,16 +1,81 @@
-/**
- * Sorts WfSpec thread names for display: entrypoint first, then user-named
- * threads (e.g. fetch-docs-branch, index-branch), then exception handlers
- * (exn-handler-*) alphabetically.
- */
-export function sortThreadNames(names: string[], entrypointThreadName: string): string[] {
-  const entrypoint = entrypointThreadName
-  const rest = names.filter(n => n !== entrypoint)
-  const userThreads = rest.filter(n => !n.startsWith('exn-handler-')).sort((a, b) => a.localeCompare(b))
-  const exnHandlers = rest.filter(n => n.startsWith('exn-handler-')).sort((a, b) => a.localeCompare(b))
-  return [
-    ...(names.includes(entrypoint) ? [entrypoint] : []),
-    ...userThreads,
-    ...exnHandlers,
-  ]
+import { WfSpec } from 'littlehorse-client/proto'
+
+type NodeLike = {
+  outgoingEdges?: { sinkNodeName: string }[]
+  failureHandlers?: { handlerSpecName?: string; handler_spec_name?: string }[]
+  node?: {
+    $case: string
+    value?: Record<string, unknown>
+  }
+}
+
+/** DFS from entrypoint; collect thread names. wait_for_threads handlers (on node or in value) go to deferred. */
+function definitionOrder(spec: WfSpec): string[] {
+  const ep = spec.threadSpecs[spec.entrypointThreadName]
+  const nodes = ep?.nodes as Record<string, NodeLike> | undefined
+  if (!nodes) return []
+
+  const entryId = Object.entries(nodes).find(([, n]) => n.node?.$case === 'entrypoint')?.[0]
+  if (!entryId) return []
+
+  const seen = new Set<string>()
+  const order: string[] = []
+  const deferred: string[] = []
+  const map = nodes
+
+  function add(name: string, toDeferred = false) {
+    if (!name || seen.has(name)) return
+    seen.add(name)
+    if (toDeferred) deferred.push(name)
+    else order.push(name)
+  }
+
+  const visited = new Set<string>()
+  function visit(id: string) {
+    if (visited.has(id)) return
+    visited.add(id)
+    const n = map[id]
+    if (!n) return
+    const inner = n.node
+    const isWait = inner?.$case === 'wait_for_threads' || inner?.$case === 'waitForThreads'
+
+    // Failure handlers: defer if this node is wait_for_threads, else add to order
+    for (const h of n.failureHandlers ?? []) {
+      const name = h.handlerSpecName ?? h.handler_spec_name
+      if (name) add(name, isWait)
+    }
+
+    const v = inner?.value as { threadSpecName?: string; thread_spec_name?: string; perThreadFailureHandlers?: { handlerSpecName?: string; handler_spec_name?: string }[]; per_thread_failure_handlers?: { handlerSpecName?: string; handler_spec_name?: string }[] } | undefined
+    const threadName = v?.threadSpecName ?? v?.thread_spec_name
+    const isStartThread = inner?.$case === 'start_thread' || inner?.$case === 'startThread'
+    const isStartMultiple = inner?.$case === 'start_multiple_threads' || inner?.$case === 'startMultipleThreads'
+    if (isStartThread && threadName) add(threadName)
+    if (isStartMultiple && threadName) add(threadName)
+
+    const perThread = v?.perThreadFailureHandlers ?? v?.per_thread_failure_handlers ?? []
+    if (isWait) {
+      for (const h of perThread) {
+        const name = h?.handlerSpecName ?? h?.handler_spec_name
+        if (name) add(name, true)
+      }
+    }
+
+    for (const e of n.outgoingEdges ?? []) if (map[e.sinkNodeName]) visit(e.sinkNodeName)
+  }
+  visit(entryId)
+  return [...order, ...deferred]
+}
+
+/** Thread names in WfSpec definition order: entrypoint first, then as referenced in entrypoint graph, then rest alphabetical. */
+export function sortThreadNames(spec: WfSpec): string[] {
+  const all = Object.keys(spec.threadSpecs)
+  const ep = spec.entrypointThreadName
+  const ordered = definitionOrder(spec)
+  if (ordered.length === 0) {
+    const rest = all.filter(n => n !== ep).sort((a, b) => a.localeCompare(b))
+    return [...(all.includes(ep) ? [ep] : []), ...rest]
+  }
+  const result = [...(all.includes(ep) ? [ep] : []), ...ordered.filter(n => n !== ep)]
+  const rest = all.filter(n => !result.includes(n)).sort((a, b) => a.localeCompare(b))
+  return [...result, ...rest]
 }

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
@@ -39,7 +39,7 @@ export const WfSpec: FC<WfSpecProps> = ({ spec }) => {
       <DiagramProvider value={{ thread, setThread, selectedNode, setSelectedNode }}>
         <Diagram spec={spec} />
       </DiagramProvider>
-      {sortThreadNames(Object.keys(spec.threadSpecs), spec.entrypointThreadName).map(name => (
+      {sortThreadNames(spec).map(name => (
           <Thread key={name} name={name} spec={spec.threadSpecs[name]} />
         ))}
 

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
@@ -7,6 +7,7 @@ import { LucidePlayCircle } from 'lucide-react'
 import { FC, useCallback, useState } from 'react'
 import { Diagram } from '../../../components/Diagram'
 import { useModal } from '../../../hooks/useModal'
+import { sortThreadNames } from '../../../utils/sortThreadNames'
 import { Details } from './Details'
 import { ScheduledWfRuns } from './ScheduledWfRuns'
 import { Thread } from './Thread'
@@ -38,9 +39,7 @@ export const WfSpec: FC<WfSpecProps> = ({ spec }) => {
       <DiagramProvider value={{ thread, setThread, selectedNode, setSelectedNode }}>
         <Diagram spec={spec} />
       </DiagramProvider>
-      {Object.keys(spec.threadSpecs)
-        .reverse()
-        .map(name => (
+      {sortThreadNames(Object.keys(spec.threadSpecs), spec.entrypointThreadName).map(name => (
           <Thread key={name} name={name} spec={spec.threadSpecs[name]} />
         ))}
 


### PR DESCRIPTION
## Summary
Sort WfSpec thread tabs and accordions so the main flow and branches appear before exception handlers.

## Changes
- **Entrypoint first** – main workflow thread is always first
- **User-named threads next** – e.g. `fetch-docs-branch`, `index-branch`, alphabetically
- **Exception handlers last** – `exn-handler-*` threads grouped at the end, alphabetically

## Implementation
- Added `sortThreadNames()` in `dashboard/.../diagram/utils/sortThreadNames.ts`
- ThreadPanel (tabs above the diagram) and WfSpec (thread accordions below) both use this sort

## Example (ingest-repo)
Before: entrypoint could appear in the middle; exn-handler threads mixed with branches.
After: **entrypoint** → **fetch-docs-branch** → **index-branch** → **exn-handler-1-...** → **exn-handler-2-...** → **exn-handler-5-...**