### PR TITLE
fix(dashboard): honor WfSpec defaults in run workflow form

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/WfRunForm.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/WfRunForm.tsx
@@ -1,5 +1,6 @@
+import { getPrimitiveFormDefaultValue } from '@/app/utils'
 import { Input } from '@/components/ui/input'
-import { ThreadVarDef, VariableType, WfSpec } from 'littlehorse-client/proto'
+import { ThreadVarDef, VariableType, WfRunVariableAccessLevel, WfSpec } from 'littlehorse-client/proto'
 import { forwardRef, useMemo } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import FormField from './components/FormField'
@@ -9,14 +10,42 @@ export type FormValues = {
   [key: string]: unknown
 }
 
+export type WfRunFormSubmitMeta = {
+  /**
+   * Map of field names that the user has changed away from the WfSpec default.
+   * Used to distinguish "no value provided" (skip the variable so the server
+   * applies its default) from "user explicitly entered/cleared a value".
+   */
+  dirtyFields: Record<string, boolean | undefined>
+}
+
 interface WfRunFormProps {
   wfSpecVariables: ThreadVarDef[]
   wfSpec: WfSpec
-  onSubmit: (data: FormValues) => void
+  onSubmit: (data: FormValues, meta: WfRunFormSubmitMeta) => void
 }
 
 export const WfRunForm = forwardRef<HTMLFormElement, WfRunFormProps>(({ wfSpecVariables, wfSpec, onSubmit }, ref) => {
-  const methods = useForm<FormValues>()
+  // Pre-populate primitive form fields with the default value declared in the
+  // WfSpec's VariableDef. Combined with `dirtyFields`-based filtering at submit
+  // time, this lets us tell whether the user actually provided a value or
+  // simply accepted the default (in which case we should let the server apply
+  // it instead of overwriting it from the dashboard).
+  const defaultValues = useMemo<FormValues>(() => {
+    const values: FormValues = {}
+    for (const variable of wfSpecVariables) {
+      const varDef = variable.varDef
+      if (!varDef?.name) continue
+      if (variable.accessLevel === WfRunVariableAccessLevel.INHERITED_VAR) continue
+      if (varDef.typeDef?.definedType?.$case !== 'primitiveType') continue
+      const defaultFormValue = getPrimitiveFormDefaultValue(varDef.defaultValue)
+      if (defaultFormValue === undefined) continue
+      values[varDef.name] = defaultFormValue
+    }
+    return values
+  }, [wfSpecVariables])
+
+  const methods = useForm<FormValues>({ defaultValues })
 
   // sorted by required first
   const sortedVariables = useMemo(
@@ -28,9 +57,13 @@ export const WfRunForm = forwardRef<HTMLFormElement, WfRunFormProps>(({ wfSpecVa
     [wfSpecVariables]
   )
 
+  const handleSubmit = (data: FormValues) => {
+    onSubmit(data, { dirtyFields: methods.formState.dirtyFields as Record<string, boolean | undefined> })
+  }
+
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)} ref={ref} className="space-y-4">
+      <form onSubmit={methods.handleSubmit(handleSubmit)} ref={ref} className="space-y-4">
         <FormField
           label={'Custom WfRun Id'}
           as={Input}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/StructDefGroup.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/StructDefGroup.tsx
@@ -1,5 +1,5 @@
 import { getStructDef } from '@/app/actions/getStructDef'
-import { getVariableCaseFromType } from '@/app/utils'
+import { getPrimitiveFormDefaultValue, getVariableCaseFromType } from '@/app/utils'
 import { Button } from '@/components/ui/button'
 import { FieldGroup } from '@/components/ui/field'
 import { StructDefId, StructField, VariableType, VariableValue } from 'littlehorse-client/proto'
@@ -54,24 +54,7 @@ const StructPrimitiveField: FC<StructPrimitiveFieldProps> = ({
   const fieldId = useMemo(() => [STRUCT_FORM_FIELD_PREFIX, ...structPath, fieldName].join('.'), [structPath, fieldName])
   const value = useWatch({ name: fieldId, control })
 
-  const defaultFormValue = useMemo(() => {
-    const union = defaultValue?.value
-    if (!union) return undefined
-
-    switch (union.$case) {
-      case 'bool':
-        return union.value ? 'true' : 'false'
-      case 'int':
-      case 'double':
-        return union.value
-      case 'str':
-      case 'jsonObj':
-      case 'jsonArr':
-        return union.value
-      default:
-        return undefined
-    }
-  }, [defaultValue])
+  const defaultFormValue = useMemo(() => getPrimitiveFormDefaultValue(defaultValue), [defaultValue])
 
   useEffect(() => {
     if (!disabled) {

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
@@ -17,7 +17,7 @@ import { Modal } from '../../context'
 import { useModal } from '../../hooks/useModal'
 import { runWfSpec } from '../../wfSpec/[...props]/actions/runWfSpec'
 import { DOT_REPLACEMENT_PATTERN, StructFormContextValue, StructFormProvider } from '../Forms/context/StructFormContext'
-import { FormValues, WfRunForm } from '../Forms/WfRunForm'
+import { FormValues, WfRunForm, WfRunFormSubmitMeta } from '../Forms/WfRunForm'
 
 export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
   const { showModal, setShowModal } = useModal()
@@ -50,7 +50,7 @@ export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
   )
 
   const formatVariablesPayload = useCallback(
-    (values: FormValues) => {
+    (values: FormValues, dirtyFields: WfRunFormSubmitMeta['dirtyFields']) => {
       const { structValues: _ignoredStructValues, ...primitiveValues } = values as FormValues & {
         structValues?: Record<string, unknown>
       }
@@ -66,6 +66,12 @@ export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
 
       const transformedObj = Object.keys(primitiveValues).reduce((acc: RunWfRequest['variables'], key) => {
         if (primitiveValues[key] === undefined) return acc
+
+        // Only send primitive variables the user actually changed away from
+        // the WfSpec default. Otherwise the server applies its own default and
+        // we avoid overwriting it (see issue #2205).
+        if (!dirtyFields[key]) return acc
+
         const transformedKey = key.split(DOT_REPLACEMENT_PATTERN).join('.')
 
         if (
@@ -87,13 +93,13 @@ export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
     [matchVariableType, wfSpecVariables]
   )
 
-  const handleFormSubmit = async (values: FormValues) => {
+  const handleFormSubmit = async (values: FormValues, meta: WfRunFormSubmitMeta) => {
     const customWfRunId = values.customWfRunId as string
     const parentWfRunId = values.parentWfRunId as string
     delete values.customWfRunId
     delete values.parentWfRunId
     if (!wfSpec.id || (wfSpec.parentWfSpec && !parentWfRunId)) return
-    const variables = formatVariablesPayload(values)
+    const variables = formatVariablesPayload(values, meta.dirtyFields)
 
     try {
       const wfRun = await runWfSpec({

--- a/dashboard/src/app/utils/variables.test.ts
+++ b/dashboard/src/app/utils/variables.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'littlehorse-client/proto'
 import {
   formatTypeDefinition,
+  getPrimitiveFormDefaultValue,
   getTypedVariableValue,
   getVariable,
   getVariableCaseFromTypeDef,
@@ -370,6 +371,41 @@ describe('getTypedVariableValue', () => {
     expect(variableValue).toStrictEqual({
       value: { $case: 'utcTimestamp', value: '2024-06-15T14:30:45.123456789Z' },
     })
+  })
+})
+
+describe('getPrimitiveFormDefaultValue', () => {
+  it('returns undefined when no default is provided', () => {
+    expect(getPrimitiveFormDefaultValue(undefined)).toBeUndefined()
+    expect(getPrimitiveFormDefaultValue({} as VariableValue)).toBeUndefined()
+  })
+
+  it('returns the str value for STR defaults', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'str', value: 'hello' } })).toEqual('hello')
+  })
+
+  it('preserves empty string defaults', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'str', value: '' } })).toEqual('')
+  })
+
+  it('returns numeric values for INT/DOUBLE defaults', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'int', value: '42' as any } })).toEqual('42')
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'double', value: 1.5 } })).toEqual(1.5)
+  })
+
+  it('serializes BOOL defaults as form-friendly strings', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'bool', value: true } })).toEqual('true')
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'bool', value: false } })).toEqual('false')
+  })
+
+  it('returns the JSON string for JSON_OBJ/JSON_ARR defaults', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'jsonObj', value: '{"a":1}' } })).toEqual('{"a":1}')
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'jsonArr', value: '[1,2]' } })).toEqual('[1,2]')
+  })
+
+  it('returns undefined for non-primitive cases', () => {
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'bytes', value: Buffer.from('') } as any })).toBeUndefined()
+    expect(getPrimitiveFormDefaultValue({ value: { $case: 'struct', value: {} as any } })).toBeUndefined()
   })
 })
 

