### PR TITLE
feat(dashboard): centralize route paths

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/FormLabel.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/FormLabel.tsx
@@ -1,4 +1,5 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
+import { routes } from '@/app/routes'
 import { getVariableCaseFromType, VARIABLE_CASE_LABELS } from '@/app/utils'
 import { AccessLevelBadge, MaskedBadge, OptionalBadge, RequiredBadge, TypeBadge } from '@/components/ui/badge'
 import { FieldLabel } from '@/components/ui/field'
@@ -23,7 +24,7 @@ const FormLabel: FC<FormLabelProps> = ({ label, variableType, structDefId, acces
           <TypeBadge>
             <LinkWithTenant
               className="underline"
-              href={`/structDef/${structDefId.name}/${structDefId.version}`}
+              href={routes.structDef.detail(structDefId.name, structDefId.version)}
             >{`Struct<${structDefId.name},${structDefId.version}>`}</LinkWithTenant>
           </TypeBadge>
         )}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
@@ -15,6 +15,7 @@ import { FC, useCallback, useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { Modal } from '../../context'
 import { useModal } from '../../hooks/useModal'
+import { routes, withTenant } from '@/app/routes'
 import { runWfSpec } from '../../wfSpec/[...props]/actions/runWfSpec'
 import { DOT_REPLACEMENT_PATTERN, StructFormContextValue, StructFormProvider } from '../Forms/context/StructFormContext'
 import { FormValues, WfRunForm } from '../Forms/WfRunForm'
@@ -108,7 +109,7 @@ export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
       if (!wfRun.id) return
       toast.success('Workflow has been executed')
       setShowModal(false)
-      router.push(`/${tenantId}/wfRun/${wfRunIdToPath(wfRun.id)}`)
+      router.push(withTenant(tenantId, routes.wfRun.detail(wfRunIdToPath(wfRun.id))))
     } catch (error: any) {
       if (error.message) {
         const sanitizedErrorMessage = error.message.slice(error.message.indexOf(':') + 1).trim()

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ChildWFNode.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ChildWFNode.tsx
@@ -1,4 +1,5 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
+import { routes } from '@/app/routes'
 import { RunChildWfNode, VariableAssignment as VariableAssignmentProto } from 'littlehorse-client/proto'
 import { LinkIcon } from 'lucide-react'
 import { FC } from 'react'
@@ -10,7 +11,9 @@ export const ChildWFNode: FC<{ node: RunChildWfNode }> = ({ node }) => {
   const wfSpecName = wfSpec?.$case === 'wfSpecName' ? wfSpec.value : wfSpec?.$case === 'wfSpecVar' ? 'variable' : '—'
 
   const wfSpecLink =
-    wfSpecName && wfSpecName !== 'variable' && wfSpecName !== '—' ? `/wfSpec/${wfSpecName}/${majorVersion}.0` : null
+    wfSpecName && wfSpecName !== 'variable' && wfSpecName !== '—'
+      ? routes.wfSpec.detail(wfSpecName, `${majorVersion}.0`)
+      : null
 
   return (
     <div className="flex max-w-full flex-1 flex-col gap-2">

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ExternalEventNode.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ExternalEventNode.tsx
@@ -1,4 +1,5 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
+import { routes } from '@/app/routes'
 import { ExternalEventNode as ExternalEventNodeProto } from 'littlehorse-client/proto'
 import { LinkIcon } from 'lucide-react'
 import { FC } from 'react'
@@ -14,7 +15,7 @@ export const ExternalEventNode: FC<{ node: ExternalEventNodeProto }> = ({ node }
       <div className="mb-2 flex items-center">
         <p className="flex-grow truncate text-lg font-medium">{externalEventDefId.name}</p>
 
-        <LinkWithTenant href={`/externalEventDef/${externalEventDefId.name}`}>
+        <LinkWithTenant href={routes.externalEventDef.detail(externalEventDefId.name)}>
           <LinkIcon className="ml-1 h-4 w-4 cursor-pointer hover:text-slate-600" />
         </LinkWithTenant>
       </div>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/TaskNode.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/TaskNode.tsx
@@ -1,4 +1,5 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
+import { routes } from '@/app/routes'
 import { TaskNode as TaskNodeProto } from 'littlehorse-client/proto'
 import { LinkIcon } from 'lucide-react'
 import { FC } from 'react'
@@ -15,7 +16,7 @@ export const TaskNode: FC<{ node: TaskNodeProto }> = ({ node }) => {
       <div className="mb-2 flex items-center">
         <p className="flex-grow truncate text-lg font-medium">{getTaskName(node.taskToExecute)}</p>
         {taskToExecute?.$case === 'taskDefId' && (
-          <LinkWithTenant href={`/taskDef/${taskToExecute.value.name}`}>
+          <LinkWithTenant href={routes.taskDef.detail(taskToExecute.value.name)}>
             <LinkIcon className="ml-1 h-4 w-4 cursor-pointer hover:text-slate-600" />
           </LinkWithTenant>
         )}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ThrowEventNode.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Node/ThrowEventNode.tsx
@@ -1,4 +1,5 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
+import { routes } from '@/app/routes'
 import { ThrowEventNode as ThrowEventNodeProto } from 'littlehorse-client/proto'
 import { LinkIcon } from 'lucide-react'
 import { FC } from 'react'
@@ -15,7 +16,7 @@ export const ThrowEventNode: FC<{ node: ThrowEventNodeProto }> = ({ node }) => {
       <small className="node-title">ThrowEvent</small>
       <div className="mb-2 flex items-center">
         <p className="flex-grow truncate text-lg font-medium">{eventDefId.name}</p>
-        <LinkWithTenant href={`/workflowEventDef/${eventDefId.name}`}>
+        <LinkWithTenant href={routes.workflowEventDef.detail(eventDefId.name)}>
           <LinkIcon className="ml-1 h-4 w-4 cursor-pointer hover:text-slate-600" />
         </LinkWithTenant>
       </div>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/ChildWFNodeRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/ChildWFNodeRun.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/app/routes'
 import { wfRunIdToPath } from '@/app/utils/wfRun'
 import { RunChildWfNodeRun as RunChildWfNodeRunProto } from 'littlehorse-client/proto'
 import { FC } from 'react'
@@ -5,9 +6,10 @@ import { InputVariables } from '../Components'
 import { NodeVariable } from '../Components/NodeVariable'
 
 export const ChildWFNodeRun: FC<{ node: RunChildWfNodeRunProto }> = ({ node }) => {
-  const childWfRunLink = node.childWfRunId ? `/wfRun/${wfRunIdToPath(node.childWfRunId)}` : ''
+  const childWfRunLink = node.childWfRunId ? routes.wfRun.detail(wfRunIdToPath(node.childWfRunId)) : ''
   const wfSpecLink =
-    node.wfSpecId && `/wfSpec/${node.wfSpecId.name}/${node.wfSpecId.majorVersion}/${node.wfSpecId.revision}`
+    node.wfSpecId &&
+    routes.wfSpec.detailWithRevision(node.wfSpecId.name, node.wfSpecId.majorVersion, node.wfSpecId.revision)
 
   const inputVars =
     node.inputs && Object.keys(node.inputs).length > 0

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/WaitForChildWfNodeRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/WaitForChildWfNodeRun.tsx
@@ -1,10 +1,11 @@
+import { routes } from '@/app/routes'
 import { wfRunIdToPath } from '@/app/utils/wfRun'
 import { WaitForChildWfNodeRun as WaitForChildWfNodeRunProto } from 'littlehorse-client/proto'
 import { FC } from 'react'
 import { NodeVariable } from '../Components/NodeVariable'
 
 export const WaitForChildWfNodeRun: FC<{ node: WaitForChildWfNodeRunProto }> = ({ node }) => {
-  const childWfRunLink = node.childWfRunId ? `/wfRun/${wfRunIdToPath(node.childWfRunId)}` : ''
+  const childWfRunLink = node.childWfRunId ? routes.wfRun.detail(wfRunIdToPath(node.childWfRunId)) : ''
 
   return (
     <div className="ml-1 flex max-w-full flex-1 flex-col">

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/ChildWorkflows.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/ChildWorkflows.tsx
@@ -3,6 +3,7 @@
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { SelectionLink } from '@/app/(authenticated)/[tenantId]/components/SelectionLink'
 import { SEARCH_DEFAULT_LIMIT, TIME_RANGES, TimeRange } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { getStatus, wfRunIdToPath } from '@/app/utils'
 import { computeStartTimeWindow, StartTimeWindow } from '@/app/utils/dateTime'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -83,7 +84,7 @@ export const ChildWorkflows: FC<{ parentWfRunId: WfRunId; spec: WfSpec }> = ({ p
                   {page.results.map(wfRun => {
                     if (!wfRun.wfRun.id) return null
                     return (
-                      <SelectionLink key={wfRun.wfRun.id.id} href={`/wfRun/${wfRunIdToPath(wfRun.wfRun.id)}`}>
+                      <SelectionLink key={wfRun.wfRun.id.id} href={routes.wfRun.detail(wfRunIdToPath(wfRun.wfRun.id))}>
                         <p>{wfRun.wfRun.id.id}</p>
                         <span className={cn('ml-2 rounded px-2', WF_RUN_STATUS[wfRun.wfRun.status].backgroundColor)}>
                           {`${wfRun.wfRun.status ?? ''}`}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/Details.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/Details.tsx
@@ -1,8 +1,9 @@
 'use client'
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
-import { flattenWfRunId, formatDate, wfRunIdToPath } from '@/app/utils'
 import { ThreadType } from '@/app/(authenticated)/[tenantId]/(diagram)/context'
 import { useSelectedThreadError } from '@/app/(authenticated)/[tenantId]/(diagram)/hooks/useSelectedThreadError'
+import { routes } from '@/app/routes'
+import { flattenWfRunId, formatDate, wfRunIdToPath } from '@/app/utils'
 import { WfRun } from 'littlehorse-client/proto'
 import { Expand } from 'lucide-react'
 import { FC, useState } from 'react'
@@ -28,7 +29,7 @@ export const Details: FC<DetailsProps> = ({ selectedThread, ...wfRun }) => {
       {id.parentWfRunId && (
         <div className="flex items-center gap-2">
           Parent WfRun:
-          <LinkWithTenant href={`/wfRun/${wfRunIdToPath(id.parentWfRunId)}`} linkStyle>
+          <LinkWithTenant href={routes.wfRun.detail(wfRunIdToPath(id.parentWfRunId))} linkStyle>
             <p>{id.parentWfRunId.id}</p>
           </LinkWithTenant>
         </div>
@@ -37,7 +38,7 @@ export const Details: FC<DetailsProps> = ({ selectedThread, ...wfRun }) => {
         <div className="flex items-center gap-2">
           WfSpec:
           <LinkWithTenant
-            href={`/wfSpec/${wfSpecId.name}/${wfSpecId.majorVersion}/${wfSpecId.revision}`}
+            href={routes.wfSpec.detailWithRevision(wfSpecId.name, wfSpecId.majorVersion, wfSpecId.revision)}
             className="flex items-center gap-2 text-blue-500 underline"
           >
             {`${wfSpecId.name} ${wfSpecId.majorVersion}.${wfSpecId.revision}`}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
@@ -3,6 +3,7 @@ import { Diagram } from '@/app/(authenticated)/[tenantId]/(diagram)/components/D
 import { ThreadType } from '@/app/(authenticated)/[tenantId]/(diagram)/context'
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
 import { getWfRun, WfRunResponse } from '@/app/actions/getWfRun'
+import { routes } from '@/app/routes'
 import { wfRunIdToPath } from '@/app/utils'
 import { Separator } from '@/components/ui/separator'
 import { useWhoAmI } from '@/contexts/WhoAmIContext'
@@ -45,7 +46,8 @@ export const WfRun: FC<WfRunResponse> = wfRunData => {
 
   const wfSpecUrl = useMemo(() => {
     const { name, majorVersion, revision } = wfRun.wfSpecId ?? {}
-    return `/wfSpec/${name}/${majorVersion}/${revision}`
+    if (name == null || majorVersion == null || revision == null) return ''
+    return routes.wfSpec.detailWithRevision(name, majorVersion, revision)
   }, [wfRun.wfSpecId])
 
   if (!wfRunId) {

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/SearchVariableDialog.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/SearchVariableDialog.tsx
@@ -1,7 +1,8 @@
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
-import { wfRunIdToPath } from '@/app/utils/wfRun'
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { SEARCH_DEFAULT_LIMIT } from '@/app/constants'
+import { routes } from '@/app/routes'
+import { wfRunIdToPath } from '@/app/utils'
 import { getTypedVariableValue, getVariableDefType } from '@/app/utils/variables'
 import { Button } from '@/components/ui/button'
 import {
@@ -106,7 +107,7 @@ export const SearchVariableDialog: FC<Props> = ({ spec }) => {
                   <div key={`${wfRunIdToPath(variableId.wfRunId)}-${variableId.threadRunNumber}`}>
                     <LinkWithTenant
                       className="py-2 text-blue-500 hover:underline"
-                      href={`/wfRun/${wfRunIdToPath(variableId.wfRunId)}?threadRunNumber=${variableId.threadRunNumber}`}
+                      href={`${routes.wfRun.detail(wfRunIdToPath(variableId.wfRunId))}?threadRunNumber=${variableId.threadRunNumber}`}
                     >
                       {wfRunIdToPath(variableId.wfRunId)}
                     </LinkWithTenant>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/Versions.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/Versions.tsx
@@ -1,4 +1,5 @@
 import { VersionSelector } from '@/app/(authenticated)/[tenantId]/components/VersionSelector'
+import { routes } from '@/app/routes'
 import { WfSpecId } from 'littlehorse-client/proto'
 import { useParams } from 'next/navigation'
 import { FC, useCallback, useState } from 'react'
@@ -17,7 +18,7 @@ export const Versions: FC<{ wfSpecId?: WfSpecId }> = ({ wfSpecId }) => {
 
   return (
     <VersionSelector
-      path={`/wfSpec/${props[0]}`}
+      path={routes.wfSpec.base(props![0] as string)}
       currentVersion={`${majorVersion}.${revision}`}
       versions={versions}
       loadVersions={loadVersions}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
@@ -2,6 +2,7 @@
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { SelectionLink } from '@/app/(authenticated)/[tenantId]/components/SelectionLink'
 import { SEARCH_DEFAULT_LIMIT, TIME_RANGES, TimeRange } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { getStatus, wfRunIdToPath } from '@/app/utils'
 import { computeStartTimeWindow, StartTimeWindow } from '@/app/utils/dateTime'
 import { useWhoAmI } from '@/contexts/WhoAmIContext'
@@ -84,7 +85,7 @@ export const WfRuns: FC<WfSpec> = spec => {
               {page.results.map(wfRun => {
                 if (!wfRun.wfRun.id) return null
                 return (
-                  <SelectionLink key={wfRun.wfRun.id.id} href={`/wfRun/${wfRunIdToPath(wfRun.wfRun.id)}`}>
+                  <SelectionLink key={wfRun.wfRun.id.id} href={routes.wfRun.detail(wfRunIdToPath(wfRun.wfRun.id))}>
                     <p>{wfRun.wfRun.id.id}</p>
                     <span className={cn('ml-2 rounded px-2', WF_RUN_STATUS[wfRun.wfRun.status].color)}>
                       {`${wfRun.wfRun.status ?? ''}`}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfSpec.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { DiagramProvider, NodeInContext } from '@/app/(authenticated)/[tenantId]/(diagram)/context'
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
+import { routes } from '@/app/routes'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { WfSpec as Spec } from 'littlehorse-client/proto'
 import { LucidePlayCircle } from 'lucide-react'
@@ -28,7 +29,7 @@ export const WfSpec: FC<WfSpecProps> = ({ spec }) => {
   }, [spec, setModal, setShowModal])
   return (
     <>
-      <Navigation href="/" title="Go back to WfSpecs" />
+      <Navigation href={routes.appRoot()} title="Go back to WfSpecs" />
       <div className="flex items-center justify-between">
         <Details status={spec.status} id={spec.id} />
         <button className="flex items-center gap-1 rounded-sm bg-blue-500 p-2 px-4 text-white" onClick={onClick}>

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/Header.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { getServerVersion } from '@/app/actions/getServerVersion'
+import { routes } from '@/app/routes'
 import { useWhoAmI } from '@/contexts/WhoAmIContext'
 import LhLogo from '@/littlehorse.svg'
 import { FC } from 'react'
@@ -22,7 +23,7 @@ export const Header: FC = () => {
   return (
     <nav className="mb-4 border-gray-200 bg-black px-8 dark:bg-gray-900">
       <div className="mx-auto flex flex-wrap items-center justify-between py-4">
-        <LinkWithTenant href="/" className="flex items-center space-x-1 rtl:space-x-reverse">
+        <LinkWithTenant href={routes.appRoot()} className="flex items-center space-x-1 rtl:space-x-reverse">
           <LhLogo className="h-8 fill-white" />
           <div className="hidden flex-col gap-0 space-y-[-10px] text-xl font-bold text-white md:flex">
             <span>LITTLE</span>

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/SearchHeader.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/SearchHeader.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { SEARCH_ENTITIES, SearchType } from '@/app/constants'
+import { routes } from '@/app/routes'
 import LinkWithTenant from './LinkWithTenant'
 
 import { FC } from 'react'
@@ -20,7 +21,7 @@ export const SearchHeader: FC<Props> = ({ currentType }) => {
           {SEARCH_ENTITIES.map(type => (
             <LinkWithTenant
               key={type}
-              href={`?type=${type}`}
+              href={routes.search.typeQuery(type)}
               className={`block p-2 ${type === currentType ? 'bg-gray-100' : ''}`}
             >
               {type}

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/TenantSelector.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/TenantSelector.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { routes } from '@/app/routes'
 import { useWhoAmI } from '@/contexts/WhoAmIContext'
 import {
   DropdownMenu,
@@ -41,7 +42,7 @@ export const TenantSelector: FC = () => {
           <DropdownMenuItem
             key={tenant}
             className="block w-full px-4 py-2 text-left text-sm hover:bg-gray-100"
-            onClick={() => router.push(`/${tenant}`)}
+            onClick={() => router.push(routes.tenant.root(tenant))}
           >
             {tenant}
           </DropdownMenuItem>

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/TypeDisplay.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/TypeDisplay.tsx
@@ -1,4 +1,5 @@
 import { formatTypeDefinition } from '@/app/utils'
+import { routes } from '@/app/routes'
 import { TypeBadge } from '@/components/ui/badge'
 import { TypeDefinition } from 'littlehorse-client/proto'
 import { FC } from 'react'
@@ -23,7 +24,7 @@ export const TypeDisplay: FC<Props> = ({ definedType }) => {
         <TypeBadge>
           <LinkWithTenant
             className="flex underline"
-            href={`/structDef/${definedType.value.name}/${definedType.value.version}`}
+            href={routes.structDef.detail(definedType.value.name, definedType.value.version)}
           >
             {`Struct<${definedType.value.name},${definedType.value.version}>`}
           </LinkWithTenant>

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/ExternalEventDefTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/ExternalEventDefTable.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/app/routes'
 import { ExternalEventDefId } from 'littlehorse-client/proto'
 import { FC } from 'react'
 import { SearchResultProps } from '.'
@@ -13,7 +14,7 @@ export const ExternalEventDefTable: FC<SearchResultProps> = ({ pages = [] }) => 
   return (
     <div className="py-4">
       {allResults.map(({ name }: ExternalEventDefId) => (
-        <SelectionLink key={name} href={`/externalEventDef/${name}`}>
+        <SelectionLink key={name} href={routes.externalEventDef.detail(name)}>
           <p className="group">{name}</p>
         </SelectionLink>
       ))}

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/StructDefTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/StructDefTable.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/app/routes'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { StructDefId } from 'littlehorse-client/proto'
 import { FC } from 'react'
@@ -27,7 +28,7 @@ export const StructDefTable: FC<SearchResultProps> = ({ pages = [] }) => {
             <TableRow key={`${name}.${version}`} className="hover:bg-gray-50">
               <TableCell>
                 <LinkWithTenant
-                  href={`/structDef/${name}/${version}`}
+                  href={routes.structDef.detail(name, version)}
                   className="font-medium text-blue-600 hover:text-blue-800 hover:underline"
                 >
                   {name}

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/TaskDefTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/TaskDefTable.tsx
@@ -1,4 +1,5 @@
 import { getTaskDefs } from '@/app/actions/getTaskDefs'
+import { routes } from '@/app/routes'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { TaskDefData } from '@/types'
 import { TaskDefId } from 'littlehorse-client/proto'
@@ -72,7 +73,7 @@ export const TaskDefTable: FC<TaskDefTableProps> = ({
             <TableRow key={taskDef.name} className="hover:bg-gray-50">
               <TableCell>
                 <LinkWithTenant
-                  href={`/taskDef/${taskDef.name}`}
+                  href={routes.taskDef.detail(taskDef.name)}
                   className="font-medium text-blue-600 hover:text-blue-800 hover:underline"
                 >
                   {taskDef.name}

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/UserTaskDefTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/UserTaskDefTable.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/app/routes'
 import { UserTaskDefId } from 'littlehorse-client/proto'
 import { FC } from 'react'
 import { SearchResultProps } from '.'
@@ -14,7 +15,7 @@ export const UserTaskDefTable: FC<SearchResultProps> = ({ pages = [] }) => {
   return (
     <div className="py-4">
       {allResults.map(({ name, version }: UserTaskDefId) => (
-        <SelectionLink key={`${name}.${version}`} href={`/userTaskDef/${name}/${version}`}>
+        <SelectionLink key={`${name}.${version}`} href={routes.userTaskDef.detail(name, version)}>
           <p className="group">{name}</p>
           <VersionTag label={`Latest: v${version}`} />
         </SelectionLink>

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/WfSpecTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/WfSpecTable.tsx
@@ -1,4 +1,5 @@
 import { getLatestWfSpecs } from '@/app/actions/getLatestWfSpec'
+import { routes } from '@/app/routes'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { WfSpecData } from '@/types'
 import { Calendar } from 'lucide-react'
@@ -74,7 +75,7 @@ export const WfSpecTable: FC<WfSpecTableProps> = ({
             <TableRow key={wfSpec.name} className="hover:bg-gray-50">
               <TableCell>
                 <LinkWithTenant
-                  href={`/wfSpec/${wfSpec.name}/${wfSpec.latestVersion}`}
+                  href={routes.wfSpec.detail(wfSpec.name, wfSpec.latestVersion)}
                   className="font-medium text-blue-600 hover:text-blue-800 hover:underline"
                 >
                   {wfSpec.name}
@@ -88,7 +89,10 @@ export const WfSpecTable: FC<WfSpecTableProps> = ({
               <TableCell>
                 {wfSpec.parentWfSpec ? (
                   <LinkWithTenant
-                    href={`/wfSpec/${wfSpec.parentWfSpec.wfSpecName}/${wfSpec.parentWfSpec.wfSpecMajorVersion}.0`}
+                    href={routes.wfSpec.detail(
+                      wfSpec.parentWfSpec.wfSpecName,
+                      `${wfSpec.parentWfSpec.wfSpecMajorVersion}.0`
+                    )}
                     className="text-sm text-blue-600 hover:text-blue-800 hover:underline"
                   >
                     {wfSpec.parentWfSpec.wfSpecName} (v{wfSpec.parentWfSpec.wfSpecMajorVersion})

--- a/dashboard/src/app/(authenticated)/[tenantId]/components/tables/WorkflowEventDefTable.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/tables/WorkflowEventDefTable.tsx
@@ -1,3 +1,4 @@
+import { routes } from '@/app/routes'
 import { WorkflowEventDefId } from 'littlehorse-client/proto'
 import { FC } from 'react'
 import { SearchResultProps } from '.'
@@ -13,7 +14,7 @@ export const WorkflowEventDefTable: FC<SearchResultProps> = ({ pages = [] }) => 
   return (
     <div className="py-4">
       {allResults.map(({ name }: WorkflowEventDefId) => (
-        <SelectionLink key={name} href={`/workflowEventDef/${name}`}>
+        <SelectionLink key={name} href={routes.workflowEventDef.detail(name)}>
           <p className="group">{name}</p>
         </SelectionLink>
       ))}

--- a/dashboard/src/app/(authenticated)/[tenantId]/externalEventDef/[name]/components/ExternalEventDef.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/externalEventDef/[name]/components/ExternalEventDef.tsx
@@ -3,6 +3,7 @@ import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWith
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { SEARCH_DEFAULT_LIMIT } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { wfRunIdToPath, getVariableValue, localDateTimeToUTCIsoString, utcToLocalDateTime } from '@/app/utils'
 import {
   AlertDialog,
@@ -134,7 +135,7 @@ export const ExternalEventDef: FC<Props> = ({ spec }) => {
 
   return (
     <>
-      <Navigation href="/?type=ExternalEventDef" title="Go back to ExternalEventDef" />
+      <Navigation href={routes.search.homeWithType('ExternalEventDef')} title="Go back to ExternalEventDef" />
       <Details spec={spec} />
       <hr className="mt-6" />
       <div className="mt-6">
@@ -206,7 +207,7 @@ export const ExternalEventDef: FC<Props> = ({ spec }) => {
                                   <LinkWithTenant
                                     className="py-2 text-blue-500 hover:underline"
                                     target="_blank"
-                                    href={`/wfRun/${wfRunIdToPath(externalEvent.id.wfRunId)}?threadRunNumber=${externalEvent.threadRunNumber}&nodeRunName=${externalEvent.nodeRunPosition}-${spec.id?.name}-EXTERNAL_EVENT`}
+                                    href={`${routes.wfRun.detail(wfRunIdToPath(externalEvent.id.wfRunId))}?threadRunNumber=${externalEvent.threadRunNumber}&nodeRunName=${externalEvent.nodeRunPosition}-${spec.id?.name}-EXTERNAL_EVENT`}
                                   >
                                     {wfRunIdToPath(externalEvent.id.wfRunId)}
                                   </LinkWithTenant>

--- a/dashboard/src/app/(authenticated)/[tenantId]/structDef/[name]/components/StructDef.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/structDef/[name]/components/StructDef.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
+import { routes } from '@/app/routes'
 import { Separator } from '@/components/ui/separator'
 import { StructDef } from 'littlehorse-client/proto'
 import { FC } from 'react'
@@ -15,7 +16,7 @@ export const StructDefClient: FC<Props> = ({ structDef }) => {
 
   return (
     <>
-      <Navigation href="/?type=StructDef" title="Go back to StructDefs" />
+      <Navigation href={routes.search.homeWithType('StructDef')} title="Go back to StructDefs" />
       <Details id={structDef.id} description={structDef.description} />
       <Fields fields={structDef.structDef.fields} />
 

--- a/dashboard/src/app/(authenticated)/[tenantId]/taskDef/[name]/components/TaskDef.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/taskDef/[name]/components/TaskDef.tsx
@@ -4,6 +4,7 @@ import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigati
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { PaginatedWfSpecList, searchWfSpecs } from '@/app/actions/getWfSpecsByTaskDef'
 import { SEARCH_DEFAULT_LIMIT } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { localDateTimeToUTCIsoString, utcToLocalDateTime, wfRunIdToPath } from '@/app/utils'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -71,7 +72,7 @@ export const TaskDef: FC<Props> = ({ spec }) => {
 
   return (
     <>
-      <Navigation href="/?type=TaskDef" title="Go back to TaskDefs" />
+      <Navigation href={routes.search.homeWithType('TaskDef')} title="Go back to TaskDefs" />
       <Details spec={spec} />
       <TaskDefSchema spec={spec} />
 
@@ -86,7 +87,7 @@ export const TaskDef: FC<Props> = ({ spec }) => {
                 .flatMap(page => page.results)
                 .map(wfSpec => (
                   <Fragment key={wfSpec.name}>
-                    <SelectionLink href={`/wfSpec/${wfSpec.name}/${wfSpec.majorVersion}.${wfSpec.revision}`}>
+                    <SelectionLink href={routes.wfSpec.detail(wfSpec.name, `${wfSpec.majorVersion}.${wfSpec.revision}`)}>
                       <p className="group">{wfSpec.name}</p>
                       <div className="flex items-center gap-2 rounded bg-blue-200 px-2 font-mono text-sm text-gray-500">
                         <TagIcon className="h-4 w-4 fill-none stroke-gray-500 stroke-1" />v{wfSpec.majorVersion}.
@@ -173,7 +174,7 @@ export const TaskDef: FC<Props> = ({ spec }) => {
                                   <LinkWithTenant
                                     className="py-2 text-blue-500 hover:underline"
                                     target="_blank"
-                                    href={`/wfRun/${wfRunIdToPath(taskRun.id.wfRunId)}?threadRunNumber=${taskRun.source?.taskRunSource?.value.nodeRunId?.threadRunNumber}`}
+                                    href={`${routes.wfRun.detail(wfRunIdToPath(taskRun.id.wfRunId))}?threadRunNumber=${taskRun.source?.taskRunSource?.value.nodeRunId?.threadRunNumber}`}
                                   >
                                     {wfRunIdToPath(taskRun.id.wfRunId)}
                                   </LinkWithTenant>

--- a/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/[...props]/components/UserTaskDef.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/[...props]/components/UserTaskDef.tsx
@@ -9,6 +9,7 @@ import {
 
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
 import { SEARCH_DEFAULT_LIMIT } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { localDateTimeToUTCIsoString, utcToLocalDateTime, wfRunIdToPath } from '@/app/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -76,7 +77,7 @@ export const UserTaskDef: FC<Props> = ({ spec }) => {
 
   return (
     <>
-      <Navigation href="/?type=UserTaskDef" title="Go back to UserTaskDefs" />
+      <Navigation href={routes.search.homeWithType('UserTaskDef')} title="Go back to UserTaskDefs" />
       <Details id={spec} />
       <Fields fields={spec.fields} />
       <hr className="mt-6" />
@@ -166,7 +167,7 @@ export const UserTaskDef: FC<Props> = ({ spec }) => {
                             <LinkWithTenant
                               className="py-2 text-blue-500 hover:underline"
                               target="_blank"
-                              href={`/wfRun/${wfRunIdToPath(userTaskRun.id.wfRunId)}?threadRunNumber=${userTaskRun.nodeRunId?.threadRunNumber}&nodeRunName=${nodeRun.nodeName}`}
+                              href={`${routes.wfRun.detail(wfRunIdToPath(userTaskRun.id.wfRunId))}?threadRunNumber=${userTaskRun.nodeRunId?.threadRunNumber}&nodeRunName=${nodeRun.nodeName}`}
                             >
                               {wfRunIdToPath(userTaskRun.id.wfRunId)}
                             </LinkWithTenant>
@@ -182,7 +183,10 @@ export const UserTaskDef: FC<Props> = ({ spec }) => {
                           <TableCell>
                             <Button asChild>
                               <LinkWithTenant
-                                href={`/userTaskDef/audit/${userTaskRun.id?.wfRunId?.id}/${userTaskRun.id?.userTaskGuid}`}
+                                href={routes.userTaskDef.audit(
+                                  userTaskRun.id?.wfRunId?.id ?? '',
+                                  userTaskRun.id?.userTaskGuid ?? ''
+                                )}
                               >
                                 View Audit Log
                               </LinkWithTenant>

--- a/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/[...props]/components/Versions.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/[...props]/components/Versions.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { VersionSelector } from '@/app/(authenticated)/[tenantId]/components/VersionSelector'
+import { routes } from '@/app/routes'
 import { UserTaskDefId } from 'littlehorse-client/proto'
 import { useParams } from 'next/navigation'
 import { FC, useCallback, useState } from 'react'
@@ -18,7 +19,7 @@ export const Versions: FC<{ id?: UserTaskDefId }> = ({ id }) => {
 
   return (
     <VersionSelector
-      path={`/wfSpec/${props[0]}`}
+      path={routes.wfSpec.base(props![0] as string)}
       currentVersion={`${version}`}
       versions={versions}
       loadVersions={loadVersions}

--- a/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/audit/[...ids]/page.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/userTaskDef/audit/[...ids]/page.tsx
@@ -1,6 +1,7 @@
 import { Details } from '@/app/(authenticated)/[tenantId]/components/Details'
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
 import { getUserTaskRun } from '@/app/actions/getUserTaskRun'
+import { routes } from '@/app/routes'
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { ClientError, Status } from 'nice-grpc-common'
@@ -26,7 +27,7 @@ export default async function Page({ params: { ids, tenantId } }: Props) {
           description={{
             wfRunId: (
               <Button variant="link" className="p-0" asChild>
-                <LinkWithTenant href={`/wfRun/${wfRunId}`}>{wfRunId}</LinkWithTenant>
+                <LinkWithTenant href={routes.wfRun.detail(wfRunId)}>{wfRunId}</LinkWithTenant>
               </Button>
             ),
             userTaskRunId: userTaskGuid,

--- a/dashboard/src/app/(authenticated)/[tenantId]/workflowEventDef/[name]/components/WorkflowEventDef.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/workflowEventDef/[name]/components/WorkflowEventDef.tsx
@@ -3,6 +3,7 @@ import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWith
 import { Navigation } from '@/app/(authenticated)/[tenantId]/components/Navigation'
 import { SearchFooter } from '@/app/(authenticated)/[tenantId]/components/SearchFooter'
 import { SEARCH_DEFAULT_LIMIT } from '@/app/constants'
+import { routes } from '@/app/routes'
 import { localDateTimeToUTCIsoString, utcToLocalDateTime, wfRunIdToPath } from '@/app/utils'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -43,7 +44,7 @@ export const WorkflowEventDef: FC<Props> = ({ spec }) => {
 
   return (
     <>
-      <Navigation href="/?type=WorkflowEventDef" title="Go back to WorkflowEventDef" />
+      <Navigation href={routes.search.homeWithType('WorkflowEventDef')} title="Go back to WorkflowEventDef" />
       <Details spec={spec} />
       <hr className="mt-6" />
       <div className="mb-4 mt-6 flex items-center justify-between">
@@ -97,7 +98,7 @@ export const WorkflowEventDef: FC<Props> = ({ spec }) => {
                             <LinkWithTenant
                               className="py-2 text-blue-500 hover:underline"
                               target="_blank"
-                              href={`/wfRun/${wfRunIdToPath(workflowEvent.id.wfRunId)}?threadRunNumber=${workflowEvent.nodeRunId?.threadRunNumber}&nodeRunName=${workflowEvent.nodeRunId?.position}-throw-${spec.id?.name}-THROW_EVENT`}
+                              href={`${routes.wfRun.detail(wfRunIdToPath(workflowEvent.id.wfRunId))}?threadRunNumber=${workflowEvent.nodeRunId?.threadRunNumber}&nodeRunName=${workflowEvent.nodeRunId?.position}-throw-${spec.id?.name}-THROW_EVENT`}
                             >
                               {wfRunIdToPath(workflowEvent.id.wfRunId)}
                             </LinkWithTenant>

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { routes } from './routes'
 import getWhoAmI from './getWhoami'
 
 export default async function Home() {
@@ -12,6 +13,6 @@ export default async function Home() {
       </p>
     </div>
   ) : (
-    redirect(`/${whoAmI.tenants[0] ?? 'default'}`)
+    redirect(routes.tenant.root(whoAmI.tenants[0] ?? 'default'))
   )
 }

--- a/dashboard/src/app/routes.ts
+++ b/dashboard/src/app/routes.ts
@@ -1,0 +1,52 @@
+export const routes = {
+  appRoot: () => '/',
+
+  tenant: {
+    root: (tenantId: string) => `/${tenantId}`,
+  },
+
+  wfSpec: {
+    base: (name: string) => `/wfSpec/${name}`,
+    detail: (name: string, version: string | number) => `/wfSpec/${name}/${version}`,
+    detailWithRevision: (name: string, majorVersion: string | number, revision: string | number) =>
+      `/wfSpec/${name}/${majorVersion}/${revision}`,
+  },
+
+  wfRun: {
+    detail: (wfRunUrlSegment: string) => `/wfRun/${wfRunUrlSegment}`,
+  },
+
+  structDef: {
+    detail: (name: string, version: string | number) => `/structDef/${name}/${version}`,
+  },
+
+  taskDef: {
+    detail: (name: string) => `/taskDef/${name}`,
+  },
+
+  userTaskDef: {
+    detail: (name: string, version: string | number) => `/userTaskDef/${name}/${version}`,
+    audit: (wfRunId: string, userTaskGuid: string) => `/userTaskDef/audit/${wfRunId}/${userTaskGuid}`,
+  },
+
+  externalEventDef: {
+    detail: (name: string) => `/externalEventDef/${name}`,
+  },
+
+  workflowEventDef: {
+    detail: (name: string) => `/workflowEventDef/${name}`,
+  },
+
+  search: {
+    homeWithType: (type: string) => `/?type=${type}`,
+    typeQuery: (type: string) => `?type=${type}`,
+  },
+} as const
+
+export function withTenant(tenantId: string, tenantRelativePath: string): string {
+  if (tenantRelativePath === '') {
+    return `/${tenantId}`
+  }
+  const normalized = tenantRelativePath.startsWith('/') ? tenantRelativePath : `/${tenantRelativePath}`
+  return `/${tenantId}${normalized}`
+}


### PR DESCRIPTION
resolves #2203 

Path strings were scattered across the dashboard. They’re defined in `dashboard/src/app/routes.ts` now, and the rest of the app imports from there.

The URLs themselves are the same; this just gives one place to edit them.