### PR TITLE
fix(server): use unmodifiable set for static field in LHConstants

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHConstants.java
+++ b/server/src/main/java/io/littlehorse/common/LHConstants.java
@@ -4,8 +4,6 @@ import io.littlehorse.sdk.common.proto.ACLAction;
 import io.littlehorse.sdk.common.proto.ACLResource;
 import io.littlehorse.sdk.common.proto.ServerACL;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 public class LHConstants {
@@ -31,7 +29,7 @@ public class LHConstants {
     public static final String VAR_ERROR = "VAR_ERROR";
     public static final String TASK_ERROR = "TASK_ERROR";
     public static final String INTERNAL_ERROR = "INTERNAL_ERROR";
-    public static final Set<String> RESERVED_EXCEPTION_NAMES = new HashSet<>(Arrays.asList(
+    public static final Set<String> RESERVED_EXCEPTION_NAMES = Set.of(
             CHILD_FAILURE,
             VAR_SUB_ERROR,
             VAR_MUTATION_ERROR,
@@ -40,7 +38,7 @@ public class LHConstants {
             VAR_ERROR,
             TASK_ERROR,
             INTERNAL_ERROR,
-            USER_TASK_CANCELLED));
+            USER_TASK_CANCELLED);
 
     public static final int DEFAULT_TASK_TIMEOUT_SECONDS = 60;
 


### PR DESCRIPTION
Resolves 1 SpotBug P1 Bug regarding a mutable set in a static field.

## Bug Description

```
Field is a mutable collection ( MS_MUTABLE_COLLECTION ):
io.littlehorse.common.LHConstants:
In class io.littlehorse.common.LHConstants
Field io.littlehorse.common.LHConstants.RESERVED_EXCEPTION_NAMES
At LHConstants.java:[line 34]
io.littlehorse.common.LHConstants.RESERVED_EXCEPTION_NAMES is a mutable collection
A mutable collection instance is assigned to a static final field, thus can be changed by malicious code or by accident from another package. Consider wrapping this field into Collections.unmodifiableSet/List/Map/etc. to avoid this vulnerability.
```