--- a/dashboard/src/app/utils/variables.ts
+++ b/dashboard/src/app/utils/variables.ts
@@ -248,6 +248,33 @@ export const getTypedVariableValue = (
 }
 
 /**
+ * Converts a VariableValue (from a `VariableDef.defaultValue`) into the
+ * representation used by primitive form fields in the Execute WfRun form.
+ *
+ * Returns `undefined` for non-primitive cases (struct, array, bytes, wfRunId)
+ * since those need bespoke rendering.
+ */
+export const getPrimitiveFormDefaultValue = (defaultValue?: VariableValue): unknown => {
+  const union = defaultValue?.value
+  if (!union) return undefined
+
+  switch (union.$case) {
+    case 'bool':
+      return union.value ? 'true' : 'false'
+    case 'int':
+    case 'double':
+      return union.value
+    case 'str':
+    case 'jsonObj':
+    case 'jsonArr':
+    case 'utcTimestamp':
+      return union.value
+    default:
+      return undefined
+  }
+}
+
+/**
  * After 0.13.2, the `VariableDef.type` and `VariableDef.maskedValue` fields are deprecated.
  * These fields are replaced with `VariableDef.typeDef`.
  *


### PR DESCRIPTION
resolves #2205

Blank fields in the run-workflow UI were overwriting variable defaults from the spec. Values from the form get merged with WfSpec defaults before the run starts. Helper is in variables.ts with tests.

### Video

https://github.com/user-attachments/assets/fb41f6fe-2755-446e-a93d-84b72754292c

