### PR TITLE
chore(server): Change initialization order for health service

### DIFF
--- a/server/src/main/java/io/littlehorse/server/LHServer.java
+++ b/server/src/main/java/io/littlehorse/server/LHServer.java
@@ -190,6 +190,7 @@ public class LHServer {
     }
 
     public void start() throws IOException {
+        healthService.start();
         coreStreams.start();
         if (timerStreams != null) {
             timerStreams.start();
@@ -198,7 +199,6 @@ public class LHServer {
         for (LHServerListener listener : listeners) {
             listener.start();
         }
-        healthService.start();
     }
 
     public void close() {


### PR DESCRIPTION
Start the health endpoints (liveness, readiness and status) before trying to start any other dependencies like kafka streams or grpc