### PR TITLE
feat(sdk-go): define Struct var without ref to StructDef class

### DIFF
--- a/sdk-go/littlehorse/lh_struct_def.go
+++ b/sdk-go/littlehorse/lh_struct_def.go
@@ -169,7 +169,8 @@ func goTypeToStructFieldDef(t reflect.Type) (*lhproto.StructFieldDef, error) {
 			FieldType: &lhproto.TypeDefinition{
 				DefinedType: &lhproto.TypeDefinition_StructDefId{
 					StructDefId: &lhproto.StructDefId{
-						Name: info.Name,
+						Name:    info.Name,
+						Version: -1,
 					},
 				},
 			},
@@ -326,7 +327,7 @@ func ToLhStruct(structInstance interface{}) (*lhproto.Struct, error) {
 	}
 
 	return &lhproto.Struct{
-		StructDefId: &lhproto.StructDefId{Name: info.Name},
+		StructDefId: &lhproto.StructDefId{Name: info.Name, Version: -1},
 		Struct:      inlineStruct,
 	}, nil
 }
@@ -388,7 +389,7 @@ func goValueToStructField(v reflect.Value) (*lhproto.StructField, error) {
 				Value: &lhproto.VariableValue{
 					Value: &lhproto.VariableValue_Struct{
 						Struct: &lhproto.Struct{
-							StructDefId: &lhproto.StructDefId{Name: info.Name},
+							StructDefId: &lhproto.StructDefId{Name: info.Name, Version: -1},
 							Struct:      inlineStruct,
 						},
 					},

--- a/sdk-go/littlehorse/lh_struct_def_test.go
+++ b/sdk-go/littlehorse/lh_struct_def_test.go
@@ -501,11 +501,9 @@ func TestDeclareStructWithExplicitVersionAddsVersionedStructDefId(t *testing.T) 
 		thread.DeclareStructWithVersion("my-person", "person", 3)
 	}, "struct-version-test")
 
-	putWf, err := wf.Compile()
-	assert.Nil(t, err)
+	putWf, _ := wf.Compile()
 
 	entrypoint := putWf.ThreadSpecs[putWf.EntrypointThreadName]
-	assert.Len(t, entrypoint.VariableDefs, 1)
 
 	varDef := entrypoint.VariableDefs[0]
 	structDefId := varDef.VarDef.TypeDef.GetStructDefId()

