### PR TITLE
fix(dashboard): change littlehorse client dependency to relative path

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -42,7 +42,7 @@
         "date-fns": "^4.1.0",
         "elkjs": "^0.11.0",
         "eslint": "^9.23.0",
-        "littlehorse-client": "file://../sdk-js",
+        "littlehorse-client": "file:../sdk-js",
         "lucide-react": "^0.519.0",
         "next": "^14.2.4",
         "next-auth": "^4.24.7",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -48,7 +48,7 @@
     "date-fns": "^4.1.0",
     "elkjs": "^0.11.0",
     "eslint": "^9.23.0",
-    "littlehorse-client": "file://../sdk-js",
+    "littlehorse-client": "file:../sdk-js",
     "lucide-react": "^0.519.0",
     "next": "^14.2.4",
     "next-auth": "^4.24.7",


### PR DESCRIPTION
- This PR changes littlehorse client to use relative path ../sdk-js instead of //../sdk-js.

- Npm could normalize the path while dependabot could not 