### PR TITLE
feat(sdk-dotnet): add Arrays

### DIFF
--- a/examples/dotnet/ArraysExample/ArrayWorker.cs
+++ b/examples/dotnet/ArraysExample/ArrayWorker.cs
@@ -1,0 +1,22 @@
+using LittleHorse.Sdk.Worker;
+
+namespace Examples.ArraysExample;
+
+public class ArrayWorker
+{
+    [LHTaskMethod("produce-array")]
+    [LHType(masked: false, isLHArray: true)]
+    public Task<long[]> ProduceArray()
+    {
+        Console.WriteLine("Producing native LittleHorse Array of type Long");
+        return Task.FromResult(new long[] { 1L, 2L, 3L });
+    }
+
+    [LHTaskMethod("consume-array")]
+    public Task<string> ConsumeArray([LHType(masked: false, isLHArray: true)] long[] arr)
+    {
+        var arrText = "[" + string.Join(", ", arr) + "]";
+        Console.WriteLine($"Consuming LHArray: {arrText}");
+        return Task.FromResult("consumed:" + arrText);
+    }
+}

--- a/examples/dotnet/ArraysExample/ArraysExample.csproj
+++ b/examples/dotnet/ArraysExample/ArraysExample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../sdk-dotnet/LittleHorse.Sdk/LittleHorse.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/dotnet/ArraysExample/Program.cs
+++ b/examples/dotnet/ArraysExample/Program.cs
@@ -1,0 +1,112 @@
+using Examples.ArraysExample;
+using LittleHorse.Sdk;
+using LittleHorse.Sdk.Workflow.Spec;
+using LittleHorse.Sdk.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ArraysExample;
+
+public class Program
+{
+    private static ServiceProvider? _serviceProvider;
+
+    private static void SetupApplication()
+    {
+        _serviceProvider = new ServiceCollection()
+            .AddLogging(config =>
+            {
+                config.AddConsole();
+                config.SetMinimumLevel(LogLevel.Debug);
+            })
+            .BuildServiceProvider();
+    }
+
+    private static Dictionary<string, string> GetDictionaryFromMainArgs(string[] args)
+    {
+        return args.Select(item => item.Split('='))
+            .ToDictionary(item => item[0], item => item[1]);
+    }
+
+    private static LHConfig GetLHConfig(string[] args, ILoggerFactory loggerFactory)
+    {
+        var config = new LHConfig(loggerFactory);
+        var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string filePath = Path.Combine(userProfilePath, ".config/littlehorse.config");
+
+        if (File.Exists(filePath))
+        {
+            config = new LHConfig(filePath, loggerFactory);
+        }
+
+        if (args.Length > 0)
+        {
+            var lhConfigs = GetDictionaryFromMainArgs(args);
+            config = new LHConfig(lhConfigs, loggerFactory);
+        }
+
+        return config;
+    }
+
+    private static Workflow GetWorkflow()
+    {
+        void Entrypoint(WorkflowThread wf)
+        {
+            // Declare a typed LH Array variable (elements are Long).
+            WfRunVariable arrVar = wf.DeclareArray("my-array", typeof(long));
+
+            NodeOutput produced = wf.Execute("produce-array");
+            arrVar.Assign(produced);
+
+            wf.Execute("consume-array", arrVar);
+        }
+
+        return new Workflow("example-arrays", Entrypoint);
+    }
+
+    private static List<LHTaskWorker<ArrayWorker>> GetWorkers(LHConfig config)
+    {
+        var worker = new ArrayWorker();
+
+        return new List<LHTaskWorker<ArrayWorker>>
+        {
+            new LHTaskWorker<ArrayWorker>(worker, "produce-array", config),
+            new LHTaskWorker<ArrayWorker>(worker, "consume-array", config)
+        };
+    }
+
+    public static async Task Main(string[] args)
+    {
+        SetupApplication();
+        if (_serviceProvider == null)
+        {
+            return;
+        }
+
+        var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger<Program>();
+
+        LHConfig config = GetLHConfig(args, loggerFactory);
+        Workflow workflow = GetWorkflow();
+        List<LHTaskWorker<ArrayWorker>> workers = GetWorkers(config);
+
+        // Register TaskDefs.
+        foreach (var worker in workers)
+        {
+            await worker.RegisterTaskDef();
+        }
+
+        // Register workflow.
+        await workflow.RegisterWfSpec(config.GetGrpcClientInstance());
+
+        await Task.Delay(300);
+
+        // Start workers.
+        foreach (var worker in workers)
+        {
+            logger.LogInformation("Starting worker {TaskDefName}", worker.TaskDefName);
+        }
+
+        await Task.WhenAll(workers.Select(worker => worker.Start()));
+    }
+}

--- a/examples/dotnet/ArraysExample/README.md
+++ b/examples/dotnet/ArraysExample/README.md
@@ -1,0 +1,34 @@
+# Arrays Example (.NET)
+
+This example mirrors the Java `examples/java/arrays` sample using the .NET SDK.
+
+## What it does
+
+- Declares a native LittleHorse ARRAY variable in the workflow (`Long` elements)
+- Executes `produce-array` to return a native LH Array
+- Assigns that output to the workflow array variable
+- Executes `consume-array` with the array variable as input
+
+## Source files
+
+- `Program.cs`: workflow and worker bootstrapping
+- `ArrayWorker.cs`: task implementations with `[LHType(isLHArray = true)]`
+
+## Run
+
+```bash
+cd examples/dotnet/ArraysExample
+dotnet build
+dotnet run
+```
+
+In another terminal, run the workflow:
+
+```bash
+lhctl run example-arrays
+```
+
+## Notes
+
+- `produce-array` is annotated with `[LHType(masked: false, isLHArray: true)]` so return type is a native LH Array.
+- `consume-array` parameter is annotated with `[LHType(masked: false, isLHArray: true)]` so input is read as native LH Array.

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -28,6 +28,7 @@ Use another terminal for `lhctl run ...` commands.
 
 ## .NET Example Index
 
+- [`ArraysExample/`](./ArraysExample/README.md): Native LH Array producer/consumer workflow.
 - [`AwaitWorkflowEventExample/`](./AwaitWorkflowEventExample/README.md): Wait for workflow events.
 - [`BasicExample/`](./BasicExample/README.md): Minimal hello-world workflow.
 - [`CheckpointTasksExample/`](./CheckpointTasksExample/README.md): Checkpoint tasks.

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHMappingHelperTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHMappingHelperTest.cs
@@ -428,4 +428,128 @@ public class LHMappingHelperTest
 
         Assert.Throws<LHSerdeException>(() => LHMappingHelper.VariableValueToObject(variableValue, typeof(TestStruct)));
     }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithLongArray_ShouldProduceArrayVariableValue()
