### PR TITLE
fix(server): throw NodeRun failure if try to spawn too many threads

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
@@ -20,10 +20,10 @@ import io.littlehorse.common.model.corecommand.subcommand.ResumeWfRunRequestMode
 import io.littlehorse.common.model.corecommand.subcommand.SleepNodeMaturedModel;
 import io.littlehorse.common.model.corecommand.subcommand.StopWfRunRequestModel;
 import io.littlehorse.common.model.getable.core.externalevent.ExternalEventModel;
+import io.littlehorse.common.model.getable.core.noderun.NodeFailureException;
 import io.littlehorse.common.model.getable.core.noderun.NodeRunModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.model.getable.core.wfrun.failure.FailureBeingHandledModel;
-import io.littlehorse.common.model.getable.core.noderun.NodeFailureException;
 import io.littlehorse.common.model.getable.core.wfrun.failure.FailureModel;
 import io.littlehorse.common.model.getable.core.wfrun.failure.PendingFailureHandlerModel;
 import io.littlehorse.common.model.getable.core.wfrun.haltreason.ManualHaltModel;
@@ -446,8 +446,7 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
             }
             ThreadRunModel interruptor;
             try {
-                interruptor =
-                        startThread(pi.handlerSpecName, time, pi.interruptedThreadId, vars, ThreadType.INTERRUPT);
+                interruptor = startThread(pi.handlerSpecName, time, pi.interruptedThreadId, vars, ThreadType.INTERRUPT);
             } catch (NodeFailureException exn) {
                 putFailureOnThreadRun(toInterrupt, exn.getFailure(), time, processorContext);
                 continue;
@@ -567,9 +566,7 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
                                                 + "per WfRun: %d. Reduce the number of spawned ThreadRuns or increase "
                                                 + "LHS_X_MAX_THREAD_RUNS_PER_WF_RUN.",
                                         this.threadRunsUseMeCarefully.size(),
-                                        this.executionContext
-                                                .serverConfig()
-                                                .getMaxThreadRunsPerWfRun()),
+                                        this.executionContext.serverConfig().getMaxThreadRunsPerWfRun()),
                                 LHErrorType.INTERNAL_ERROR.toString()),
                         time,
                         null);

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
@@ -23,6 +23,7 @@ import io.littlehorse.common.model.getable.core.externalevent.ExternalEventModel
 import io.littlehorse.common.model.getable.core.noderun.NodeRunModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.model.getable.core.wfrun.failure.FailureBeingHandledModel;
+import io.littlehorse.common.model.getable.core.noderun.NodeFailureException;
 import io.littlehorse.common.model.getable.core.wfrun.failure.FailureModel;
 import io.littlehorse.common.model.getable.core.wfrun.failure.PendingFailureHandlerModel;
 import io.littlehorse.common.model.getable.core.wfrun.haltreason.ManualHaltModel;
@@ -346,11 +347,23 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
             Date start,
             Integer parentThreadId,
             Map<String, VariableValueModel> variables,
-            ThreadType type) {
+            ThreadType type)
+            throws NodeFailureException {
         CoreProcessorContext processorContext = executionContext.castOnSupport(CoreProcessorContext.class);
         ThreadSpecModel tspec = getWfSpec().getThreadSpecs().get(threadName);
         if (tspec == null) {
             throw new RuntimeException("Invalid thread name, should be impossible");
+        }
+
+        int maxThreadRuns = executionContext.serverConfig().getMaxThreadRunsPerWfRun();
+        if (parentThreadId != null && threadRunsUseMeCarefully.size() >= maxThreadRuns) {
+            throw new NodeFailureException(new FailureModel(
+                    String.format(
+                            "WfRun would have %d ThreadRuns, exceeding the maximum number of ThreadRuns "
+                                    + "per WfRun: %d. Reduce the number of spawned ThreadRuns or increase "
+                                    + "LHS_X_MAX_THREAD_RUNS_PER_WF_RUN at the server configuration level.",
+                            threadRunsUseMeCarefully.size() + 1, maxThreadRuns),
+                    LHConstants.INTERNAL_ERROR));
         }
 
         ThreadRunModel newThread = new ThreadRunModel(processorContext);
@@ -431,8 +444,14 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
             } else {
                 vars = new HashMap<>();
             }
