### PR TITLE
test(sdk-java): add unit test to lock in empty TaskDef description behavior

### DIFF
--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
@@ -43,7 +43,8 @@ public class LHTaskSignatureTest {
         }
 
         @LHTaskMethod(value = "blank-desc-task")
-        public void blankDescTask() {};
+        public void blankDescTask() {}
+        ;
     }
 
     @LHStructDef("car")

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
@@ -40,6 +40,9 @@ public class LHTaskSignatureTest {
         public UuidHolder adapterStructTask(UuidHolder in) {
             return in;
         }
+
+        @LHTaskMethod(value = "blank-desc-task", description = "")
+        public void blankDescTask() {};
     }
 
     @LHStructDef("car")
@@ -105,12 +108,19 @@ public class LHTaskSignatureTest {
         assertThat(taskSignature.hasWorkerContext()).isTrue();
     }
 
-    // @Test
-    // void shouldReturnNoStructDefDependenciesAfterRefactor() {
-    //     LHTaskSignature taskSignature = signatureFor("struct-task", Car.class);
+    @Test
+    void shouldReturnNoStructDefDependenciesAfterRefactor() {
+        LHTaskSignature taskSignature = signatureFor("struct-task", Car.class);
 
-    //     assertThat(taskSignature.getStructDefDependencies()).isEmpty();
-    // }
+        assertThat(taskSignature.getStructDefDependencies()).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreEmptyTaskDefDescription() {
+        LHTaskSignature taskSignature = signatureFor("blank-desc-task");
+
+        assertThat(taskSignature.toPutTaskDefRequest().hasDescription()).isFalse();
+    }
 
     @Test
     void shouldUseTypeAdapterForStructDefFieldTypes() {

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
@@ -44,7 +44,6 @@ public class LHTaskSignatureTest {
 
         @LHTaskMethod(value = "blank-desc-task")
         public void blankDescTask() {}
-        ;
     }
 
     @LHStructDef("car")

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
@@ -118,12 +118,12 @@ public class LHTaskSignatureTest {
         assertThat(taskSignature.hasWorkerContext()).isTrue();
     }
 
-    @Test
-    void shouldReturnNoStructDefDependenciesAfterRefactor() {
-        LHTaskSignature taskSignature = signatureFor("struct-task", Car.class);
+    // @Test
+    // void shouldReturnNoStructDefDependenciesAfterRefactor() {
+    //     LHTaskSignature taskSignature = signatureFor("struct-task", Car.class);
 
-        assertThat(taskSignature.getStructDefDependencies()).isEmpty();
-    }
+    //     assertThat(taskSignature.getStructDefDependencies()).isEmpty();
+    // }
 
     @Test
     void shouldUseTypeAdapterForStructDefFieldTypes() {

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/taskdefutil/LHTaskSignatureTest.java
@@ -41,7 +41,7 @@ public class LHTaskSignatureTest {
             return in;
         }
 
-        @LHTaskMethod(value = "blank-desc-task", description = "")
+        @LHTaskMethod(value = "blank-desc-task")
         public void blankDescTask() {};
     }
 
@@ -101,6 +101,13 @@ public class LHTaskSignatureTest {
     }
 
     @Test
+    void shouldIgnoreEmptyTaskDefDescription() {
+        LHTaskSignature taskSignature = signatureFor("blank-desc-task");
+
+        assertThat(taskSignature.toPutTaskDefRequest().hasDescription()).isFalse();
+    }
+
+    @Test
     void shouldIgnoreWorkerContextInTaskDefParameter() {
         LHTaskSignature taskSignature = signatureFor("worker-context-task", WorkerContext.class);
 
@@ -113,13 +120,6 @@ public class LHTaskSignatureTest {
         LHTaskSignature taskSignature = signatureFor("struct-task", Car.class);
 
         assertThat(taskSignature.getStructDefDependencies()).isEmpty();
-    }
-
-    @Test
-    void shouldIgnoreEmptyTaskDefDescription() {
-        LHTaskSignature taskSignature = signatureFor("blank-desc-task");
-
-        assertThat(taskSignature.toPutTaskDefRequest().hasDescription()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
This PR adds a unit test to lock in the behavior guaranteed in our 1.0 `sdk-java` API:

When a description is an empty string or unspecified (which defaults to empty string) in the `LHTaskMethod` annotation, we should not supply it to the `optional description` field in the `PutTaskDefRequest` generated by our SDK.