+    {
+        long[] numbers = new long[] { 1L, 2L, 3L };
+
+        var val = LHMappingHelper.ObjectToVariableValueAsNativeArray(numbers, typeof(long[]));
+
+        Assert.Equal(VariableValue.ValueOneofCase.Array, val.ValueCase);
+        Assert.Equal(3, val.Array.Items.Count);
+        Assert.Equal(1L, val.Array.Items[0].Int);
+        Assert.Equal(2L, val.Array.Items[1].Int);
+        Assert.Equal(3L, val.Array.Items[2].Int);
+    }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithStringArray_ShouldProduceStrItems()
+    {
+        string[] words = new[] { "hello", "world" };
+
+        var val = LHMappingHelper.ObjectToVariableValueAsNativeArray(words, typeof(string[]));
+
+        Assert.Equal(VariableValue.ValueOneofCase.Array, val.ValueCase);
+        Assert.Equal(2, val.Array.Items.Count);
+        Assert.Equal("hello", val.Array.Items[0].Str);
+        Assert.Equal("world", val.Array.Items[1].Str);
+    }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithStringList_ShouldProduceArrayVariableValue()
+    {
+        var words = new List<string> { "foo", "bar" };
+
+        var val = LHMappingHelper.ObjectToVariableValueAsNativeArray(words, typeof(List<string>));
+
+        Assert.Equal(VariableValue.ValueOneofCase.Array, val.ValueCase);
+        Assert.Equal(2, val.Array.Items.Count);
+        Assert.Equal("foo", val.Array.Items[0].Str);
+        Assert.Equal("bar", val.Array.Items[1].Str);
+    }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithNull_ShouldReturnNullVariableValue()
+    {
+        var val = LHMappingHelper.ObjectToVariableValueAsNativeArray(null);
+
+        Assert.Equal(VariableValue.ValueOneofCase.None, val.ValueCase);
+    }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithByteArray_ShouldThrow()
+    {
+        // byte[] is BYTES in LH, never a native array
+        Assert.Throws<LHSerdeException>(
+            () => LHMappingHelper.ObjectToVariableValueAsNativeArray(new byte[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void ObjectToVariableValueAsNativeArray_WithScalarValue_ShouldThrow()
+    {
+        // mirrors: shouldFailNativeArraySerializationForNonArrayDeclaredType
+        Assert.Throws<LHSerdeException>(
+            () => LHMappingHelper.ObjectToVariableValueAsNativeArray("not-an-array"));
+    }
+
+    [Fact]
+    public void VariableValueToObject_WithNativeArray_ShouldDeserializeToTypedArray()
+    {
+        // mirrors: shouldDeserializeNativeLHArrayToJavaArray
+        var nativeArray = new VariableValue
+        {
+            Array = new LittleHorse.Sdk.Common.Proto.Array
+            {
+                Items = { new VariableValue { Int = 7L }, new VariableValue { Int = 9L } }
+            }
+        };
+
+        var result = (long[])LHMappingHelper.VariableValueToObject(nativeArray, typeof(long[]))!;
+
+        Assert.Equal(new long[] { 7L, 9L }, result);
+    }
+
+    [Fact]
+    public void VariableValueToObject_WithNativeArray_ShouldDeserializeToList()
+    {
+        var nativeArray = new VariableValue
+        {
+            Array = new LittleHorse.Sdk.Common.Proto.Array
+            {
+                Items = { new VariableValue { Str = "a" }, new VariableValue { Str = "b" } }
+            }
+        };
+
+        var result = (List<string>)LHMappingHelper.VariableValueToObject(nativeArray, typeof(List<string>))!;
+
+        Assert.Equal(new List<string> { "a", "b" }, result);
+    }
+
+    [Fact]
+    public void VariableValueToObject_WithNativeArrayAndByteArrayTarget_ShouldThrow()
+    {
+        var nativeArray = new VariableValue
+        {
+            Array = new LittleHorse.Sdk.Common.Proto.Array
+            {
+                Items = { new VariableValue { Int = 1L } }
+            }
+        };
+
+        Assert.Throws<LHSerdeException>(
+            () => LHMappingHelper.VariableValueToObject(nativeArray, typeof(byte[])));
+    }
+
+    [Fact]
+    public void ValueCaseToVariableType_WithNativeArray_ShouldThrowNotSupported()
+    {
+        var nativeArrayValue = new VariableValue
+        {
+            Array = new LittleHorse.Sdk.Common.Proto.Array()
+        };
+
+        Assert.Throws<NotSupportedException>(
+            () => LHMappingHelper.ValueCaseToVariableType(nativeArrayValue.ValueCase));
+    }
 }

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHStructPropertyTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Helper/LHStructPropertyTest.cs
@@ -89,7 +89,8 @@ public class LHStructPropertyTest
 
         StructFieldDef fieldDef = property.ToStructFieldDef();
 
-        Assert.Equal(VariableType.JsonArr, fieldDef.FieldType.PrimitiveType);
+        Assert.Equal(TypeDefinition.DefinedTypeOneofCase.InlineArrayDef, fieldDef.FieldType.DefinedTypeCase);
+        Assert.Equal(VariableType.Str, fieldDef.FieldType.InlineArrayDef.ArrayType.PrimitiveType);
     }
 
     [Fact]

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskParameterTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskParameterTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Exceptions;
+using LittleHorse.Sdk.Worker;
+using Xunit;
+
+namespace LittleHorse.Sdk.Tests.Worker
+{
+    public class LHTaskParameterTest
+    {
+        [Fact]
+        public void ShouldHandleJsonArrayTaskParameter()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "test-json-arr");
+            ParameterInfo parameter = method.GetParameters()[0];
+            var taskParameter = new LHTaskParameter(parameter, 0, logger: null);
+
+            var expectedVariableDef = new VariableDef
+            {
+                Name = "param1",
+                TypeDef = new TypeDefinition { PrimitiveType = VariableType.JsonArr }
+            };
+
+            Assert.Equal(expectedVariableDef, taskParameter.VariableDef);
+        }
+
+        [Fact]
+        public void ShouldHandleNativeArrayTaskParameter()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "test-native-arr");
+            ParameterInfo parameter = method.GetParameters()[0];
+            var taskParameter = new LHTaskParameter(parameter, 0, logger: null);
+
+            var expectedVariableDef = new VariableDef
+            {
+                Name = "param1",
+                TypeDef = new TypeDefinition
+                {
+                    InlineArrayDef = new InlineArrayDef
+                    {
+                        ArrayType = new TypeDefinition { PrimitiveType = VariableType.Str }
+                    }
+                }
+            };
+
+            Assert.Equal(expectedVariableDef, taskParameter.VariableDef);
+        }
+
+        [Fact]
+        public void ShouldHandleNativeListTaskParameter()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "test-native-list");
+            ParameterInfo parameter = method.GetParameters()[0];
+            var taskParameter = new LHTaskParameter(parameter, 0, logger: null);
+
+            Assert.Equal(TypeDefinition.DefinedTypeOneofCase.InlineArrayDef, taskParameter.VariableDef.TypeDef.DefinedTypeCase);
+            Assert.Equal(VariableType.Str, taskParameter.VariableDef.TypeDef.InlineArrayDef.ArrayType.PrimitiveType);
+        }
+
+        [Fact]
+        public void ShouldFailWhenIsLHArrayUsedOnNonArrayParameter()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "non-array-lh-array-invalid-task");
+            ParameterInfo parameter = method.GetParameters()[0];
+
+            var ex = Assert.Throws<LHTaskSchemaMismatchException>(() => new LHTaskParameter(parameter, 0, logger: null));
+            Assert.Contains("@LHType(isLHArray = true) can only be used on array or IList<T> parameters", ex.Message);
+        }
+
+        [Fact]
+        public void ShouldFailWhenIsLHArrayUsedOnByteArrayParameter()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "bytes-lh-array-invalid-task");
+            ParameterInfo parameter = method.GetParameters()[0];
+
+            var ex = Assert.Throws<LHTaskSchemaMismatchException>(() => new LHTaskParameter(parameter, 0, logger: null));
+            Assert.Contains("Cannot use @LHType(isLHArray = true) with byte[]", ex.Message);
+        }
+
+        [Fact]
+        public void ShouldFailWhenNativeArrayElementResolvesToJsonObj()
+        {
+            MethodInfo method = GetTaskMethodByName(typeof(ParameterTestTasks), "invalid-native-arr-pojo");
+            ParameterInfo parameter = method.GetParameters()[0];
+
+            var ex = Assert.Throws<ArgumentException>(() => new LHTaskParameter(parameter, 0, logger: null));
+            Assert.Contains("cannot contain", ex.Message);
+        }
+
+        private static MethodInfo GetTaskMethodByName(Type clazz, string taskName)
+        {
+            return clazz.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Single(m => m.GetCustomAttribute(typeof(LHTaskMethodAttribute)) is LHTaskMethodAttribute attr
+                    && attr.Value == taskName);
+        }
+
+        private class UnannotatedArrayElement
+        {
+            public string? Name { get; set; }
+        }
+
+        private class ParameterTestTasks
+        {
+            [LHTaskMethod("test-json-arr")]
+            public Task TestJsonArr([LHType(masked: false, name: "param1")] string[] param1)
+            {
+                return Task.CompletedTask;
+            }
+
+            [LHTaskMethod("test-native-arr")]
+            public Task TestNativeArr([LHType(masked: false, name: "param1", isLHArray: true)] string[] param1)
+            {
+                return Task.CompletedTask;
+            }
+
+            [LHTaskMethod("test-native-list")]
+            public Task TestNativeList([LHType(masked: false, name: "param1", isLHArray: true)] List<string> param1)
+            {
+                return Task.CompletedTask;
+            }
+
+            [LHTaskMethod("non-array-lh-array-invalid-task")]
+            public Task NonArrayLhArrayInvalidTask([LHType(masked: false, isLHArray: true)] string customer)
+            {
+                return Task.CompletedTask;
+            }
+
+            [LHTaskMethod("bytes-lh-array-invalid-task")]
+            public Task BytesLhArrayInvalidTask([LHType(masked: false, isLHArray: true)] byte[] bytes)
+            {
+                return Task.CompletedTask;
+            }
+
+            [LHTaskMethod("invalid-native-arr-pojo")]
+            public Task InvalidNativeArrayPojo([LHType(masked: false, name: "param1", isLHArray: true)] UnannotatedArrayElement[] param1)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskReturnTypeTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskReturnTypeTest.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Exceptions;
+using LittleHorse.Sdk.Worker;
+using Xunit;
+
+namespace LittleHorse.Sdk.Tests.Worker
+{
+    public class LHTaskReturnTypeTest
+    {
+        [Fact]
+        public void ShouldHandleJsonArrayTaskReturnType()
+        {
+            MethodInfo taskMethod = GetTaskMethodByName(typeof(ReturnTypeTestTasks), "test-json-arr");
+            var taskReturnType = new LHTaskReturnType(taskMethod);
+
+            var expectedReturnType = new ReturnType
+            {
+                ReturnType_ = new TypeDefinition { PrimitiveType = VariableType.JsonArr }
+            };
+
+            Assert.Equal(expectedReturnType, taskReturnType.ReturnType);
+        }
+
+        [Fact]
+        public void ShouldHandleNativeArrayTaskReturnType()
+        {
+            MethodInfo taskMethod = GetTaskMethodByName(typeof(ReturnTypeTestTasks), "test-native-arr");
+            var taskReturnType = new LHTaskReturnType(taskMethod);
+
+            var expectedReturnType = new ReturnType
+            {
+                ReturnType_ = new TypeDefinition
+                {
+                    InlineArrayDef = new InlineArrayDef
+                    {
+                        ArrayType = new TypeDefinition { PrimitiveType = VariableType.Str }
+                    }
+                }
+            };
+
+            Assert.Equal(expectedReturnType, taskReturnType.ReturnType);
+        }
+
+        [Fact]
+        public void ShouldFailWhenIsLHArrayUsedOnNonArrayReturnType()
+        {
+            MethodInfo taskMethod = GetTaskMethodByName(typeof(ReturnTypeTestTasks), "non-array-lh-array-invalid-task");
+
+            var ex = Assert.Throws<LHTaskSchemaMismatchException>(() => new LHTaskReturnType(taskMethod));
+            Assert.Contains("@LHType(isLHArray = true) can only be used on array or IList<T> return types", ex.Message);
+        }
+
+        [Fact]
+        public void ShouldFailWhenIsLHArrayUsedOnByteArrayReturnType()
+        {
+            MethodInfo taskMethod = GetTaskMethodByName(typeof(ReturnTypeTestTasks), "bytes-lh-array-invalid-task");
+
+            var ex = Assert.Throws<LHTaskSchemaMismatchException>(() => new LHTaskReturnType(taskMethod));
+            Assert.Contains("Cannot use @LHType(isLHArray = true) with byte[]", ex.Message);
+        }
+
+        [Fact]
+        public void ShouldFailWhenNativeArrayReturnElementResolvesToJsonObj()
+        {
+            MethodInfo taskMethod = GetTaskMethodByName(typeof(ReturnTypeTestTasks), "invalid-native-arr-pojo");
+
+            var ex = Assert.Throws<ArgumentException>(() => new LHTaskReturnType(taskMethod));
+            Assert.Contains("cannot contain", ex.Message);
+        }
+
+        private static MethodInfo GetTaskMethodByName(Type clazz, string taskName)
+        {
+            return clazz.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Single(m => m.GetCustomAttribute(typeof(LHTaskMethodAttribute)) is LHTaskMethodAttribute attr
+                    && attr.Value == taskName);
+        }
+
+        private class UnannotatedArrayElement
+        {
+            public string? Name { get; set; }
+        }
+
+        private class ReturnTypeTestTasks
+        {
+            [LHTaskMethod("test-json-arr")]
+            public Task<string[]> TestJsonArr()
+            {
+                return Task.FromResult(new string[] { "a" });
+            }
+
+            [LHTaskMethod("test-native-arr")]
+            [LHType(masked: false, isLHArray: true)]
+            public Task<string[]> TestNativeArr()
+            {
+                return Task.FromResult(new string[] { "a" });
+            }
+
+            [LHTaskMethod("non-array-lh-array-invalid-task")]
+            [LHType(masked: false, isLHArray: true)]
+            public Task<string> NonArrayLhArrayInvalidTask()
+            {
+                return Task.FromResult("hello");
+            }
+
+            [LHTaskMethod("bytes-lh-array-invalid-task")]
+            [LHType(masked: false, isLHArray: true)]
+            public Task<byte[]> BytesLhArrayInvalidTask()
+            {
+                return Task.FromResult(new byte[] { 1, 2, 3 });
+            }
+
+            [LHTaskMethod("invalid-native-arr-pojo")]
+            [LHType(masked: false, isLHArray: true)]
+            public Task<UnannotatedArrayElement[]> InvalidNativeArrayPojo()
+            {
+                return Task.FromResult(new[] { new UnannotatedArrayElement() });
+            }
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskSignatureTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/LHTaskSignatureTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LittleHorse.Sdk.Common.Proto;
@@ -230,7 +231,148 @@ public class LHTaskSignatureTest
 
         Assert.Equal(TASK_DEF_DESCRIPTION, taskSignature.TaskDefDescription);
     }
-    
+
+    // ──────────────────────────────────────────────────────────────
+    // LH Array parameter tests (mirrors LHTaskParameterTest.java)
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TaskSignature_WithNativeArrayParam_ShouldProduceInlineArrayDef()
+    {
+        var taskSignature = new LHTaskSignature<TestWorker>("native-arr-param", new TestWorker());
+
+        var expectedVariableDef = new VariableDef
+        {
+            Name = "words",
+            TypeDef = new TypeDefinition
+            {
+                InlineArrayDef = new InlineArrayDef
+                {
+                    ArrayType = new TypeDefinition { PrimitiveType = VariableType.Str }
+                }
+            }
+        };
+
+        Assert.Single(taskSignature.VariableDefs);
+        Assert.Equal(expectedVariableDef, taskSignature.VariableDefs[0]);
+    }
+
+    [Fact]
+    public void TaskSignature_WithNativeArrayListParam_ShouldProduceInlineArrayDef()
+    {
+        var taskSignature = new LHTaskSignature<TestWorker>("native-arr-list-param", new TestWorker());
+
+        var expectedVariableDef = new VariableDef
+        {
+            Name = "words",
+            TypeDef = new TypeDefinition
+            {
+                InlineArrayDef = new InlineArrayDef
+                {
+                    ArrayType = new TypeDefinition { PrimitiveType = VariableType.Str }
+                }
+            }
+        };
+
+        Assert.Single(taskSignature.VariableDefs);
+        Assert.Equal(expectedVariableDef, taskSignature.VariableDefs[0]);
+    }
+
+    [Fact]
+    public void TaskSignature_WithJsonArrayParam_ShouldProducePrimitiveJsonArr()
+    {
+        var taskSignature = new LHTaskSignature<TestWorker>("json-arr-param", new TestWorker());
+
+        var expectedVariableDef = new VariableDef
+        {
+            Name = "words",
+            TypeDef = new TypeDefinition { PrimitiveType = VariableType.JsonArr }
+        };
+
+        Assert.Single(taskSignature.VariableDefs);
+        Assert.Equal(expectedVariableDef, taskSignature.VariableDefs[0]);
+    }
+
+    [Fact]
+    public void TaskSignature_WithIsLHArrayOnNonArrayParam_ShouldThrow()
+    {
+        var exception = Assert.Throws<LHTaskSchemaMismatchException>(
+            () => new LHTaskSignature<TestWorker>("non-array-lh-array-param", new TestWorker()));
+
+        Assert.Contains("@LHType(isLHArray = true) can only be used on array or IList<T> parameters", exception.Message);
+    }
+
+    [Fact]
+    public void TaskSignature_WithIsLHArrayOnBytesParam_ShouldThrow()
+    {
+        var exception = Assert.Throws<LHTaskSchemaMismatchException>(
+            () => new LHTaskSignature<TestWorker>("bytes-lh-array-param", new TestWorker()));
+
+        Assert.Contains("Cannot use @LHType(isLHArray = true) with byte[]", exception.Message);
+    }
+
+    [Fact]
+    public void TaskSignature_WithIsLHArrayAndJsonObjElementParam_ShouldThrow()
+    {
+        // UnannotatedPoco resolves to JSON_OBJ — forbidden inside a native LH Array.
+        Assert.Throws<ArgumentException>(
+            () => new LHTaskSignature<TestWorker>("invalid-native-arr-jsonobj-param", new TestWorker()));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // LH Array return type tests (mirrors LHTaskReturnTypeTest.java)
+    // ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TaskSignature_WithNativeArrayReturnType_ShouldProduceInlineArrayDef()
+    {
+        var taskSignature = new LHTaskSignature<TestWorker>("native-arr-return", new TestWorker());
+
+        var expectedReturnType = new ReturnType
+        {
+            ReturnType_ = new TypeDefinition
+            {
+                InlineArrayDef = new InlineArrayDef
+                {
+                    ArrayType = new TypeDefinition { PrimitiveType = VariableType.Str }
+                }
+            }
+        };
+
+        Assert.Equal(expectedReturnType, taskSignature.ReturnType);
+    }
+
+    [Fact]
+    public void TaskSignature_WithJsonArrayReturnType_ShouldProducePrimitiveJsonArr()
+    {
+        var taskSignature = new LHTaskSignature<TestWorker>("json-arr-return", new TestWorker());
+
+        var expectedReturnType = new ReturnType
+        {
+            ReturnType_ = new TypeDefinition { PrimitiveType = VariableType.JsonArr }
+        };
+
+        Assert.Equal(expectedReturnType, taskSignature.ReturnType);
+    }
+
+    [Fact]
+    public void TaskSignature_WithIsLHArrayOnNonArrayReturnType_ShouldThrow()
+    {
+        var exception = Assert.Throws<LHTaskSchemaMismatchException>(
+            () => new LHTaskSignature<TestWorker>("non-array-lh-array-return", new TestWorker()));
+
+        Assert.Contains("@LHType(isLHArray = true) can only be used on array or IList<T> return types", exception.Message);
+    }
+
+    [Fact]
+    public void TaskSignature_WithIsLHArrayOnBytesReturnType_ShouldThrow()
+    {
+        var exception = Assert.Throws<LHTaskSchemaMismatchException>(
+            () => new LHTaskSignature<TestWorker>("bytes-lh-array-return", new TestWorker()));
+
+        Assert.Contains("Cannot use @LHType(isLHArray = true) with byte[]", exception.Message);
+    }
+
     class TestWorker
     {
         [LHTaskMethod(TASK_DEF_NAME_ADD)]
@@ -298,5 +440,74 @@ public class LHTaskSignatureTest
         {
             return Task.FromResult($"Output value: {account_number}");
         }
+
+        [LHTaskMethod("native-arr-param")]
+        public Task NativeArrayParam([LHType(masked: false, isLHArray: true)] string[] words)
+        {
+            return Task.CompletedTask;
+        }
+
+        [LHTaskMethod("native-arr-list-param")]
+        public Task NativeArrayListParam([LHType(masked: false, isLHArray: true)] List<string> words)
+        {
+            return Task.CompletedTask;
+        }
+
+        [LHTaskMethod("json-arr-param")]
+        public Task JsonArrayParam(string[] words)
+        {
+            return Task.CompletedTask;
+        }
+
+        [LHTaskMethod("native-arr-return")]
+        [LHType(masked: false, isLHArray: true)]
+        public Task<string[]> NativeArrayReturn()
+        {
+            return Task.FromResult(new string[] { "a" });
+        }
+
+        [LHTaskMethod("json-arr-return")]
+        public Task<string[]> JsonArrayReturn()
+        {
+            return Task.FromResult(new string[] { "a" });
+        }
+
+        [LHTaskMethod("non-array-lh-array-param")]
+        public Task NonArrayLhArrayParam([LHType(masked: false, isLHArray: true)] string word)
+        {
+            return Task.CompletedTask;
+        }
+
+        [LHTaskMethod("non-array-lh-array-return")]
+        [LHType(masked: false, isLHArray: true)]
+        public Task<string> NonArrayLhArrayReturn()
+        {
+            return Task.FromResult("word");
+        }
+
+        [LHTaskMethod("bytes-lh-array-param")]
+        public Task BytesLhArrayParam([LHType(masked: false, isLHArray: true)] byte[] data)
+        {
+            return Task.CompletedTask;
+        }
+
+        [LHTaskMethod("bytes-lh-array-return")]
+        [LHType(masked: false, isLHArray: true)]
+        public Task<byte[]> BytesLhArrayReturn()
+        {
+            return Task.FromResult(new byte[] { 1 });
+        }
+
+        [LHTaskMethod("invalid-native-arr-jsonobj-param")]
+        public Task InvalidNativeArrayJsonObjParam([LHType(masked: false, isLHArray: true)] UnannotatedPoco[] items)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    // A plain class with no [LHStructDef] — resolves to JSON_OBJ, forbidden in native arrays.
+    private class UnannotatedPoco
+    {
+        public string? Name { get; set; }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/VariableMappingTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Worker/VariableMappingTest.cs
@@ -412,6 +412,10 @@ public class VariableMappingTest
     {
         var inputVar = new VariableDef();
         inputVar.Type = type;
+        inputVar.TypeDef = new TypeDefinition
+        {
+            PrimitiveType = type
+        };
         TaskDef? taskDef = new TaskDef();
         TaskDefId taskDefId = new TaskDefId();
         taskDef.Id = taskDefId;

--- a/sdk-dotnet/LittleHorse.Sdk.Tests/Workflow/Spec/WorkflowThreadTest.cs
+++ b/sdk-dotnet/LittleHorse.Sdk.Tests/Workflow/Spec/WorkflowThreadTest.cs
@@ -213,6 +213,30 @@ public class WorkflowThreadTest
     }
 
     [Fact]
+    public void WfThread_DeclareArray_ShouldCompileWithInlineArrayDef()
+    {
+        var workflowName = "TestWorkflow";
+        var mockParentWorkflow = new Mock<Sdk.Workflow.Spec.Workflow>(workflowName, _action);
+
+        void EntryPointAction(WorkflowThread wf)
+        {
+            wf.DeclareArray("words", typeof(string));
+        }
+
+        var workflowThread = new WorkflowThread(mockParentWorkflow.Object, EntryPointAction);
+        var compiled = workflowThread.Compile();
+
+        Assert.Single(compiled.VariableDefs);
+        Assert.Equal("words", compiled.VariableDefs[0].VarDef.Name);
+        Assert.Equal(
+            TypeDefinition.DefinedTypeOneofCase.InlineArrayDef,
+            compiled.VariableDefs[0].VarDef.TypeDef.DefinedTypeCase);
+        Assert.Equal(
+            VariableType.Str,
+            compiled.VariableDefs[0].VarDef.TypeDef.InlineArrayDef.ArrayType.PrimitiveType);
+    }
+
+    [Fact]
     public void WfThread_InvokingExecuteTasksWithArgs_ShouldBuildSpecWithTaskNodeAndVariablesDefs()
     {
         var workflowName = "TestWorkflow";

--- a/sdk-dotnet/LittleHorse.Sdk/Exceptions/ForbiddenJsonTypeException.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Exceptions/ForbiddenJsonTypeException.cs
@@ -1,0 +1,25 @@
+using LittleHorse.Sdk.Common.Proto;
+
+namespace LittleHorse.Sdk.Exceptions
+{
+    /// <summary>
+    /// Thrown when a type definition includes forbidden JSON primitives in a native array context.
+    /// </summary>
+    public class ForbiddenJsonTypeException : Exception
+    {
+        /// <summary>
+        /// The forbidden variable type that was found.
+        /// </summary>
+        public VariableType ForbiddenType { get; }
+
+        /// <summary>
+        /// Creates a new instance of the exception.
+        /// </summary>
+        /// <param name="forbiddenType">The forbidden variable type.</param>
+        public ForbiddenJsonTypeException(VariableType forbiddenType)
+            : base($"Forbidden type [{forbiddenType}] in StructDef or InlineArrayDef. Use Struct/Array typing instead of JSON_OBJ/JSON_ARR.")
+        {
+            ForbiddenType = forbiddenType;
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHArrayType.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHArrayType.cs
@@ -1,0 +1,69 @@
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Exceptions;
+
+namespace LittleHorse.Sdk.Helper
+{
+    /// <summary>
+    /// Represents a native LittleHorse array type.
+    /// </summary>
+    public class LHArrayType : LHClassType
+    {
+        private readonly LHClassType _componentType;
+
+        /// <summary>
+        /// Creates an LH array wrapper from a .NET array type.
+        /// </summary>
+        /// <param name="type">A .NET array type (for example, typeof(string[])).</param>
+        public LHArrayType(Type type) : base(type)
+        {
+            if (!type.IsArray)
+            {
+                throw new ArgumentException($"LHArrayType can only be created from array types; got {type.Name}.");
+            }
+
+            if (type == typeof(byte[]))
+            {
+                throw new ArgumentException("byte[] is BYTES in LittleHorse and cannot be used as a native LH Array type.");
+            }
+
+            Type? componentClass = type.GetElementType();
+            if (componentClass == null)
+            {
+                throw new ArgumentException($"Unable to resolve array component type for {type.Name}.");
+            }
+
+            _componentType = componentClass.IsArray
+                ? new LHArrayType(componentClass)
+                : LHClassType.FromType(componentClass);
+
+            try
+            {
+                LHTypeConstraintValidator.EnsureNoJsonPrimitiveTypes(_componentType.GetTypeDefinition());
+            }
+            catch (ForbiddenJsonTypeException ex)
+            {
+                throw new ArgumentException(
+                    $"Native LH Array component type cannot contain {ex.ForbiddenType}. Use strongly typed Struct/Array definitions.",
+                    ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override TypeDefinition.DefinedTypeOneofCase GetDefinedTypeCase()
+        {
+            return TypeDefinition.DefinedTypeOneofCase.InlineArrayDef;
+        }
+
+        /// <inheritdoc />
+        public override TypeDefinition GetTypeDefinition()
+        {
+            return new TypeDefinition
+            {
+                InlineArrayDef = new InlineArrayDef
+                {
+                    ArrayType = _componentType.GetTypeDefinition()
+                }
+            };
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHClassType.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHClassType.cs
@@ -31,10 +31,13 @@ namespace LittleHorse.Sdk.Helper
       if (type == null)
       {
         throw new ArgumentNullException(nameof(type), "Type cannot be null.");
-      } else if (Attribute.IsDefined(type, typeof(LHStructDefAttribute)))
+      }
+
+      if (Attribute.IsDefined(type, typeof(LHStructDefAttribute)))
       {
         return new LHStructDefType(type);
       }
+
       return new LHPrimitiveType(type);
     }
 

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHMappingHelper.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHMappingHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Linq;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using LittleHorse.Sdk.Common.Proto;
@@ -129,6 +130,50 @@ namespace LittleHorse.Sdk.Helper
         }
 
         /// <summary>
+        /// Serializes a .NET array/list into a native LittleHorse ARRAY VariableValue.
+        /// This mirrors the Java <c>objToVarValAsNativeArray</c> behavior as an explicit API.
+        /// </summary>
+        /// <param name="obj">The array/list object to serialize.</param>
+        /// <param name="declaredArrayType">
+        /// The declared .NET type of the array or list (e.g. <c>typeof(string[])</c> or <c>typeof(List&lt;string&gt;)</c>).
+        /// When provided, the element type is resolved from this type and used to serialize each item,
+        /// mirroring the Java SDK's type-safe element serialization via the declared component type.
+        /// </param>
+        internal static VariableValue ObjectToVariableValueAsNativeArray(object? obj, Type? declaredArrayType = null)
+        {
+            if (obj == null)
+            {
+                return new VariableValue();
+            }
+
+            if (obj is byte[])
+            {
+                throw new LHSerdeException("Cannot serialize byte[] as native ARRAY. Use BYTES instead.");
+            }
+
+            if (obj is System.Array nativeArray)
+            {
+                Type? elementType = declaredArrayType?.GetElementType();
+                return new VariableValue
+                {
+                    Array = ToNativeArray(nativeArray, elementType)
+                };
+            }
+
+            if (obj is IList list)
+            {
+                Type? elementType = declaredArrayType != null && TryGetListElementType(declaredArrayType, out Type et) ? et : null;
+                return new VariableValue
+                {
+                    Array = ToNativeArray(list, elementType)
+                };
+            }
+
+            throw new LHSerdeException(
+                $"Native array serialization requires an array or IList value, but got [{obj.GetType().Name}].");
+        }
+
+        /// <summary>
         /// Converts an LH VariableValue to a C# object
         /// </summary>
         /// <param name="val">The value</param>
@@ -165,6 +210,8 @@ namespace LittleHorse.Sdk.Helper
                     return val.Bool;
                 case VariableValue.ValueOneofCase.Struct:
                     return DeserializeStructToObject(val.Struct, type);
+                case VariableValue.ValueOneofCase.Array:
+                    return DeserializeNativeArrayToObject(val.Array, type);
                 case VariableValue.ValueOneofCase.JsonArr:
                     jsonStr = val.JsonArr;
                     return JsonHandler.DeserializeFromJson(jsonStr, type);
@@ -360,12 +407,36 @@ namespace LittleHorse.Sdk.Helper
                     return VariableType.Timestamp;
                 case VariableValue.ValueOneofCase.WfRunId:
                     return VariableType.WfRunId;
+                case VariableValue.ValueOneofCase.Array:
+                    throw new NotSupportedException(
+                        "Native LH ARRAY does not map to a single VariableType. Use TypeDefinition.InlineArrayDef instead.");
                 case VariableValue.ValueOneofCase.JsonObj:
                     return VariableType.JsonObj;
                 case VariableValue.ValueOneofCase.None:
                 default:
                     return VariableType.JsonObj;
             }
+        }
+
+        internal static bool TryGetListElementType(Type type, out Type elementType)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IList<>))
+            {
+                elementType = type.GetGenericArguments()[0];
+                return true;
+            }
+
+            Type? listInterface = type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>));
+
+            if (listInterface != null)
+            {
+                elementType = listInterface.GetGenericArguments()[0];
+                return true;
+            }
+
+            elementType = null!;
+            return false;
         }
 
         /// <summary>
@@ -472,6 +543,91 @@ namespace LittleHorse.Sdk.Helper
             }
 
             throw new ArgumentException($"Unexpected task status: {status}");;
+        }
+
+        private static Common.Proto.Array ToNativeArray(System.Array array, Type? elementType)
+        {
+            var output = new Common.Proto.Array();
+            foreach (object? item in array)
+            {
+                output.Items.Add(SerializeArrayElement(item, elementType));
+            }
+
+            return output;
+        }
+
+        private static Common.Proto.Array ToNativeArray(IList list, Type? elementType)
+        {
+            var output = new Common.Proto.Array();
+            foreach (object? item in list)
+            {
+                output.Items.Add(SerializeArrayElement(item, elementType));
+            }
+
+            return output;
+        }
+
+        /// <summary>
+        /// Serializes a single array element using the declared element type when available,
+        /// mirroring the Java SDK's type-aware per-element serialization.
+        /// </summary>
+        private static VariableValue SerializeArrayElement(object? item, Type? elementType)
+        {
+            if (item == null)
+            {
+                return new VariableValue();
+            }
+
+            // If the element itself is a native array/list and we have a nested element type,
+            // recurse so that multi-dimensional LH Arrays are handled correctly.
+            if (elementType != null && elementType.IsArray && elementType != typeof(byte[]) && item is System.Array nestedArray)
+            {
+                return ObjectToVariableValueAsNativeArray(nestedArray, elementType);
+            }
+
+            return ObjectToVariableValue(item);
+        }
+
+        private static object DeserializeNativeArrayToObject(Common.Proto.Array arrayValue, Type targetType)
+        {
+            if (targetType == typeof(byte[]))
+            {
+                throw new LHSerdeException("Cannot deserialize native LH ARRAY into byte[]. Use BYTES instead.");
+            }
+
+            if (targetType.IsArray)
+            {
+                Type? elementType = targetType.GetElementType();
+                if (elementType == null)
+                {
+                    throw new LHSerdeException($"Unable to resolve array element type for {targetType.FullName}.");
+                }
+
+                System.Array output = System.Array.CreateInstance(elementType, arrayValue.Items.Count);
+                for (int i = 0; i < arrayValue.Items.Count; i++)
+                {
+                    output.SetValue(VariableValueToObject(arrayValue.Items[i], elementType), i);
+                }
+
+                return output;
+            }
+
+            if (TryGetListElementType(targetType, out Type listElementType))
+            {
+                Type concreteListType = typeof(List<>).MakeGenericType(listElementType);
+                IList outputList = (IList)(Activator.CreateInstance(concreteListType)
+                    ?? throw new LHSerdeException($"Could not instantiate {concreteListType.FullName}."));
+
+                foreach (VariableValue item in arrayValue.Items)
+                {
+                    outputList.Add(VariableValueToObject(item, listElementType));
+                }
+
+                return outputList;
+            }
+
+            throw new LHSerdeException(
+                $"Cannot deserialize native LH ARRAY into target type [{targetType.FullName}]. Expected array or IList<T>.");
         }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHStructDefType.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHStructDefType.cs
@@ -125,7 +125,9 @@ namespace LittleHorse.Sdk.Helper
 
       foreach (LHStructProperty property in GetStructProperties())
       {
-        inlineStructDef.Fields.Add(property.FieldName, property.ToStructFieldDef());
+        StructFieldDef fieldDef = property.ToStructFieldDef();
+        LHTypeConstraintValidator.EnsureNoJsonPrimitiveTypes(fieldDef.FieldType);
+        inlineStructDef.Fields.Add(property.FieldName, fieldDef);
       }
 
       return inlineStructDef;

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHStructProperty.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHStructProperty.cs
@@ -71,6 +71,17 @@ namespace LittleHorse.Sdk.Helper
       {
         object? val = _pd.GetValue(o);
         if (val == null) return null;
+
+        if (val is System.Array && val is not byte[])
+        {
+          return LHMappingHelper.ObjectToVariableValueAsNativeArray(val, _pd.PropertyType);
+        }
+
+        if (val is System.Collections.IList)
+        {
+          return LHMappingHelper.ObjectToVariableValueAsNativeArray(val, _pd.PropertyType);
+        }
+
         return LHMappingHelper.ObjectToVariableValue(val);
       }
       catch (Exception ex)
@@ -159,6 +170,18 @@ namespace LittleHorse.Sdk.Helper
     /// </summary>
     public LHClassType GetPropertyType()
     {
+      Type propertyType = _pd.PropertyType;
+
+      if (propertyType.IsArray && propertyType != typeof(byte[]))
+      {
+        return new LHArrayType(propertyType);
+      }
+
+      if (LHMappingHelper.TryGetListElementType(propertyType, out Type elementType))
+      {
+        return new LHArrayType(elementType.MakeArrayType());
+      }
+
       return LHClassType.FromType(_pd.PropertyType);
     }
 

--- a/sdk-dotnet/LittleHorse.Sdk/Helper/LHTypeConstraintValidator.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Helper/LHTypeConstraintValidator.cs
@@ -1,0 +1,38 @@
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Exceptions;
+
+namespace LittleHorse.Sdk.Helper
+{
+    internal static class LHTypeConstraintValidator
+    {
+        internal static void EnsureNoJsonPrimitiveTypes(TypeDefinition typeDefinition)
+        {
+            VariableType? forbidden = FindForbiddenJsonPrimitive(typeDefinition);
+            if (forbidden.HasValue)
+            {
+                throw new ForbiddenJsonTypeException(forbidden.Value);
+            }
+        }
+
+        private static VariableType? FindForbiddenJsonPrimitive(TypeDefinition typeDefinition)
+        {
+            switch (typeDefinition.DefinedTypeCase)
+            {
+                case TypeDefinition.DefinedTypeOneofCase.PrimitiveType:
+                    if (typeDefinition.PrimitiveType == VariableType.JsonObj
+                        || typeDefinition.PrimitiveType == VariableType.JsonArr)
+                    {
+                        return typeDefinition.PrimitiveType;
+                    }
+
+                    return null;
+
+                case TypeDefinition.DefinedTypeOneofCase.InlineArrayDef:
+                    return FindForbiddenJsonPrimitive(typeDefinition.InlineArrayDef.ArrayType);
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/Internal/LHServerConnection.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/Internal/LHServerConnection.cs
@@ -168,7 +168,7 @@ namespace LittleHorse.Sdk.Worker.Internal
             try
             {
                 var result = await Invoke(scheduledTask, workerContext);
-                var serialized = LHMappingHelper.ObjectToVariableValue(result);
+                var serialized = SerializeTaskOutput(result);
                 taskResult.Output = serialized;
                 taskResult.Status = TaskStatus.TaskSuccess;
 
@@ -243,6 +243,36 @@ namespace LittleHorse.Sdk.Worker.Internal
             taskResult.Time = Timestamp.FromDateTime(DateTime.UtcNow);
 
             return taskResult;
+        }
+
+        private VariableValue SerializeTaskOutput(object? result)
+        {
+            TypeDefinition? outputType = _lhTask.TaskDef?.ReturnType?.ReturnType_;
+            bool expectNativeArray = outputType != null
+                && outputType.DefinedTypeCase == TypeDefinition.DefinedTypeOneofCase.InlineArrayDef;
+
+            if (!expectNativeArray)
+            {
+                return LHMappingHelper.ObjectToVariableValue(result);
+            }
+
+            System.Type? declaredReturnType = _lhTask.TaskMethod?.ReturnType.IsGenericType == true
+                ? _lhTask.TaskMethod.ReturnType.GetGenericArguments().FirstOrDefault()
+                : null;
+
+            if (result is System.Array && result is not byte[])
+            {
+                return LHMappingHelper.ObjectToVariableValueAsNativeArray(result, declaredReturnType);
+            }
+
+            if (result is System.Collections.IList listResult && result is not byte[])
+            {
+                return LHMappingHelper.ObjectToVariableValueAsNativeArray(listResult, declaredReturnType);
+            }
+
+            throw new LHSerdeException(
+                $"Task method is declared to return a native LH Array but the actual result type " +
+                $"[{result?.GetType().Name ?? "null"}] is not an array or IList.");
         }
 
         private async Task<object?> Invoke(ScheduledTask scheduledTask, LHWorkerContext workerContext)

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskParameter.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskParameter.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Helper;
+using Microsoft.Extensions.Logging;
+
+namespace LittleHorse.Sdk.Worker
+{
+    internal sealed class LHTaskParameter
+    {
+        private readonly VariableDef _variableDef;
+
+        internal VariableDef VariableDef => _variableDef;
+
+        internal LHTaskParameter(ParameterInfo parameter, int index, ILogger? logger)
+        {
+            LHTypeMetadata metadata = LHTypeMetadata.From(parameter);
+            metadata.ValidateLHArrayUsage(parameter.ParameterType, LHTypeMetadata.ValidationContext.Parameter, parameter.Name ?? $"param{index}");
+
+            string? paramName = parameter.Name;
+            if (string.IsNullOrWhiteSpace(paramName))
+            {
+                logger?.LogWarning("Unable to inspect parameter names using reflection; using parameter index as name.");
+                paramName = $"param{index}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(metadata.Name))
+            {
+                paramName = metadata.Name;
+            }
+
+            LHClassType lhClassType = LHTypeMetadata.ResolveTaskDefinitionType(parameter.ParameterType, metadata.IsLHArray);
+            TypeDefinition typeDef = lhClassType.GetTypeDefinition();
+            typeDef.Masked = metadata.Masked;
+
+            _variableDef = new VariableDef
+            {
+                Name = paramName,
+                TypeDef = typeDef
+            };
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskReturnType.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskReturnType.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using LittleHorse.Sdk.Common.Proto;
+using LittleHorse.Sdk.Exceptions;
+using LittleHorse.Sdk.Helper;
+
+namespace LittleHorse.Sdk.Worker
+{
+    internal sealed class LHTaskReturnType
+    {
+        private readonly ReturnType _returnType;
+
+        internal ReturnType ReturnType => _returnType;
+
+        internal LHTaskReturnType(MethodInfo taskMethod)
+        {
+            if (taskMethod.ReturnType == typeof(void) || taskMethod.ReturnType == typeof(Task))
+            {
+                _returnType = new ReturnType { };
+                return;
+            }
+
+            if (!taskMethod.ReturnType.IsGenericType
+                || taskMethod.ReturnType.GetGenericTypeDefinition() != typeof(Task<>))
+            {
+                throw new LHTaskSchemaMismatchException("Task methods must return Task<type>, Task, or void");
+            }
+
+            Type returnType = taskMethod.ReturnType.GetGenericArguments().First();
+            LHTypeMetadata metadata = LHTypeMetadata.From(taskMethod);
+            metadata.ValidateLHArrayUsage(returnType, LHTypeMetadata.ValidationContext.ReturnType, taskMethod.Name);
+
+            LHClassType lhClassType = LHTypeMetadata.ResolveTaskDefinitionType(returnType, metadata.IsLHArray);
+            TypeDefinition typeDef = lhClassType.GetTypeDefinition();
+            typeDef.Masked = metadata.Masked;
+
+            _returnType = new ReturnType
+            {
+                ReturnType_ = typeDef
+            };
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskSignature.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTaskSignature.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using LittleHorse.Sdk.Common.Proto;
 using LittleHorse.Sdk.Exceptions;
-using LittleHorse.Sdk.Helper;
 using Microsoft.Extensions.Logging;
 
 namespace LittleHorse.Sdk.Worker
@@ -87,71 +86,15 @@ namespace LittleHorse.Sdk.Worker
                     continue;
                 }
 
-                _variableDefs.Add(BuildVariableDef(methodParams[i], i));
+                var taskParameter = new LHTaskParameter(methodParams[i], i, _logger);
+                _variableDefs.Add(taskParameter.VariableDef);
             }
-        }
-
-        private VariableDef BuildVariableDef(ParameterInfo param, int index)
-        {
-            var paramType = param.ParameterType;
-            var lhClassType = LHClassType.FromType(paramType);
-            var typeDef = lhClassType.GetTypeDefinition();
-
-            var maskedParam = false;
-            var paramName = param.Name;
-            if (string.IsNullOrWhiteSpace(paramName))
-            {
-                _logger.LogWarning("Unable to inspect parameter names using reflection; using parameter index as name.");
-                paramName = $"param{index}";
-            }
-
-            if (param.GetCustomAttribute(typeof(LHTypeAttribute)) is LHTypeAttribute lhTypeValue)
-            {
-                maskedParam = lhTypeValue.Masked;
-                if (!lhTypeValue.Name.Trim().Equals(string.Empty))
-                {
-                    paramName = lhTypeValue.Name;
-                }
-            }
-
-            typeDef.Masked = maskedParam;
-
-            return new VariableDef
-            {
-                Name = paramName,
-                TypeDef = typeDef
-            };
         }
         
         private ReturnType BuildReturnType()
         {
-            if (TaskMethod.ReturnType == typeof(void) || TaskMethod.ReturnType == typeof(Task))
-            {
-                return new ReturnType { };
-            }
-
-            if (!TaskMethod.ReturnType.IsGenericType
-                || TaskMethod.ReturnType.GetGenericTypeDefinition() != typeof(Task<>))
-            {
-                throw new LHTaskSchemaMismatchException("Task methods must return Task<type>, Task, or void");
-            }
-
-            var returnType = TaskMethod.ReturnType.GetGenericArguments().First();
-            var lhClassType = LHClassType.FromType(returnType);
-            var typeDef = lhClassType.GetTypeDefinition();
-            var maskedValue = false;
-
-            if (TaskMethod.GetCustomAttribute(typeof(LHTypeAttribute)) is LHTypeAttribute lhType)
-            {
-                maskedValue = lhType.Masked;
-            }
-
-            typeDef.Masked = maskedValue;
-
-            return new ReturnType
-            {
-                ReturnType_ = typeDef
-            };
+            var taskReturnType = new LHTaskReturnType(TaskMethod);
+            return taskReturnType.ReturnType;
         }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTypeAttribute.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTypeAttribute.cs
@@ -21,6 +21,11 @@
         /// An optional name associated with the attribute.
         /// </summary>
         public string Name { get; }
+
+        /// <summary>
+        /// Indicates whether arrays/lists should be treated as native LittleHorse ARRAY.
+        /// </summary>
+        public bool IsLHArray { get; }
         
         /// <summary>
         /// Constructor of the attribute.
@@ -30,6 +35,7 @@
         {
             Masked = masked;
             Name = string.Empty;
+            IsLHArray = false;
         }
         
         /// <summary>
@@ -41,6 +47,32 @@
         {
             Masked = masked;
             Name = name;
+            IsLHArray = false;
+        }
+
+        /// <summary>
+        /// Constructor of the attribute.
+        /// </summary>
+        /// <param name="masked">A bool input that makes a method response or an input param be masked.</param>
+        /// <param name="isLHArray">Whether arrays/lists should use native LittleHorse ARRAY encoding.</param>
+        public LHTypeAttribute(bool masked, bool isLHArray)
+        {
+            Masked = masked;
+            Name = string.Empty;
+            IsLHArray = isLHArray;
+        }
+
+        /// <summary>
+        /// Constructor of the attribute.
+        /// </summary>
+        /// <param name="masked">A bool input that makes a method response or an input param be masked.</param>
+        /// <param name="name">The name of the masked field.</param>
+        /// <param name="isLHArray">Whether arrays/lists should use native LittleHorse ARRAY encoding.</param>
+        public LHTypeAttribute(bool masked, string name, bool isLHArray)
+        {
+            Masked = masked;
+            Name = name;
+            IsLHArray = isLHArray;
         }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/LHTypeMetadata.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/LHTypeMetadata.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using LittleHorse.Sdk.Exceptions;
+using LittleHorse.Sdk.Helper;
+
+namespace LittleHorse.Sdk.Worker
+{
+    /// <summary>
+    /// Metadata extracted from <see cref="LHTypeAttribute"/> on methods and parameters.
+    /// </summary>
+    internal sealed class LHTypeMetadata
+    {
+        internal enum ValidationContext
+        {
+            Parameter,
+            ReturnType
+        }
+
+        internal bool Masked { get; }
+        internal string Name { get; }
+        internal bool IsLHArray { get; }
+
+        private LHTypeMetadata(bool masked, string name, bool isLHArray)
+        {
+            Masked = masked;
+            Name = name;
+            IsLHArray = isLHArray;
+        }
+
+        internal static LHTypeMetadata From(ParameterInfo parameter)
+        {
+            if (parameter.GetCustomAttribute(typeof(LHTypeAttribute)) is not LHTypeAttribute lhType)
+            {
+                return new LHTypeMetadata(masked: false, name: string.Empty, isLHArray: false);
+            }
+
+            return new LHTypeMetadata(lhType.Masked, lhType.Name, lhType.IsLHArray);
+        }
+
+        internal static LHTypeMetadata From(MethodInfo method)
+        {
+            if (method.GetCustomAttribute(typeof(LHTypeAttribute)) is not LHTypeAttribute lhType)
+            {
+                return new LHTypeMetadata(masked: false, name: string.Empty, isLHArray: false);
+            }
+
+            return new LHTypeMetadata(lhType.Masked, lhType.Name, lhType.IsLHArray);
+        }
+
+        internal static LHClassType ResolveTaskDefinitionType(Type type, bool isLHArray)
+        {
+            if (!isLHArray)
+            {
+                return LHClassType.FromType(type);
+            }
+
+            if (type == typeof(byte[]))
+            {
+                throw new LHTaskSchemaMismatchException("Cannot use IsLHArray=true with byte[]. byte[] is BYTES.");
+            }
+
+            if (type.IsArray)
+            {
+                return new LHArrayType(type);
+            }
+
+            if (LHMappingHelper.TryGetListElementType(type, out Type elementType))
+            {
+                return new LHArrayType(elementType.MakeArrayType());
+            }
+
+            throw new LHTaskSchemaMismatchException(
+                $"IsLHArray=true requires an array or IList<T> type, but got {type.Name}.");
+        }
+
+        internal void ValidateLHArrayUsage(Type dotNetType, ValidationContext context, string contextName)
+        {
+            if (!IsLHArray)
+            {
+                return;
+            }
+
+            if (dotNetType == typeof(byte[]))
+            {
+                throw new LHTaskSchemaMismatchException(
+                    "Cannot use @LHType(isLHArray = true) with byte[]. byte[] maps to BYTES in LittleHorse.");
+            }
+
+            if (!dotNetType.IsArray && !LHMappingHelper.TryGetListElementType(dotNetType, out _))
+            {
+                throw new LHTaskSchemaMismatchException(BuildUnexpectedLHArrayMessage(context, contextName, dotNetType));
+            }
+        }
+
+        private static string BuildUnexpectedLHArrayMessage(ValidationContext context, string contextName, Type dotNetType)
+        {
+            if (context == ValidationContext.Parameter)
+            {
+                return "@LHType(isLHArray = true) can only be used on array or IList<T> parameters. Invalid parameter "
+                    + contextName
+                    + " with .NET type "
+                    + dotNetType.FullName
+                    + ".";
+            }
+
+            return "@LHType(isLHArray = true) can only be used on array or IList<T> return types. Invalid return type for method "
+                + contextName
+                + " with .NET type "
+                + dotNetType.FullName
+                + ".";
+        }
+    }
+}

--- a/sdk-dotnet/LittleHorse.Sdk/Worker/VariableMapping.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Worker/VariableMapping.cs
@@ -27,7 +27,7 @@ namespace LittleHorse.Sdk.Worker
 
             VariableDef input = taskDef.InputVars[position];
 
-            ValidateType(input.Type, _type, _name);
+            ValidateType(input.TypeDef, _type, _name);
         }
 
         internal object? Assign(ScheduledTask taskInstance, LHWorkerContext workerContext)
@@ -50,45 +50,27 @@ namespace LittleHorse.Sdk.Worker
             }
         }
         
-        private void ValidateType(VariableType taskDefInputType, Type paramType, string? paramName)
+        private void ValidateType(TypeDefinition taskDefInputType, Type paramType, string? paramName)
         {
             string errorMsg = string.Empty;
 
-            switch (taskDefInputType)
+            switch (taskDefInputType.DefinedTypeCase)
             {
-                case VariableType.Int:
-                    if (!LHMappingHelper.IsInt(paramType))
+                case TypeDefinition.DefinedTypeOneofCase.PrimitiveType:
+                    errorMsg = ValidatePrimitiveType(taskDefInputType.PrimitiveType, paramType);
+                    break;
+                case TypeDefinition.DefinedTypeOneofCase.InlineArrayDef:
+                    if (!(paramType.IsArray || LHMappingHelper.TryGetListElementType(paramType, out _)))
                     {
-                        errorMsg = $"TaskDef provides INT, func accepts {paramType.Name}";
+                        errorMsg = $"TaskDef provides ARRAY, func accepts {paramType.Name}";
                     }
                     break;
-                case VariableType.Double:
-                    if (!LHMappingHelper.IsFloat(paramType))
+                case TypeDefinition.DefinedTypeOneofCase.StructDefId:
+                    if (!Attribute.IsDefined(paramType, typeof(LHStructDefAttribute))
+                        && paramType != typeof(Common.Proto.Struct))
                     {
-                        errorMsg = $"TaskDef provides DOUBLE, func accepts {paramType.Name}";
+                        errorMsg = $"TaskDef provides STRUCT, func accepts {paramType.Name}";
                     }
-                    break;
-                case VariableType.Str:
-                    if (!paramType.IsAssignableFrom(typeof(string)))
-                    {
-                        errorMsg = $"TaskDef provides STRING, func accepts {paramType.Name}";
-                    }
-                    break;
-                case VariableType.Bool:
-                    if (!paramType.IsAssignableFrom(typeof(bool)))
-                    {
-                        errorMsg = $"TaskDef provides BOOL, func accepts {paramType.Name}";
-                    }
-                    break;
-                case VariableType.Bytes:
-                    if (!paramType.IsAssignableFrom(typeof(byte[])))
-                    {
-                        errorMsg = $"TaskDef provides BYTES, func accepts {paramType.Name}";
-                    }
-                    break;
-                case VariableType.JsonArr:
-                case VariableType.JsonObj:
-                    _logger?.LogInformation($"It will use Newtonsoft to deserialize Json string into {paramType.Name}");
                     break;
                 default:
                     throw new Exception("Not possible");
@@ -99,6 +81,54 @@ namespace LittleHorse.Sdk.Worker
                 errorMsg = $"Invalid assignment for var {paramName}: {errorMsg}";
                 throw new LHTaskSchemaMismatchException(errorMsg);
             }
+        }
+
+        private string ValidatePrimitiveType(VariableType primitiveType, Type paramType)
+        {
+            switch (primitiveType)
+            {
+                case VariableType.Int:
+                    if (!LHMappingHelper.IsInt(paramType))
+                    {
+                        return $"TaskDef provides INT, func accepts {paramType.Name}";
+                    }
+
+                    break;
+                case VariableType.Double:
+                    if (!LHMappingHelper.IsFloat(paramType))
+                    {
+                        return $"TaskDef provides DOUBLE, func accepts {paramType.Name}";
+                    }
+
+                    break;
+                case VariableType.Str:
+                    if (!paramType.IsAssignableFrom(typeof(string)))
+                    {
+                        return $"TaskDef provides STRING, func accepts {paramType.Name}";
+                    }
+
+                    break;
+                case VariableType.Bool:
+                    if (!paramType.IsAssignableFrom(typeof(bool)))
+                    {
+                        return $"TaskDef provides BOOL, func accepts {paramType.Name}";
+                    }
+
+                    break;
+                case VariableType.Bytes:
+                    if (!paramType.IsAssignableFrom(typeof(byte[])))
+                    {
+                        return $"TaskDef provides BYTES, func accepts {paramType.Name}";
+                    }
+
+                    break;
+                case VariableType.JsonArr:
+                case VariableType.JsonObj:
+                    _logger?.LogInformation($"It will use Newtonsoft to deserialize Json string into {paramType.Name}");
+                    break;
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/sdk-dotnet/LittleHorse.Sdk/Workflow/Spec/WorkflowThread.cs
+++ b/sdk-dotnet/LittleHorse.Sdk/Workflow/Spec/WorkflowThread.cs
@@ -527,6 +527,28 @@ public class WorkflowThread
     }
 
     /// <summary>
+    /// Creates a native LittleHorse ARRAY variable in the ThreadSpec.
+    /// </summary>
+    /// <param name="name">It is the name of the variable.</param>
+    /// <param name="elementType">It is the .NET type of each element in the array.</param>
+    /// <returns>The value of WfRunVariable.</returns>
+    public WfRunVariable DeclareArray(string name, Type elementType)
+    {
+        if (elementType == null)
+        {
+            throw new ArgumentNullException(nameof(elementType));
+        }
+
+        if (elementType == typeof(byte))
+        {
+            throw new ArgumentException("byte[] is BYTES in LittleHorse. Use DeclareBytes for BYTES.");
+        }
+
+        var arrayType = elementType.MakeArrayType();
+        return AddStructVariable(name, new LHArrayType(arrayType));
+    }
+
+    /// <summary>
     /// Creates a Struct variable based on a StructDef-annotated class.
     /// </summary>
     /// <param name="name">


### PR DESCRIPTION
This PR adds LH Arrays to `sdk-dotnet`:

- Call `WorkflowThread.declareArray()` to declare Array variables in WfSpecs
- Use Arrays in LHTaskMethods as long as you have the `isLHArray` annotation
- Defaults to using Arrays over `JSON_ARR` in `StructDef`s
- Refactors some internal utilities to make Arrays and other types easier to design