### PR TITLE
feat(test-utils): allow `StructDef`s to evolve and prevent registering twice

### DIFF
--- a/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
+++ b/test-utils/src/main/java/io/littlehorse/test/LHExtension.java
@@ -26,9 +26,11 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -141,7 +143,7 @@ public class LHExtension
     }
 
     private static void registerStructDefs(Class<?> testClass, TestContext testContext) throws IllegalAccessException {
-        List<LHStructDefType> structDefRequests = scanStructDefsSetup(testClass);
+        Set<LHStructDefType> structDefRequests = scanStructDefsSetup(testClass);
         structDefRequests.forEach(testContext::registerStructDef);
     }
 
@@ -178,14 +180,14 @@ public class LHExtension
         }
     }
 
-    private static List<LHStructDefType> scanStructDefsSetup(AnnotatedElement instanceClass) {
+    private static Set<LHStructDefType> scanStructDefsSetup(AnnotatedElement instanceClass) {
         LHTypeAdapterRegistry typeAdapterRegistry = LHTypeAdapterRegistry.empty();
         if (instanceClass.isAnnotationPresent(WithStructDefs.class)) {
             return List.of(instanceClass.getAnnotation(WithStructDefs.class).value()).stream()
                     .map(clazz -> new LHStructDefType(clazz, typeAdapterRegistry))
-                    .toList();
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
         }
-        return List.of();
+        return Set.of();
     }
 
     private WithWorkers[] scanWorkersSetup(AnnotatedElement instanceClass) {

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -26,9 +26,11 @@ import io.littlehorse.test.exception.LHTestExceptionUtil;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -47,12 +49,16 @@ public class TestContext {
 
     private final Map<String, WfSpec> wfSpecStore = new HashMap<>();
 
+    private final Set<String> registeredStructDefs = new HashSet<>();
+
     private final Lock wfSpecStoreLock;
+    private final Lock registeredStructDefsLock;
 
     public TestContext(TestBootstrapper bootstrapper) {
         this.config = bootstrapper.getWorkerConfig();
         this.lhClient = this.config.getBlockingStub();
         this.wfSpecStoreLock = new ReentrantLock();
+        this.registeredStructDefsLock = new ReentrantLock();
     }
 
     public List<String> discoverTaskDefNames(Object testInstance) {
@@ -109,9 +115,20 @@ public class TestContext {
     }
 
     public void registerStructDef(LHStructDefType structDef) {
-        lhClient.putStructDef(structDef.toPutStructDefRequest().toBuilder()
-                .setAllowedUpdates(StructDefCompatibilityType.FULLY_COMPATIBLE_SCHEMA_UPDATES)
-                .build());
+        String structDefName = structDef.getStructDefId().getName();
+
+        registeredStructDefsLock.lock();
+        try {
+            if (!registeredStructDefs.add(structDefName)) {
+                return;
+            }
+
+            lhClient.putStructDef(structDef.toPutStructDefRequest().toBuilder()
+                    .setAllowedUpdates(StructDefCompatibilityType.FULLY_COMPATIBLE_SCHEMA_UPDATES)
+                    .build());
+        } finally {
+            registeredStructDefsLock.unlock();
+        }
     }
 
     public void registerExternalEventDef(ExternalEventDef externalEventDef) {

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -110,8 +110,8 @@ public class TestContext {
 
     public void registerStructDef(LHStructDefType structDef) {
         lhClient.putStructDef(structDef.toPutStructDefRequest().toBuilder()
-            .setAllowedUpdates(StructDefCompatibilityType.FULLY_COMPATIBLE_SCHEMA_UPDATES)
-            .build());
+                .setAllowedUpdates(StructDefCompatibilityType.FULLY_COMPATIBLE_SCHEMA_UPDATES)
+                .build());
     }
 
     public void registerExternalEventDef(ExternalEventDef externalEventDef) {

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -9,6 +9,7 @@ import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.PutExternalEventDefRequest;
 import io.littlehorse.sdk.common.proto.PutUserTaskDefRequest;
 import io.littlehorse.sdk.common.proto.PutWorkflowEventDefRequest;
+import io.littlehorse.sdk.common.proto.StructDefCompatibilityType;
 import io.littlehorse.sdk.common.proto.WfSpec;
 import io.littlehorse.sdk.common.proto.WorkflowEventDef;
 import io.littlehorse.sdk.usertask.UserTaskSchema;
@@ -108,7 +109,9 @@ public class TestContext {
     }
 
     public void registerStructDef(LHStructDefType structDef) {
-        lhClient.putStructDef(structDef.toPutStructDefRequest());
+        lhClient.putStructDef(structDef.toPutStructDefRequest().toBuilder()
+            .setAllowedUpdates(StructDefCompatibilityType.FULLY_COMPATIBLE_SCHEMA_UPDATES)
+            .build());
     }
 
     public void registerExternalEventDef(ExternalEventDef externalEventDef) {

--- a/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
+++ b/test-utils/src/main/java/io/littlehorse/test/internal/TestContext.java
@@ -5,6 +5,7 @@ import io.littlehorse.sdk.common.proto.ExternalEventDef;
 import io.littlehorse.sdk.common.proto.ExternalEventDefId;
 import io.littlehorse.sdk.common.proto.GetLatestUserTaskDefRequest;
 import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.PutExternalEventDefRequest;
 import io.littlehorse.sdk.common.proto.PutUserTaskDefRequest;
@@ -49,7 +50,7 @@ public class TestContext {
 
     private final Map<String, WfSpec> wfSpecStore = new HashMap<>();
 
-    private final Set<String> registeredStructDefs = new HashSet<>();
+    private final Set<StructDefRegistrationKey> registeredStructDefs = new HashSet<>();
 
     private final Lock wfSpecStoreLock;
     private final Lock registeredStructDefsLock;
@@ -115,11 +116,12 @@ public class TestContext {
     }
 
     public void registerStructDef(LHStructDefType structDef) {
-        String structDefName = structDef.getStructDefId().getName();
+        StructDefRegistrationKey registrationKey =
+                new StructDefRegistrationKey(structDef.getStructDefId().getName(), structDef.getInlineStructDef());
 
         registeredStructDefsLock.lock();
         try {
-            if (!registeredStructDefs.add(structDefName)) {
+            if (!registeredStructDefs.add(registrationKey)) {
                 return;
             }
 
@@ -246,4 +248,6 @@ public class TestContext {
     public LHConfig getConfig() {
         return config;
     }
+
+    private record StructDefRegistrationKey(String name, InlineStructDef structDef) {}
 }


### PR DESCRIPTION
Small PR that improves StructDef registration helpers in `test-utils`.

### 1. Allows StructDefs registered using the `test-utils` `WithStructDefs` annotation to evolve by setting the `AllowedUpdates` type to `FULLY_COMPATIBLE_SCHEMA_UPDATES`.

I do not see a use case where this _needs_ to be configurable (like setting NO_SCHEMA_UPDATES in one case but FULLY_COMPATIBLE_SCHEMA_UPDATES in another), but if that use case comes up we can adjust for that later.

## Example Use Case

Say you want to register two versions of a StructDef before E2E tests are executed (real use case in PR #2211:

```java
@LHTest
@WithStructDefs({StructV0.class, StructV1.class})
public class MyE2ETest {
}
```

### 2. Keeps a Set of already registered `StructDef`s so that if two classes rely on the same `StructDef`, it is not registered twice.