### PR TITLE
feat(sdk-js): added support for mTLS

### DIFF
--- a/dashboard/.env.sample
+++ b/dashboard/.env.sample
@@ -3,6 +3,13 @@ LHC_API_HOST=localhost
 LHC_API_PORT=2023
 # LHC_API_PROTOCOL=
 # LHC_CA_CERT=
+# LHC_CLIENT_CERT=
+# LHC_CLIENT_KEY=
+
+## If using mTLS with `./local-dev/do-server.sh mtls` use this config:
+# LHC_CLIENT_CERT=<workspace>/littlehorse/local-dev/certs/client/client.crt
+# LHC_CLIENT_KEY=<workspace>/littlehorse/local-dev/certs/client/client.key
+# LHC_CA_CERT=<workspace>/littlehorse/local-dev/certs/ca/ca.crt
 
 # OAuth Configuration
 LHD_OAUTH_ENABLED=false

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -37,6 +37,8 @@ If running the app without Docker, you need to fill in the environment variables
 - `LHC_API_PORT` littlehorse port
 - `LHC_CA_CERT` To specify the path to the self signed certificate that the dashboard needs to connect to a LittleHorse server configured to work with OAuth.
 - `LHC_API_PROTOCOL` specify the communication protocol PLAINTEXT or TLS. If not provided it defaults to PLAINTEXT.
+- `LHC_CLIENT_CERT` To specify the path to the client certificate that the dashboard needs to connect to a LittleHorse server configured to work with mTLS.
+- `LHC_CLIENT_KEY` To specify the path to the client key that the dashboard needs to connect to a LittleHorse server configured to work with mTLS.
 - `LHD_OAUTH_ENABLED` enable oauth authentication
 - `LHD_OAUTH_ENCRYPT_SECRET` random string that will be used to encrypt the secrets and also the JWT token
 - `LHD_OAUTH_CALLBACK_URL` the url (domain) in which the dashboard will run (required for some authentication methods). For your local you can use: `http:/localhost:3001/`
@@ -121,6 +123,23 @@ docker run --rm
 --network host
 ghcr.io/littlehorse-enterprises/littlehorse/lh-dashboard:master
 ```
+
+## mTLS
+Assuming you have a folder `./certs` containing `ca.crt`, `client.crt`, and `client.key`
+
+```bash
+docker run --rm \
+  --env LHC_API_HOST='localhost' \
+  --env LHC_API_PORT='2023' \
+  --env LHC_API_PROTOCOL='TLS' \
+  --env LHC_CLIENT_CERT='/certs/client.crt' \
+  --env LHC_CLIENT_KEY='/certs/client.key' \
+  --env LHC_CA_CERT='/certs/ca.crt' \
+  --network host \
+  -v ./certs:/certs \
+  ghcr.io/littlehorse-enterprises/littlehorse/lh-dashboard:master
+```
+
 
 ## SSL termination
 

--- a/dashboard/src/lhConfig.ts
+++ b/dashboard/src/lhConfig.ts
@@ -5,6 +5,8 @@ const CONFIG = {
   apiPort: process.env.LHC_API_PORT || '2023',
   protocol: process.env.LHC_API_PROTOCOL || 'PLAINTEXT',
   caCert: process.env.LHC_CA_CERT,
+  clientCert: process.env.LHC_CLIENT_CERT,
+  clientKey: process.env.LHC_CLIENT_KEY,
 }
 
 const config = LHConfig.from(CONFIG)

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -243,7 +243,7 @@ lhctl put principal <your principal name> --acl "acl_workflow:read" --tenantId <
 ./local-dev/issue-certificates.sh
 ```
 
