### PR TITLE
test(server): bump shouldWaitForRemoteCommandAsynchronously timeout

### DIFF
--- a/server/src/test/java/io/littlehorse/server/streams/CommandSenderTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/CommandSenderTest.java
@@ -207,7 +207,7 @@ class CommandSenderTest {
         Future<Message> future = sender.doSend(command, Empty.class, principalId, tenantId, ctx);
         Awaitility.await()
                 .pollDelay(Duration.ofNanos(1))
-                .atMost(10, TimeUnit.MILLISECONDS)
+                .atMost(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> producerResult.complete(recordMetadata));
         assertThatThrownBy(() -> future.get(1, TimeUnit.MILLISECONDS))
                 .isInstanceOf(java.util.concurrent.TimeoutException.class);


### PR DESCRIPTION
This PR is an experiment that bumps the timeout in a given test from `10ms` to `100ms` to avoid failing jobs.