-            ThreadRunModel interruptor =
-                    startThread(pi.handlerSpecName, time, pi.interruptedThreadId, vars, ThreadType.INTERRUPT);
+            ThreadRunModel interruptor;
+            try {
+                interruptor =
+                        startThread(pi.handlerSpecName, time, pi.interruptedThreadId, vars, ThreadType.INTERRUPT);
+            } catch (NodeFailureException exn) {
+                putFailureOnThreadRun(toInterrupt, exn.getFailure(), time, processorContext);
+                continue;
+            }
             interruptor.setInterruptTriggerId(pi.externalEventId);
 
             if (interruptor.status == LHStatus.ERROR) {
@@ -472,8 +491,14 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
                 vars.put(LHConstants.EXT_EVT_HANDLER_VAR, failure.content);
             }
 
-            ThreadRunModel fh =
-                    startThread(pfh.handlerSpecName, time, pfh.failedThreadRun, vars, ThreadType.FAILURE_HANDLER);
+            ThreadRunModel fh;
+            try {
+                fh = startThread(pfh.handlerSpecName, time, pfh.failedThreadRun, vars, ThreadType.FAILURE_HANDLER);
+            } catch (NodeFailureException exn) {
+                putFailureOnThreadRun(
+                        failedThr, exn.getFailure(), time, executionContext.castOnSupport(CoreProcessorContext.class));
+                continue;
+            }
 
             failedThr.getCurrentNodeRun().getFailureHandlerIds().add(fh.number);
 
@@ -538,8 +563,13 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
                         getThreadRun(0),
                         new FailureModel(
                                 String.format(
-                                        "You exceeded the maximum number of ThreadRuns per WfRun: %s",
-                                        this.executionContext.serverConfig().getMaxThreadRunsPerWfRun()),
+                                        "WfRun would have %d ThreadRuns, exceeding the maximum number of ThreadRuns "
+                                                + "per WfRun: %d. Reduce the number of spawned ThreadRuns or increase "
+                                                + "LHS_X_MAX_THREAD_RUNS_PER_WF_RUN.",
+                                        this.threadRunsUseMeCarefully.size(),
+                                        this.executionContext
+                                                .serverConfig()
+                                                .getMaxThreadRunsPerWfRun()),
                                 LHErrorType.INTERNAL_ERROR.toString()),
                         time,
                         null);
@@ -563,6 +593,13 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
                         * NEAR_MAX_THREAD_RUNS_THRESHOLD_PERCENT)
                 / 100;
         return this.threadRunsUseMeCarefully.size() >= threshold;
+    }
+
+    /**
+     * Returns the number of active ThreadRuns held by this WfRun.
+     */
+    public int getActiveThreadRunCount() {
+        return this.threadRunsUseMeCarefully.size();
     }
 
     private void archiveCompletedThreadRuns(boolean forceArchiveCompletedThreads) {

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/StartMultipleThreadsRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/subnoderun/StartMultipleThreadsRunModel.java
@@ -92,6 +92,21 @@ public class StartMultipleThreadsRunModel extends SubNodeRun<StartMultipleThread
                 throw new LHVarSubError(null, "Iterable must be ARRAY or JSON_ARR, got " + iterableVar.getValueType());
             }
 