-5. Ensure you have the following configuration settings in your LittleHorse server `/local-dev/mlts.config` file:
+5. Ensure you have the following configuration settings in your LittleHorse server `local-dev/configs/mtls.config` file:
 ```
 LHS_LISTENERS=MTLS:2023
 LHS_LISTENERS_PROTOCOL_MAP=MTLS:MTLS

--- a/sdk-js/fixtures/littlehorse.config
+++ b/sdk-js/fixtures/littlehorse.config
@@ -3,6 +3,8 @@ LHC_API_PORT=2023
 LHC_API_PROTOCOL=TLS
 LHC_TENANT_ID=example
 LHC_CA_CERT=/path/to/cert.crt
+LHC_CLIENT_CERT=/path/to/client.crt
+LHC_CLIENT_KEY=/path/to/client.key
 IGNORED_PROPERTY=should be ignored
 # Comments are also ignored
 # LHC_API_PORT=ignored

--- a/sdk-js/src/LHConfig.test.ts
+++ b/sdk-js/src/LHConfig.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { readFileSync } from 'fs'
+import { ChannelCredentials, createChannel } from 'nice-grpc'
+import { LHConfig } from './LHConfig'
+
+const createMock = jest.fn()
+const useMock = jest.fn().mockReturnValue({ create: createMock })
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+}))
+
+jest.mock('nice-grpc', () => ({
+  ChannelCredentials: {
+    createSsl: jest.fn(),
+  },
+  createChannel: jest.fn(),
+  createClientFactory: jest.fn(() => ({
+    use: useMock,
+  })),
+  Metadata: jest.fn(() => ({
+    append: jest.fn().mockReturnThis(),
+  })),
+}))
+
+describe('LHConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('creates a plaintext channel by default', () => {
+    LHConfig.from({})
+
+    expect(ChannelCredentials.createSsl).not.toHaveBeenCalled()
+    expect(createChannel).toHaveBeenCalledWith('localhost:2023', undefined)
+  })
+
+  it('creates TLS channel credentials with a CA certificate', () => {
+    const caBuffer = Buffer.from('ca-cert')
+    const tlsCreds = {} as ReturnType<typeof ChannelCredentials.createSsl>
+    ;(readFileSync as jest.Mock).mockReturnValue(caBuffer)
+    ;(ChannelCredentials.createSsl as jest.Mock).mockReturnValue(tlsCreds)
+
+    const config = LHConfig.from({
+      protocol: 'TLS',
+      caCert: '/path/to/ca.crt',
+    })
+
+    expect(readFileSync).toHaveBeenCalledWith('/path/to/ca.crt')
+    expect(ChannelCredentials.createSsl).toHaveBeenCalledWith(caBuffer)
+    expect(createChannel).toHaveBeenCalledWith('localhost:2023', tlsCreds)
+    expect(config.getChannelCredentials()).toBe(tlsCreds)
+  })
+
+  it('creates mTLS channel credentials when client cert and key are provided', () => {
+    const caBuffer = Buffer.from('ca-cert')
+    const clientCertBuffer = Buffer.from('client-cert')
+    const clientKeyBuffer = Buffer.from('client-key')
+    ;(readFileSync as jest.Mock)
+      .mockReturnValueOnce(caBuffer)
+      .mockReturnValueOnce(clientCertBuffer)
+      .mockReturnValueOnce(clientKeyBuffer)
+    ;(ChannelCredentials.createSsl as jest.Mock).mockReturnValue('mtls-creds')
+
+    LHConfig.from({
+      protocol: 'TLS',
+      caCert: '/path/to/ca.crt',
+      clientCert: '/path/to/client.crt',
+      clientKey: '/path/to/client.key',
+    })
+
+    expect(readFileSync).toHaveBeenNthCalledWith(1, '/path/to/ca.crt')
+    expect(readFileSync).toHaveBeenNthCalledWith(2, '/path/to/client.crt')
+    expect(readFileSync).toHaveBeenNthCalledWith(3, '/path/to/client.key')
+    expect(ChannelCredentials.createSsl).toHaveBeenCalledWith(caBuffer, clientKeyBuffer, clientCertBuffer)
+  })
+
+  it('falls back to one-way TLS when only one client credential file is provided', () => {
+    const clientCertBuffer = Buffer.from('client-cert')
+    ;(readFileSync as jest.Mock).mockReturnValue(clientCertBuffer)
+    ;(ChannelCredentials.createSsl as jest.Mock).mockReturnValue('tls-creds')
+
+    LHConfig.from({
+      protocol: 'TLS',
+      clientCert: '/path/to/client.crt',
+    })
+
+    expect(readFileSync).toHaveBeenCalledWith('/path/to/client.crt')
+    expect(ChannelCredentials.createSsl).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/sdk-js/src/LHConfig.ts
+++ b/sdk-js/src/LHConfig.ts
@@ -10,6 +10,8 @@ export const CONFIG_NAMES = [
   'LHC_API_PROTOCOL',
   'LHC_TENANT_ID',
   'LHC_CA_CERT',
+  'LHC_CLIENT_CERT',
+  'LHC_CLIENT_KEY',
 ] as const
 
 export type Config = {
@@ -30,6 +32,8 @@ export class LHConfig {
   private protocol?: string = 'PLAINTEXT'
   private tenantId?: string = 'default'
   private caCert?: string
+  private clientCert?: string
+  private clientKey?: string
   private channel: Channel
 
   private channelCredentials?: ChannelCredentials
@@ -41,10 +45,19 @@ export class LHConfig {
     this.protocol = mergedConfig.LHC_API_PROTOCOL
     this.tenantId = mergedConfig.LHC_TENANT_ID
     this.caCert = mergedConfig.LHC_CA_CERT
+    this.clientCert = mergedConfig.LHC_CLIENT_CERT
+    this.clientKey = mergedConfig.LHC_CLIENT_KEY
 
     if (this.protocol === 'TLS') {
       const rootCa = this.caCert ? readFileSync(this.caCert) : undefined
-      this.channelCredentials = ChannelCredentials.createSsl(rootCa)
+      const clientCert = this.clientCert ? readFileSync(this.clientCert) : undefined
+      const clientKey = this.clientKey ? readFileSync(this.clientKey) : undefined
+
+      if (clientCert && clientKey) {
+        this.channelCredentials = ChannelCredentials.createSsl(rootCa, clientKey, clientCert)
+      } else {
+        this.channelCredentials = ChannelCredentials.createSsl(rootCa)
+      }
     }
 
     this.channel = createChannel(`${this.apiHost}:${this.apiPort}`, this.channelCredentials)

--- a/sdk-js/src/utils/getPropertiesArgs.test.ts
+++ b/sdk-js/src/utils/getPropertiesArgs.test.ts
@@ -1,13 +1,15 @@
-import getPropertiesArgs from './getPropertiesArgs'
+import getPropertiesArgs, { ConfigArgs } from './getPropertiesArgs'
 
 describe('getPropertiesArgs', () => {
   it('should return partial configuration', async () => {
-    const args = {
+    const args: Partial<ConfigArgs> = {
       apiHost: 'localhost',
       apiPort: '2023',
       protocol: 'TLS',
       tenantId: 'example',
       caCert: '/path/to/cert.crt',
+      clientCert: '/path/to/client.crt',
+      clientKey: '/path/to/client.key',
     }
     const properties = getPropertiesArgs(args)
 
@@ -17,6 +19,8 @@ describe('getPropertiesArgs', () => {
       LHC_API_PROTOCOL: 'TLS',
       LHC_TENANT_ID: 'example',
       LHC_CA_CERT: '/path/to/cert.crt',
+      LHC_CLIENT_CERT: '/path/to/client.crt',
+      LHC_CLIENT_KEY: '/path/to/client.key',
     })
   })
 })

--- a/sdk-js/src/utils/getPropertiesArgs.ts
+++ b/sdk-js/src/utils/getPropertiesArgs.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
-import { CONFIG_NAMES, Config, ConfigName } from '../LHConfig'
+import { Config, ConfigName } from '../LHConfig'
 
 export type ConfigArgs = {
   apiHost: string
@@ -8,6 +6,8 @@ export type ConfigArgs = {
   protocol: string
   tenantId: string
   caCert: string
+  clientCert: string
+  clientKey: string
 }
 
 type Mapping = {
@@ -20,14 +20,17 @@ const argsMapping: Mapping = {
   protocol: 'LHC_API_PROTOCOL',
   tenantId: 'LHC_TENANT_ID',
   caCert: 'LHC_CA_CERT',
+  clientCert: 'LHC_CLIENT_CERT',
+  clientKey: 'LHC_CLIENT_KEY',
 }
 
 /**
- * Returns partial object with restricted key/value for valid config properties
- * @param path - absolute path to config file
- * @returns Partial<Config>
+ * Maps provided partial ConfigArgs to a partial Config object using the defined
+ * environment variable mapping.
+ * @param args - Partial set of configuration arguments (ConfigArgs).
+ * @returns Partial<Config> object with keys mapped to their corresponding ConfigName.
  */
-const getPropertiesFile = (args: Partial<ConfigArgs>): Partial<Config> => {
+const getPropertiesArgs = (args: Partial<ConfigArgs>): Partial<Config> => {
   const keys = Object.keys(args) as Array<keyof ConfigArgs>
   return keys.reduce<Partial<Config>>((config, key) => {
     config[argsMapping[key]] = args[key]
@@ -35,4 +38,4 @@ const getPropertiesFile = (args: Partial<ConfigArgs>): Partial<Config> => {
   }, {})
 }
 
-export default getPropertiesFile
+export default getPropertiesArgs

--- a/sdk-js/src/utils/getPropertiesFile.test.ts
+++ b/sdk-js/src/utils/getPropertiesFile.test.ts
@@ -9,6 +9,8 @@ describe('getPropertiesFile', () => {
       LHC_API_PORT: '2023',
       LHC_API_PROTOCOL: 'TLS',
       LHC_TENANT_ID: 'example',
+      LHC_CLIENT_CERT: '/path/to/client.crt',
+      LHC_CLIENT_KEY: '/path/to/client.key',
       LHC_CA_CERT: '/path/to/cert.crt',
     })
   })

--- a/sdk-js/src/utils/getPropertiesFile.ts
+++ b/sdk-js/src/utils/getPropertiesFile.ts
@@ -8,8 +8,8 @@ import { CONFIG_NAMES, Config } from '../LHConfig'
  * @returns Partial<Config>
  */
 const getPropertiesFile = (path: string): Partial<Config> => {
-  const fullpath = resolve(path)
-  const file = readFileSync(fullpath).toString()
+  const absolutePath = resolve(path)
+  const file = readFileSync(absolutePath).toString()
   return file
     .split('\n')
     .filter(Boolean)


### PR DESCRIPTION
Enable two env vars to configure mTLS in typescript/javascript clients:

- LHC_CLIENT_CERT
- LHC_CLIENT_KEY