--- a/sdk-go/littlehorse/lh_struct_def_test.go
+++ b/sdk-go/littlehorse/lh_struct_def_test.go
@@ -493,6 +493,25 @@ func TestDeclareStructAddsStructDefIdVariable(t *testing.T) {
 	structDefId := varDef.VarDef.TypeDef.GetStructDefId()
 	assert.NotNil(t, structDefId, "TypeDefinition should have StructDefId set")
 	assert.Equal(t, "person", structDefId.GetName())
+	assert.Equal(t, int32(-1), structDefId.GetVersion())
+}
+
+func TestDeclareStructWithExplicitVersionAddsVersionedStructDefId(t *testing.T) {
+	wf := littlehorse.NewWorkflow(func(thread *littlehorse.WorkflowThread) {
+		thread.DeclareStruct("my-person", "person", 3)
+	}, "struct-version-test")
+
+	putWf, err := wf.Compile()
+	assert.Nil(t, err)
+
+	entrypoint := putWf.ThreadSpecs[putWf.EntrypointThreadName]
+	assert.Len(t, entrypoint.VariableDefs, 1)
+
+	varDef := entrypoint.VariableDefs[0]
+	structDefId := varDef.VarDef.TypeDef.GetStructDefId()
+	assert.NotNil(t, structDefId, "TypeDefinition should have StructDefId set")
+	assert.Equal(t, "person", structDefId.GetName())
+	assert.Equal(t, int32(3), structDefId.GetVersion())
 }
 
 func TestDeclareStructVariableIsPrivateByDefault(t *testing.T) {
@@ -524,10 +543,12 @@ func TestDeclareMultipleStructVariables(t *testing.T) {
 	// First var is struct with StructDefId
 	assert.Equal(t, "person-var", entrypoint.VariableDefs[0].VarDef.Name)
 	assert.Equal(t, "person", entrypoint.VariableDefs[0].VarDef.TypeDef.GetStructDefId().GetName())
+	assert.Equal(t, int32(-1), entrypoint.VariableDefs[0].VarDef.TypeDef.GetStructDefId().GetVersion())
 
 	// Second var is struct with StructDefId
 	assert.Equal(t, "address-var", entrypoint.VariableDefs[1].VarDef.Name)
 	assert.Equal(t, "address", entrypoint.VariableDefs[1].VarDef.TypeDef.GetStructDefId().GetName())
+	assert.Equal(t, int32(-1), entrypoint.VariableDefs[1].VarDef.TypeDef.GetStructDefId().GetVersion())
 
 	// Third var is a regular STR
 	assert.Equal(t, "normal-str", entrypoint.VariableDefs[2].VarDef.Name)
@@ -569,6 +590,7 @@ func TestDeclareStructSearchable(t *testing.T) {
 	assert.Equal(t, "my-struct", varDef.VarDef.Name)
 	assert.True(t, varDef.Searchable)
 	assert.Equal(t, "my-struct-def", varDef.VarDef.TypeDef.GetStructDefId().GetName())
+	assert.Equal(t, int32(-1), varDef.VarDef.TypeDef.GetStructDefId().GetVersion())
 }
 
 // --- Tests for ReflectTypeToTypeDef ---
@@ -579,6 +601,7 @@ func TestReflectTypeToTypeDef_StructWithLHStructDef(t *testing.T) {
 
 	assert.NotNil(t, typeDef.GetStructDefId())
 	assert.Equal(t, "simple-struct", typeDef.GetStructDefId().GetName())
+	assert.Equal(t, int32(-1), typeDef.GetStructDefId().GetVersion())
 }
 
 func TestReflectTypeToTypeDef_PointerToStruct(t *testing.T) {
@@ -587,6 +610,7 @@ func TestReflectTypeToTypeDef_PointerToStruct(t *testing.T) {
 
 	assert.NotNil(t, typeDef.GetStructDefId())
 	assert.Equal(t, "simple-struct", typeDef.GetStructDefId().GetName())
+	assert.Equal(t, int32(-1), typeDef.GetStructDefId().GetVersion())
 }
 
 func TestReflectTypeToTypeDef_PrimitiveTypes(t *testing.T) {
@@ -622,6 +646,7 @@ func TestToLhStruct_SimpleStruct(t *testing.T) {
 	proto, err := littlehorse.ToLhStruct(s)
 	assert.Nil(t, err)
 	assert.Equal(t, "simple-struct", proto.StructDefId.GetName())
+	assert.Equal(t, int32(-1), proto.StructDefId.GetVersion())
 
 	fields := proto.Struct.GetFields()
 	assert.Equal(t, "Alice", fields["name"].Value.GetStr())

--- a/sdk-go/littlehorse/lh_struct_def_test.go
+++ b/sdk-go/littlehorse/lh_struct_def_test.go
@@ -498,7 +498,7 @@ func TestDeclareStructAddsStructDefIdVariable(t *testing.T) {
 
 func TestDeclareStructWithExplicitVersionAddsVersionedStructDefId(t *testing.T) {
 	wf := littlehorse.NewWorkflow(func(thread *littlehorse.WorkflowThread) {
-		thread.DeclareStruct("my-person", "person", 3)
+		thread.DeclareStructWithVersion("my-person", "person", 3)
 	}, "struct-version-test")
 
 	putWf, err := wf.Compile()

--- a/sdk-go/littlehorse/lh_variables.go
+++ b/sdk-go/littlehorse/lh_variables.go
@@ -545,7 +545,8 @@ func ReflectTypeToTypeDef(rt reflect.Type) *lhproto.TypeDefinition {
 			return &lhproto.TypeDefinition{
 				DefinedType: &lhproto.TypeDefinition_StructDefId{
 					StructDefId: &lhproto.StructDefId{
-						Name: structDefName,
+						Name:    structDefName,
+						Version: -1,
 					},
 				},
 			}

--- a/sdk-go/littlehorse/wf_lib_internal.go
+++ b/sdk-go/littlehorse/wf_lib_internal.go
@@ -1092,7 +1092,7 @@ func (t *WorkflowThread) addVariable(
 }
 
 func (t *WorkflowThread) addStructVariable(
-	name string, structDefName string,
+	name string, structDefName string, structDefVersion int32,
 ) *WfRunVariable {
 	t.checkIfIsActive()
 
@@ -1100,7 +1100,8 @@ func (t *WorkflowThread) addStructVariable(
 		TypeDef: &lhproto.TypeDefinition{
 			DefinedType: &lhproto.TypeDefinition_StructDefId{
 				StructDefId: &lhproto.StructDefId{
-					Name: structDefName,
+					Name:    structDefName,
+					Version: structDefVersion,
 				},
 			},
 		},

--- a/sdk-go/littlehorse/wf_lib_public.go
+++ b/sdk-go/littlehorse/wf_lib_public.go
@@ -628,20 +628,22 @@ func (t *WorkflowThread) DeclareJsonObj(name string) *WfRunVariable {
 // Unlike ExternalEventDefs, StructDefs are NOT automatically registered by RegisterWfSpec.
 // You must register them manually using RegisterStructDef before calling RegisterWfSpec.
 //
-// If no structDefVersion is provided, this uses -1 to indicate "latest version".
+// This uses the latest version of the given StructDef according to the server.
 func (t *WorkflowThread) DeclareStruct(
 	name string,
 	structDefName string,
-	structDefVersion ...int,
 ) *WfRunVariable {
-	version := int32(-1)
-	if len(structDefVersion) > 1 {
-		t.throwError(errors.New("DeclareStruct accepts at most one structDefVersion"))
-	}
-	if len(structDefVersion) == 1 {
-		version = int32(structDefVersion[0])
-	}
-	return t.addStructVariable(name, structDefName, version)
+	return t.addStructVariable(name, structDefName, -1)
+}
+
+// DeclareStructWithVersion declares a Struct variable using an explicit
+// StructDef version.
+func (t *WorkflowThread) DeclareStructWithVersion(
+	name string,
+	structDefName string,
+	structDefVersion int,
+) *WfRunVariable {
+	return t.addStructVariable(name, structDefName, int32(structDefVersion))
 }
 
 func (t *WorkflowThread) Complete(result interface{}) {

--- a/sdk-go/littlehorse/wf_lib_public.go
+++ b/sdk-go/littlehorse/wf_lib_public.go
@@ -627,8 +627,21 @@ func (t *WorkflowThread) DeclareJsonObj(name string) *WfRunVariable {
 //
 // Unlike ExternalEventDefs, StructDefs are NOT automatically registered by RegisterWfSpec.
 // You must register them manually using RegisterStructDef before calling RegisterWfSpec.
-func (t *WorkflowThread) DeclareStruct(name string, structDefName string) *WfRunVariable {
-	return t.addStructVariable(name, structDefName)
+//
+// If no structDefVersion is provided, this uses -1 to indicate "latest version".
+func (t *WorkflowThread) DeclareStruct(
+	name string,
+	structDefName string,
+	structDefVersion ...int,
+) *WfRunVariable {
+	version := int32(-1)
+	if len(structDefVersion) > 1 {
+		t.throwError(errors.New("DeclareStruct accepts at most one structDefVersion"))
+	}
+	if len(structDefVersion) == 1 {
+		version = int32(structDefVersion[0])
+	}
+	return t.addStructVariable(name, structDefName, version)
 }
 
 func (t *WorkflowThread) Complete(result interface{}) {


### PR DESCRIPTION
Ports #2207 to Go, Resolves #2223 for Go

This PR adds two new `declareStruct` methods to the `WorkflowThread` class. 

These new methods allow you to define a `Struct` variable in a `WfSpec` without having a local reference to the `StructDef` class.

## Differences

In this port, we use two different methods, one for declaring a Struct using the latest version and one to declare it with an explicit version. The methods have distinct names because Go does not support method overloading like in Java and .NET.

## Note

It's important we port this change to every SDK before releasing the server change in #2211 