+            // Enforce the max ThreadRuns limit before spawning any child threads.
+            int currentThreadCount = nodeRun.getThreadRun().getWfRun().getActiveThreadRunCount();
+            int maxAllowed = processorContext.serverConfig().getMaxThreadRunsPerWfRun();
+            int requested = iterItems.size();
+            if (currentThreadCount + requested > maxAllowed) {
+                FailureModel failure = new FailureModel(
+                        String.format(
+                                "WfRun would have %d ThreadRuns, exceeding the maximum number of ThreadRuns "
+                                        + "per WfRun: %d. Reduce the number of spawned ThreadRuns or increase "
+                                        + "LHS_X_MAX_THREAD_RUNS_PER_WF_RUN.",
+                                currentThreadCount + requested, maxAllowed),
+                        LHConstants.INTERNAL_ERROR);
+                throw new NodeFailureException(failure);
+            }
+
             for (VariableValueModel iterInput : iterItems) {
                 // Construct input variables
                 Map<String, VariableValueModel> inputs = new HashMap<>();
@@ -117,9 +132,8 @@ public class StartMultipleThreadsRunModel extends SubNodeRun<StartMultipleThread
                 childThreadIds.add(child.getNumber());
             }
         } catch (LHVarSubError | LHSerdeException | LHValidationException e) {
-            FailureModel failure = new FailureModel();
-            failure.message = "Failed constructing input variables for thread: " + e.getMessage();
-            failure.failureName = LHConstants.VAR_SUB_ERROR;
+            FailureModel failure = new FailureModel(
+                    "Failed constructing input variables for thread: " + e.getMessage(), LHConstants.VAR_SUB_ERROR);
             throw new NodeFailureException(failure);
         }
     }

--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/WfSpecModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/WfSpecModel.java
@@ -11,6 +11,7 @@ import io.littlehorse.common.model.MetadataGetable;
 import io.littlehorse.common.model.corecommand.CommandModel;
 import io.littlehorse.common.model.corecommand.subcommand.RunWfRequestModel;
 import io.littlehorse.common.model.getable.ObjectIdModel;
+import io.littlehorse.common.model.getable.core.noderun.NodeFailureException;
 import io.littlehorse.common.model.getable.core.wfrun.WfRunModel;
 import io.littlehorse.common.model.getable.global.wfspec.thread.ThreadSpecModel;
 import io.littlehorse.common.model.getable.global.wfspec.thread.ThreadVarDefModel;
@@ -450,8 +451,12 @@ public class WfSpecModel extends MetadataGetable<WfSpec> {
         out.startTime = currentCommand.getTime();
         out.transitionTo(LHStatus.RUNNING);
 
-        out.startThread(
-                entrypointThreadName, currentCommand.getTime(), null, evt.getVariables(), ThreadType.ENTRYPOINT);
+        try {
+            out.startThread(
+                    entrypointThreadName, currentCommand.getTime(), null, evt.getVariables(), ThreadType.ENTRYPOINT);
+        } catch (NodeFailureException exn) {
+            throw new IllegalStateException("Entrypoint ThreadRun should never exceed the max ThreadRun limit.", exn);
+        }
         getableManager.put(out);
         return out;
     }

