### PR TITLE
fix: replace npm in docker job

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -163,6 +163,11 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.19.0
+
       - name: Update Dashboard Version
         working-directory: ./dashboard
         run: |
@@ -177,8 +182,8 @@ jobs:
       - name: Build Dashboard
         working-directory: ./dashboard
         run: |
-          npm ci
-          npm run build
+          pnpm install
+          pnpm run build
 
       - name: Download Server dist artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
This PR fixes an issue related to an npm leftover in a pipeline job after migrating to pnpm