### PR TITLE
fix(dashboard): wire up Map/Array variable input paths

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/FormLabel.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/FormLabel.tsx
@@ -9,17 +9,28 @@ import { FC } from 'react'
 interface FormLabelProps {
   label: string
   variableType?: VariableType
+  /** Pre-formatted type label for container types (e.g. `Map<String,Integer>`) that have no single VariableType. */
+  typeLabel?: string
   structDefId?: StructDefId
   accessLevel?: WfRunVariableAccessLevel
   required?: boolean
   masked?: boolean
 }
-const FormLabel: FC<FormLabelProps> = ({ label, variableType, structDefId, accessLevel, required, masked }) => {
+const FormLabel: FC<FormLabelProps> = ({
+  label,
+  variableType,
+  typeLabel,
+  structDefId,
+  accessLevel,
+  required,
+  masked,
+}) => {
   return (
     <FieldLabel className="flex gap-2">
       <p className="font-semibold">{label}</p>
       <div className="space-x-2">
         {variableType && <TypeBadge>{VARIABLE_CASE_LABELS[getVariableCaseFromType(variableType)]}</TypeBadge>}
+        {typeLabel && <TypeBadge>{typeLabel}</TypeBadge>}
         {structDefId && (
           <TypeBadge>
             <LinkWithTenant

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/VariableFormField.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/VariableFormField.tsx
@@ -1,10 +1,75 @@
 import { ThreadVarDef, VariableType, WfRunVariableAccessLevel } from 'littlehorse-client/proto'
 import { FC } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { formatTypeDefinition } from '@/app/utils'
+import { Field, FieldError } from '@/components/ui/field'
+import { Textarea } from '@/components/ui/textarea'
+import { CircleAlert } from 'lucide-react'
 import FormField from './FormField'
 import FormLabel from './FormLabel'
 import { StructDefGroup } from './StructDefGroup'
 import { TimestampVariableField } from './TimestampVariableField'
 import { VariableTypeToFieldComponent } from './VariableTypeToFieldComponent'
+
+type ContainerKind = 'inlineArrayDef' | 'inlineMapDef'
+
+/**
+ * Text input for Map/Array variables in the Execute WfRun form. The value is entered as the
+ * same human-friendly JSON the dashboard displays (a Map is `{"one":1}`, an Array is `[1,2]`)
+ * and converted to a typed VariableValue at submit time via `getTypedVariableValueFromTypeDef`.
+ */
+const ContainerVariableField: FC<{
+  name: string
+  kind: ContainerKind
+  typeLabel: string
+  required?: boolean
+  accessLevel?: WfRunVariableAccessLevel
+  masked?: boolean
+}> = ({ name, kind, typeLabel, required, accessLevel, masked }) => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext()
+
+  const wantsObject = kind === 'inlineMapDef'
+  const placeholder = wantsObject ? '{ "key": value }' : '[ value, … ]'
+
+  return (
+    <Field>
+      <FormLabel label={name} typeLabel={typeLabel} accessLevel={accessLevel} required={required} masked={masked} />
+      <Textarea
+        id={name}
+        placeholder={placeholder}
+        className={errors[name] ? 'border-destructive' : undefined}
+        {...register(name, {
+          required: required ? `${name} is required` : false,
+          validate: value => {
+            if (!value) return true
+            let parsed: unknown
+            try {
+              parsed = JSON.parse(value)
+            } catch {
+              return 'Input must be valid JSON'
+            }
+            if (wantsObject && (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed))) {
+              return `Expected a JSON object for ${typeLabel}`
+            }
+            if (!wantsObject && !Array.isArray(parsed)) {
+              return `Expected a JSON array for ${typeLabel}`
+            }
+            return true
+          },
+        })}
+      />
+      {errors[name] && (
+        <FieldError className="flex items-center gap-1 text-sm text-destructive">
+          <CircleAlert size={16} />
+          {String(errors[name]?.message)}
+        </FieldError>
+      )}
+    </Field>
+  )
+}
 
 interface VariableFormFieldProps {
   variable: ThreadVarDef
@@ -68,6 +133,19 @@ export const VariableFormField: FC<VariableFormFieldProps> = ({ variable }) => {
         required={variable.required}
         masked={varDef.typeDef?.masked}
         defaultValue={varDef.defaultValue}
+      />
+    )
+  }
+
+  if (definedType.oneofKind === 'inlineArrayDef' || definedType.oneofKind === 'inlineMapDef') {
+    return (
+      <ContainerVariableField
+        name={name}
+        kind={definedType.oneofKind}
+        typeLabel={formatTypeDefinition(definedType)}
+        required={variable.required}
+        accessLevel={variable.accessLevel}
+        masked={varDef.typeDef?.masked}
       />
     )
   }

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/ExecuteWorkflowRun.tsx
@@ -1,4 +1,5 @@
 import { getVariableDefType, wfRunIdFromFlattenedId, wfRunIdToPath } from '@/app/utils'
+import { getTypedVariableValueFromTypeDef } from '@/app/utils/variables'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -85,6 +86,24 @@ export const ExecuteWorkflowRun: FC<Modal<WfSpec>> = ({ data: wfSpec }) => {
         }
 
         const caseName = matchVariableType(transformedKey)
+
+        // Container types (Map/Array) are entered as human-friendly JSON in a textarea
+        // (e.g. {"one":1}) and need the declared key/element types to build proper entries.
+        // fromJson would reject that shape and the create() fallback below would silently
+        // produce an EMPTY container, discarding the user's data.
+        if (caseName === 'map' || caseName === 'array') {
+          try {
+            acc[transformedKey] = getTypedVariableValueFromTypeDef(
+              variableDef?.varDef?.typeDef,
+              String(primitiveValues[key])
+            )
+          } catch {
+            // Field-level validation already blocks invalid JSON before submit; if something
+            // still slips through, omit the variable rather than send an empty container.
+          }
+          return acc
+        }
+
         // The old ts-proto `VariableValue.fromJSON({ [case]: value })` coerced JSON values
         // to the correct runtime type (e.g. base64 string -> Uint8Array for BYTES, ISO
         // string -> Timestamp). @protobuf-ts `fromJson` performs the same coercion, but

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRuns.tsx
@@ -9,7 +9,7 @@ import { usePersistedSearchLimit } from '@/app/hooks/usePersistedSearchLimit'
 import { routes } from '@/app/routes'
 import { DateLike, formatDate, getStatus, getVariableValue, toDate, wfRunIdToPath } from '@/app/utils'
 import { computeStartTimeWindow, StartTimeWindow } from '@/app/utils/dateTime'
-import { getTypedVariableValue, getVariableDefType } from '@/app/utils/variables'
+import { getVariableFilterValue } from '@/app/utils/variables'
 import { useWhoAmI } from '@/contexts/WhoAmIContext'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -34,12 +34,15 @@ const defaultSort = (): SortState => ({ key: 'startTime', dir: 'desc' })
 
 const buildVariableFilters = (filter: VariableFilter | null): VariableMatch[] => {
   if (!filter?.value?.trim()) return []
-  return [
-    {
-      varName: filter.varDef.name,
-      value: getTypedVariableValue(getVariableDefType(filter.varDef), filter.value.trim()),
-    },
-  ]
+  try {
+    return [{ varName: filter.varDef.name, value: getVariableFilterValue(filter.varDef, filter.value.trim()) }]
+  } catch {
+    // Invalid input for the selected variable type (e.g. a map/array filter whose text
+    // isn't valid JSON). This runs inside a render-time useMemo, so a throw escapes to the
+    // error boundary and white-screens the page — skip the filter instead. The dialog
+    // validates and surfaces the error before a bad filter can reach here.
+    return []
+  }
 }
 
 const toTimestamp = (value?: string): Timestamp | undefined => (value ? Timestamp.fromDate(new Date(value)) : undefined)

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRunsHeader.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfSpec/[...props]/components/WfRunsHeader.tsx
@@ -15,6 +15,7 @@ import { ClockIcon, XIcon } from 'lucide-react'
 import LinkWithTenant from '@/app/(authenticated)/[tenantId]/components/LinkWithTenant'
 import { FC, useEffect, useMemo, useState } from 'react'
 import { usePathname } from 'next/navigation'
+import { getVariableFilterValue } from '@/app/utils/variables'
 import { VariableFilter } from './types'
 
 const searchableVarDefs = (spec: WfSpec): VariableDef[] => {
@@ -51,6 +52,7 @@ export const WfRunsHeader: FC<Props> = ({
   const [open, setOpen] = useState(false)
   const [selectedName, setSelectedName] = useState(() => variableFilter?.varDef.name ?? variables[0]?.name ?? '')
   const [valueDraft, setValueDraft] = useState(variableFilter?.value ?? '')
+  const [valueError, setValueError] = useState<string | null>(null)
 
   // Keep the dialog draft synced with the source-of-truth filter so external clears reset it.
   useEffect(() => {
@@ -60,6 +62,7 @@ export const WfRunsHeader: FC<Props> = ({
     } else {
       setValueDraft('')
     }
+    setValueError(null)
   }, [variableFilter])
 
   const selectedDef = useMemo(
@@ -69,6 +72,15 @@ export const WfRunsHeader: FC<Props> = ({
 
   const applyFilter = () => {
     if (!hasVariableFilter || !selectedDef || !valueDraft.trim()) return
+    try {
+      // Parse now so an invalid value (e.g. a Map filter that isn't valid JSON) is surfaced
+      // here instead of throwing during render and white-screening the page.
+      getVariableFilterValue(selectedDef, valueDraft.trim())
+    } catch (e) {
+      setValueError(e instanceof Error ? e.message : 'Invalid value for this variable type')
+      return
+    }
+    setValueError(null)
     onVariableFilterChange({ varDef: selectedDef, value: valueDraft.trim() })
     setOpen(false)
   }
@@ -157,11 +169,15 @@ export const WfRunsHeader: FC<Props> = ({
                 <Input
                   placeholder="Variable value…"
                   value={valueDraft}
-                  onChange={e => setValueDraft(e.target.value)}
+                  onChange={e => {
+                    setValueDraft(e.target.value)
+                    if (valueError) setValueError(null)
+                  }}
                   onKeyDown={e => {
                     if (e.key === 'Enter') applyFilter()
                   }}
                 />
+                {valueError && <p className="text-xs text-destructive">{valueError}</p>}
                 <div className="flex flex-wrap gap-2">
                   <Button type="button" onClick={applyFilter} disabled={!selectedDef || !valueDraft.trim()}>
                     Apply

--- a/dashboard/src/app/(authenticated)/[tenantId]/externalEventDef/[name]/components/CreateCorrelatedEventDialog.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/externalEventDef/[name]/components/CreateCorrelatedEventDialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 import {
   getTypedVariableValue,
+  getTypedVariableValueFromTypeDef,
   getVariableCaseFromTypeDef,
   VARIABLE_CASE_LABELS,
   VariableValueCase,
@@ -96,11 +97,17 @@ export default function CreateCorrelatedEventDialog({
 
       setIsCreating(true)
 
+      // Convert using the EED's declared return type when available so container types
+      // (Map/Array) accept the same friendly JSON the dashboard displays; fall back to the
+      // primitive string path for legacy defs without a typeDef.
+      const returnType = spec.typeInformation?.returnType
       await putCorrelatedEvent({
         tenantId,
         key,
         externalEventDefName: spec.id?.name ?? '',
-        content: getTypedVariableValue(contentType, contentValue),
+        content: returnType
+          ? getTypedVariableValueFromTypeDef(returnType, contentValue)
+          : getTypedVariableValue(contentType, contentValue),
       })
 
       toast.success('Correlated event created successfully')

--- a/dashboard/src/app/utils/variables.test.ts
+++ b/dashboard/src/app/utils/variables.test.ts
@@ -11,9 +11,11 @@ import {
   formatTypeDefinition,
   getPrimitiveFormDefaultValue,
   getTypedVariableValue,
+  getTypedVariableValueFromTypeDef,
   getVariable,
   getVariableCaseFromTypeDef,
   getVariableDefType,
+  getVariableFilterValue,
   getVariableValue,
 } from './variables'
 import { normalizeUtcTimestampString } from './timestamp'
@@ -658,5 +660,75 @@ describe('getVariableValue', () => {
     })
 
     expect(getVariableValue(variableValue)).toEqual('{"one":1,"two":2}')
+  })
+})
+
+describe('getTypedVariableValueFromTypeDef', () => {
+  const mapStrInt: TypeDefinition = {
+    definedType: {
+      oneofKind: 'inlineMapDef',
+      inlineMapDef: {
+        keyType: { definedType: { oneofKind: 'primitiveType', primitiveType: VariableType.STR }, masked: false },
+        valueType: { definedType: { oneofKind: 'primitiveType', primitiveType: VariableType.INT }, masked: false },
+      },
+    },
+    masked: false,
+  }
+
+  const arrayInt: TypeDefinition = {
+    definedType: {
+      oneofKind: 'inlineArrayDef',
+      inlineArrayDef: {
+        arrayType: { definedType: { oneofKind: 'primitiveType', primitiveType: VariableType.INT }, masked: false },
+      },
+    },
+    masked: false,
+  }
+
+  it('converts friendly Map JSON into a proto Map that round-trips back to the same display', () => {
+    const vv = getTypedVariableValueFromTypeDef(mapStrInt, '{"apples":3,"bananas":5}')
+    expect(vv.value.oneofKind).toEqual('map')
+    // entries carry the declared key/value types, not raw JSON
+    expect(vv.value).toEqual({
+      oneofKind: 'map',
+      map: {
+        entries: [
+          { key: { value: { oneofKind: 'str', str: 'apples' } }, value: { value: { oneofKind: 'int', int: '3' } } },
+          { key: { value: { oneofKind: 'str', str: 'bananas' } }, value: { value: { oneofKind: 'int', int: '5' } } },
+        ],
+      },
+    })
+    expect(getVariableValue(vv)).toEqual('{"apples":3,"bananas":5}')
+  })
+
+  it('converts friendly Array JSON into a proto Array that round-trips', () => {
+    const vv = getTypedVariableValueFromTypeDef(arrayInt, '[1,2,3]')
+    expect(vv.value.oneofKind).toEqual('array')
+    expect(getVariableValue(vv)).toEqual('[1,2,3]')
+  })
+
+  it('handles nested Map<String,Array<Integer>> recursively', () => {
+    const nested: TypeDefinition = {
+      definedType: {
+        oneofKind: 'inlineMapDef',
+        inlineMapDef: {
+          keyType: { definedType: { oneofKind: 'primitiveType', primitiveType: VariableType.STR }, masked: false },
+          valueType: arrayInt,
+        },
+      },
+      masked: false,
+    }
+    const vv = getTypedVariableValueFromTypeDef(nested, '{"a":[1,2],"b":[3]}')
+    expect(getVariableValue(vv)).toEqual('{"a":[1,2],"b":[3]}')
+  })
+
+  it('throws on malformed JSON so callers can surface a validation error instead of crashing', () => {
+    expect(() => getTypedVariableValueFromTypeDef(mapStrInt, 'not json')).toThrow()
+  })
+
+  it('getVariableFilterValue builds a filter value from a map-typed VariableDef', () => {
+    const varDef: VariableDef = { name: 'settings', typeDef: mapStrInt } as VariableDef
+    const vv = getVariableFilterValue(varDef, '{"x":1}')
+    expect(getVariableValue(vv)).toEqual('{"x":1}')
   })
 })

--- a/dashboard/src/app/utils/variables.ts
+++ b/dashboard/src/app/utils/variables.ts
@@ -27,6 +27,10 @@ export const getVariableCaseFromTypeDef = (typeDef: TypeDefinition): VariableVal
       return getVariableCaseFromType(typeDef.definedType.primitiveType)
     case 'structDefId':
       return 'struct'
+    case 'inlineArrayDef':
+      return 'array'
+    case 'inlineMapDef':
+      return 'map'
     default:
       throw new Error('Unknown variable type.')
   }
@@ -298,6 +302,85 @@ export const getTypedVariableValue = (type: VariableValueCase, value: string): V
 }
 
 /**
+ * Renders a primitive JS value (already JSON-parsed) into the string shape that
+ * `getTypedVariableValue` consumes for that primitive type.
+ */
+const primitiveJsonToString = (type: VariableType, value: unknown): string => {
+  if (type === VariableType.JSON_OBJ || type === VariableType.JSON_ARR) {
+    return typeof value === 'string' ? value : JSON.stringify(value)
+  }
+  return typeof value === 'string' ? value : String(value)
+}
+
+/**
+ * Converts an already-JSON-parsed value into a VariableValue, using a TypeDefinition to
+ * type container keys/elements. This accepts the same human-friendly shape the dashboard
+ * *displays* (via `variableValueToJSON`): a Map is `{"one":1}` and an Array is `[1,2]`,
+ * NOT proto-JSON (`{"entries":[...]}` / `{"items":[...]}`). It is the input-side inverse of
+ * `variableValueToJSON` for the container types.
+ */
+const jsonValueToVariableValue = (typeDef: TypeDefinition | undefined, value: unknown): VariableValue => {
+  const definedType = typeDef?.definedType
+  switch (definedType?.oneofKind) {
+    case 'inlineArrayDef': {
+      if (!Array.isArray(value)) throw new Error('Expected a JSON array')
+      const elementType = definedType.inlineArrayDef.arrayType
+      return VariableValue.create({
+        value: { oneofKind: 'array', array: { items: value.map(el => jsonValueToVariableValue(elementType, el)) } },
+      })
+    }
+    case 'inlineMapDef': {
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error('Expected a JSON object')
+      }
+      const { keyType, valueType } = definedType.inlineMapDef
+      // Object.entries always yields string keys; the keyType drives their real parsing.
+      const entries = Object.entries(value as Record<string, unknown>).map(([k, v]) => ({
+        key: jsonValueToVariableValue(keyType, k),
+        value: jsonValueToVariableValue(valueType, v),
+      }))
+      return VariableValue.create({ value: { oneofKind: 'map', map: { entries } } })
+    }
+    case 'primitiveType':
+      return getTypedVariableValue(
+        getVariableCaseFromType(definedType.primitiveType),
+        primitiveJsonToString(definedType.primitiveType, value)
+      )
+    case 'structDefId':
+      return VariableValue.create({
+        value: { oneofKind: 'struct', struct: Struct.fromJsonString(JSON.stringify(value)) },
+      })
+    default:
+      throw new Error('Unsupported type for value conversion.')
+  }
+}
+
+/**
+ * Like `getTypedVariableValue`, but resolves container element/key types from a
+ * TypeDefinition, so Map and Array inputs can be provided in the same human-friendly JSON
+ * the dashboard displays (e.g. `{"one":1}`) rather than raw proto-JSON. Primitives and
+ * structs fall back to the existing string-based path.
+ */
+export const getTypedVariableValueFromTypeDef = (typeDef: TypeDefinition | undefined, value: string): VariableValue => {
+  const oneofKind = typeDef?.definedType?.oneofKind
+  if (oneofKind === 'inlineArrayDef' || oneofKind === 'inlineMapDef') {
+    return jsonValueToVariableValue(typeDef, JSON.parse(value))
+  }
+  if (!typeDef?.definedType) throw new Error('Variable type is unknown.')
+  return getTypedVariableValue(getVariableCaseFromTypeDef(typeDef), value)
+}
+
+/**
+ * Builds the VariableValue for a WfRun variable-search filter, handling both the new
+ * `typeDef` (including Map/Array via friendly JSON) and legacy `.type`-only VariableDefs.
+ * Throws on invalid input — callers (dialog validation, filter builder) must catch.
+ */
+export const getVariableFilterValue = (varDef: VariableDef, value: string): VariableValue =>
+  varDef.typeDef?.definedType
+    ? getTypedVariableValueFromTypeDef(varDef.typeDef, value)
+    : getTypedVariableValue(getVariableDefType(varDef), value)
+
+/**
  * Converts a VariableValue (from a `VariableDef.defaultValue`) into the
  * representation used by primitive form fields in the Execute WfRun form.
  *
@@ -337,19 +420,10 @@ export const getPrimitiveFormDefaultValue = (defaultValue?: VariableValue): unkn
  */
 export const getVariableDefType = (varDef: VariableDef): VariableValueCase => {
   if (varDef.typeDef && varDef.typeDef.definedType) {
-    const definedType = varDef.typeDef.definedType
-    switch (definedType.oneofKind) {
-      case 'primitiveType':
-        return getVariableCaseFromType(definedType.primitiveType)
-      case 'structDefId':
-        return 'struct'
-      case 'inlineArrayDef':
-        return 'array'
-      case 'inlineMapDef':
-        return 'map'
-      default:
-        throw new Error('Unknown variable type.')
-    }
+    // Delegate to the single source of truth so the two type-dispatch switches
+    // cannot drift out of sync (they previously did: map support was added here
+    // but not to getVariableCaseFromTypeDef, crashing the ExternalEventDef page).
+    return getVariableCaseFromTypeDef(varDef.typeDef)
   } else if (varDef.type) {
     return getVariableCaseFromType(varDef.type)
   }


### PR DESCRIPTION
The native Maps feature (#2368) completed the display direction (proto -> JSON) but left the input direction expecting raw proto-JSON, so Map variables either rendered no input field or crashed the page.

- Add getTypedVariableValueFromTypeDef: converts the friendly JSON the dashboard displays ({"k":v}) back into a typed proto Map/Array using the declared key/element types (recursive), plus a shared getVariableFilterValue helper.
- getVariableCaseFromTypeDef now handles inlineArrayDef/inlineMapDef, and getVariableDefType delegates to it so the two type-dispatch switches can't drift apart again (fixes the ExternalEventDef page crashing on a Map return type).
- The Execute WfRun form renders a validated textarea for Map/Array variables in the live dispatcher (VariableFormField) and converts the value on submit, instead of leaving the field unrendered and silently sending an empty container.
- The WfRun variable filter no longer throws during render (which was white-screening the whole page); the dialog validates the value and surfaces the error inline.

Adds unit tests covering map/array/nested conversion and malformed input.