### PR TITLE
chore(frontend): update gitignore

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -6,6 +6,10 @@
 .pnp.js
 .yarn/install-state.gz
 
+# ignore lockfiles other than pnpm's
+package-lock.json
+yarn.lock
+
 # testing
 /coverage
 

--- a/sdk-js/.gitignore
+++ b/sdk-js/.gitignore
@@ -1,0 +1,3 @@
+# ignore lockfiles other than pnpm's
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This PR updates `.gitignore` so no lockfiles other than pnpm's are pushed