### PR TITLE
fix(server): Fix `txnCache.get` typo that uses incorrect variable

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
@@ -103,7 +103,7 @@ public class VariableMutationModel extends LHSerializable<VariableMutation> {
 
     private VariableValueModel getVarValFromThreadInTxn(
             String varName, ThreadRunModel thread, Map<String, VariableValueModel> txnCache) throws LHVarSubError {
-        VariableValueModel result = txnCache.get(this.lhsName);
+        VariableValueModel result = txnCache.get(varName);
         if (result == null) {
             VariableModel rawVariable = thread.getVariable(varName);
             if (rawVariable == null) {

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/variable/VariableMutationModel.java
@@ -101,7 +101,7 @@ public class VariableMutationModel extends LHSerializable<VariableMutation> {
         return getVarValFromThreadInTxn(this.lhsName, thread, txnCache);
     }
 
-    private VariableValueModel getVarValFromThreadInTxn(
+    private static VariableValueModel getVarValFromThreadInTxn(
             String varName, ThreadRunModel thread, Map<String, VariableValueModel> txnCache) throws LHVarSubError {
         VariableValueModel result = txnCache.get(varName);
         if (result == null) {


### PR DESCRIPTION
This is a very simple PR that fixes a typo in the `VariableMutationModel#getVarValFromThreadInTxn()` method that calls an instance field instead of the parameterized variable. 

The PR also makes the method static as a protection from similar mistakes in the future.