--- a/server/src/test/java/e2e/MaxThreadRunCountTest.java
+++ b/server/src/test/java/e2e/MaxThreadRunCountTest.java
@@ -57,19 +57,28 @@ public class MaxThreadRunCountTest {
 
     @Test
     void shouldNotLeaveOrphanThreadsWhenSpawnExceedsLimit() {
+        int maxThreadRuns = this.serverConfig.getMaxThreadRunsPerWfRun();
         ArrayList<Integer> largeArr = new ArrayList<>();
-        for (int i = 0; i < this.serverConfig.getMaxThreadRunsPerWfRun(); i++) {
+        for (int i = 0; i < maxThreadRuns; i++) {
             largeArr.add(i);
         }
 
+        // 1 entrypoint ThreadRun + maxThreadRuns requested children would exceed the limit.
+        String expectedFailureMessage = String.format(
+                "WfRun would have %d ThreadRuns, exceeding the maximum number of ThreadRuns per WfRun: %d. "
+                        + "Reduce the number of spawned ThreadRuns or increase LHS_X_MAX_THREAD_RUNS_PER_WF_RUN.",
+                maxThreadRuns + 1, maxThreadRuns);
+
         verifier.prepareRun(spawnManyThreadsWf, Arg.of("json-arr", largeArr))
                 .waitForStatus(LHStatus.ERROR)
+                .thenVerifyNodeRun(0, 1, nodeRun -> {
+                    Assertions.assertThat(nodeRun.getStatus()).isEqualTo(LHStatus.ERROR);
+                    Assertions.assertThat(nodeRun.getFailuresList().get(0).getMessage())
+                            .isEqualTo(expectedFailureMessage);
+                })
                 .thenVerifyWfRun(wfRun -> {
                     Assertions.assertThat(wfRun.getThreadRunsCount()).isEqualTo(1);
-
-                    Assertions.assertThat(wfRun.getThreadRunsList())
-                            .noneMatch(threadRun -> threadRun.getStatus() == LHStatus.RUNNING
-                                    || threadRun.getStatus() == LHStatus.STARTING);
+                    Assertions.assertThat(wfRun.getThreadRuns(0).getStatus()).isEqualTo(LHStatus.ERROR);
                 })
                 .start();
     }

--- a/server/src/test/java/e2e/MaxThreadRunCountTest.java
+++ b/server/src/test/java/e2e/MaxThreadRunCountTest.java
@@ -48,9 +48,28 @@ public class MaxThreadRunCountTest {
         verifier.prepareRun(spawnManyThreadsWf, Arg.of("json-arr", largeArr))
                 .waitForStatus(LHStatus.ERROR)
                 .thenVerifyNodeRun(0, 1, nodeRun -> {
-                    Assertions.assertThat(nodeRun.getStatus()).isEqualTo(LHStatus.HALTING);
+                    Assertions.assertThat(nodeRun.getStatus()).isEqualTo(LHStatus.ERROR);
                     Assertions.assertThat(nodeRun.getFailuresList().get(0).getMessage())
-                            .contains("You exceeded the maximum number of ThreadRuns per WfRun");
+                            .contains("exceeding the maximum number of ThreadRuns per WfRun");
+                })
+                .start();
+    }
+
+    @Test
+    void shouldNotLeaveOrphanThreadsWhenSpawnExceedsLimit() {
+        ArrayList<Integer> largeArr = new ArrayList<>();
+        for (int i = 0; i < this.serverConfig.getMaxThreadRunsPerWfRun(); i++) {
+            largeArr.add(i);
+        }
+
+        verifier.prepareRun(spawnManyThreadsWf, Arg.of("json-arr", largeArr))
+                .waitForStatus(LHStatus.ERROR)
+                .thenVerifyWfRun(wfRun -> {
+                    Assertions.assertThat(wfRun.getThreadRunsCount()).isEqualTo(1);
+
+                    Assertions.assertThat(wfRun.getThreadRunsList())
+                            .noneMatch(threadRun -> threadRun.getStatus() == LHStatus.RUNNING
+                                    || threadRun.getStatus() == LHStatus.STARTING);
                 })
                 .start();
     }


### PR DESCRIPTION
Resolves #2357 

## Background

See Proposal #12 "Archive ThreadRuns" proposal for information about the ThreadRun Archival mechanism.

The bug: when executing a StartMultipleThreads NodeRun that pushes the active `ThreadRun` count over the `LHS_X_MAX_THREAD_RUNS_PER_WF_RUN` limit, the new ThreadRuns are spawned and then the `WfRun` catches the limit on the next advance call, but now there are orphaned child threads stuck forever.

## Solution

1. I added the limit check within the `startThread()` method so that we can catch a limit pass on a per-ThreadRun basis, making the check as atomic as possible. It's important to have this conditional check at this low level to prevent other edge cases unrelated to `SpawnMultipleThreadsRunModel` from occurring.

2. `StartMultipleThreadsRunModel` now checks if the `currentThreadRuns + requestedThreadRuns > maxThreadRuns` before spawning any child thread, making the NodeRun fail early before even calling the `startThread()` method.