### PR TITLE
cherry-pick(5cf2d5a): pin authoritative element type on nested structures

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/IngressTypeUtils.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/IngressTypeUtils.java
@@ -1,10 +1,15 @@
 package io.littlehorse.common.model.getable.global.wfspec;
 
 import io.littlehorse.common.exceptions.validation.TypeValidationException;
+import io.littlehorse.common.model.getable.core.variable.StructFieldModel;
+import io.littlehorse.common.model.getable.core.variable.StructModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
-import io.littlehorse.sdk.common.proto.TypeDefinition.DefinedTypeCase;
+import io.littlehorse.common.model.getable.global.structdef.StructDefModel;
+import io.littlehorse.common.model.getable.global.structdef.StructFieldDefModel;
 import io.littlehorse.sdk.common.proto.VariableValue;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
+import io.littlehorse.server.streams.topology.core.WfService;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -13,8 +18,10 @@ import java.util.Optional;
  * Responsibilities:
  * - If an expected type is present and is an inline-array, set the provided
  *   VariableValueModel's Array.elementType to the expected element type when
- *   the value is an ARRAY. This mirrors server-side inference and avoids
- *   relying on client-supplied element_type.
+ *   the value is an ARRAY. Nested arrays, map values, and struct fields are
+ *   pinned recursively so that inner containers also carry their authoritative
+ *   types. This mirrors server-side inference and avoids relying on
+ *   client-supplied element_type.
  * - Validate the value against the expected type and throw an LHApiException
  *   with Status.INVALID_ARGUMENT on mismatch.
  */
@@ -35,14 +42,71 @@ public class IngressTypeUtils {
                     typeDef));
         }
 
-        // If expected is inline array and value is array, set authoritative element type
-        if (typeDef.getDefinedTypeCase() == DefinedTypeCase.INLINE_ARRAY_DEF
-                && value.getValueType() == VariableValue.ValueCase.ARRAY) {
-            value.getArray().setElementType(typeDef.getInlineArrayDef().getArrayType());
-        }
+        // Set authoritative element/map/struct-field types on the value (recursively
+        // for nested arrays, map values, and struct fields) before validation.
+        applyExpectedType(typeDef, value, metadataManager);
 
         // Validate using existing TypeDefinitionModel logic. It will perform
         // per-item checks for inline arrays as needed. Map domain errors to API errors.
         typeDef.validateCompatibility(value, metadataManager);
+    }
+
+    /**
+     * Recursively pins the authoritative element type onto ARRAY values, the map type onto MAP
+     * values, and each field's type onto STRUCT values, descending into nested arrays, map entries,
+     * and struct fields so that inner containers also carry their authoritative types rather than
+     * relying on client-supplied ones.
+     */
+    private static void applyExpectedType(
+            TypeDefinitionModel typeDef, VariableValueModel value, ReadOnlyMetadataManager metadataManager) {
+        if (typeDef == null || value == null) return;
+
+        switch (typeDef.getDefinedTypeCase()) {
+            case INLINE_ARRAY_DEF:
+                if (value.getValueType() == VariableValue.ValueCase.ARRAY) {
+                    TypeDefinitionModel elementType =
+                            typeDef.getInlineArrayDef().getArrayType();
+                    value.getArray().setElementType(elementType);
+                    if (value.getArray().getItems() != null) {
+                        for (VariableValueModel item : value.getArray().getItems()) {
+                            applyExpectedType(elementType, item, metadataManager);
+                        }
+                    }
+                }
+                break;
+            case STRUCT_DEF_ID:
+                if (value.getValueType() == VariableValue.ValueCase.STRUCT) {
+                    applyExpectedTypeToStructFields(typeDef, value.getStruct(), metadataManager);
+                }
+                break;
+            default:
+                // Primitive types have no nested containers whose types need pinning.
+                break;
+        }
+    }
+
+    /**
+     * Pins the authoritative type onto each field of a STRUCT value by resolving its StructDef and
+     * recursing into the declared type of every present field. If the StructDef cannot be resolved,
+     * pinning is skipped and the subsequent validation will surface the appropriate error.
+     */
+    private static void applyExpectedTypeToStructFields(
+            TypeDefinitionModel typeDef, StructModel struct, ReadOnlyMetadataManager metadataManager) {
+        if (metadataManager == null || struct == null || struct.getInlineStruct() == null) return;
+
+        StructDefModel structDef = new WfService(metadataManager).getStructDef(typeDef.getStructDefId());
+        if (structDef == null || structDef.getStructDef() == null) return;
+
+        Map<String, StructFieldDefModel> fieldDefs = structDef.getStructDef().getFields();
+        Map<String, StructFieldModel> fieldValues = struct.getInlineStruct().getFields();
+        if (fieldDefs == null || fieldValues == null) return;
+
+        for (Map.Entry<String, StructFieldModel> entry : fieldValues.entrySet()) {
+            StructFieldDefModel fieldDef = fieldDefs.get(entry.getKey());
+            StructFieldModel fieldValue = entry.getValue();
+            if (fieldDef != null && fieldValue != null && fieldValue.getValue() != null) {
+                applyExpectedType(fieldDef.getFieldType(), fieldValue.getValue(), metadataManager);
+            }
+        }
     }
 }

--- a/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/IngressTypeUtilsTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/IngressTypeUtilsTest.java
@@ -1,0 +1,142 @@
+package io.littlehorse.common.model.getable.global.wfspec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.littlehorse.common.exceptions.validation.TypeValidationException;
+import io.littlehorse.common.model.getable.core.variable.ArrayModel;
+import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
+import io.littlehorse.common.model.getable.global.structdef.InlineArrayDefModel;
+import io.littlehorse.common.model.getable.global.structdef.StructDefModel;
+import io.littlehorse.common.model.getable.objectId.StructDefIdModel;
+import io.littlehorse.sdk.common.proto.Array;
+import io.littlehorse.sdk.common.proto.InlineArrayDef;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.InlineStructDef;
+import io.littlehorse.sdk.common.proto.Struct;
+import io.littlehorse.sdk.common.proto.StructDef;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.StructFieldDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
+import io.littlehorse.sdk.common.proto.VariableType;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
+import io.littlehorse.server.streams.topology.core.ExecutionContext;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class IngressTypeUtilsTest {
+
+    private final ReadOnlyMetadataManager metadataManager = mock(ReadOnlyMetadataManager.class);
+
+    private static TypeDefinitionModel arrayOf(TypeDefinitionModel elementType) {
+        return new TypeDefinitionModel(new InlineArrayDefModel(elementType));
+    }
+
+    private static ArrayModel intArrayWithoutElementType(long... values) {
+        ArrayList<VariableValueModel> items = new ArrayList<>();
+        for (long value : values) {
+            items.add(new VariableValueModel(value));
+        }
+        // Simulate a client-supplied array that has no authoritative element type set.
+        return new ArrayModel(items, null);
+    }
+
+    @Test
+    void shouldPinElementTypeOnTopLevelArray() throws TypeValidationException {
+        TypeDefinitionModel expected = arrayOf(new TypeDefinitionModel(VariableType.INT));
+        VariableValueModel value = new VariableValueModel(intArrayWithoutElementType(1L, 2L, 3L));
+
+        IngressTypeUtils.applyExpectedTypeAndValidate(Optional.of(expected), value, metadataManager);
+
+        assertThat(value.getArray().getElementType().getPrimitiveType()).isEqualTo(VariableType.INT);
+    }
+
+    @Test
+    void shouldPinElementTypeOnNestedArrays() throws TypeValidationException {
+        // Array<Array<INT>>
+        TypeDefinitionModel expected = arrayOf(arrayOf(new TypeDefinitionModel(VariableType.INT)));
+
+        ArrayList<VariableValueModel> outerItems = new ArrayList<>();
+        outerItems.add(new VariableValueModel(intArrayWithoutElementType(1L, 2L, 3L)));
+        VariableValueModel value = new VariableValueModel(new ArrayModel(outerItems, null));
+
+        IngressTypeUtils.applyExpectedTypeAndValidate(Optional.of(expected), value, metadataManager);
+
+        // Outer array's element type is Array<INT>.
+        assertThat(value.getArray()
+                        .getElementType()
+                        .getInlineArrayDef()
+                        .getArrayType()
+                        .getPrimitiveType())
+                .isEqualTo(VariableType.INT);
+
+        // The inner array must have its authoritative element type pinned to INT.
+        VariableValueModel innerArray = value.getArray().getItems().get(0);
+        assertThat(innerArray.getArray().getElementType().getPrimitiveType()).isEqualTo(VariableType.INT);
+    }
+
+    @Test
+    void shouldLeaveValueUntouchedWhenExpectedTypeAbsent() throws TypeValidationException {
+        VariableValueModel value = new VariableValueModel(intArrayWithoutElementType(1L, 2L, 3L));
+
+        IngressTypeUtils.applyExpectedTypeAndValidate(Optional.empty(), value, metadataManager);
+
+        // No expected type => no authoritative element type is pinned.
+        assertThat(value.getArray().getElementType()).isNull();
+    }
+
+    @Test
+    void shouldPinElementTypeOnArrayFieldInsideStruct() throws TypeValidationException {
+        // StructDef "my-struct" with a single field "nums" of type Array<INT>.
+        StructDef structDefProto = StructDef.newBuilder()
+                .setId(StructDefId.newBuilder().setName("my-struct").setVersion(0))
+                .setStructDef(InlineStructDef.newBuilder()
+                        .putFields(
+                                "nums",
+                                StructFieldDef.newBuilder()
+                                        .setFieldType(TypeDefinition.newBuilder()
+                                                .setInlineArrayDef(InlineArrayDef.newBuilder()
+                                                        .setArrayType(TypeDefinition.newBuilder()
+                                                                .setPrimitiveType(VariableType.INT))))
+                                        .build()))
+                .build();
+        ExecutionContext context = mock(ExecutionContext.class);
+        StructDefModel structDefModel = StructDefModel.fromProto(structDefProto, context);
+        when(metadataManager.getLastFromPrefix(StructDefIdModel.getPrefix("my-struct"), StructDefModel.class))
+                .thenReturn(structDefModel);
+
+        // A struct value { nums: [1, 2, 3] } whose array field has no authoritative element type.
+        VariableValue structValue = VariableValue.newBuilder()
+                .setStruct(Struct.newBuilder()
+                        .setStructDefId(
+                                StructDefId.newBuilder().setName("my-struct").setVersion(-1))
+                        .setStruct(InlineStruct.newBuilder()
+                                .putFields(
+                                        "nums",
+                                        StructField.newBuilder()
+                                                .setValue(VariableValue.newBuilder()
+                                                        .setArray(Array.newBuilder()
+                                                                .addItems(VariableValue.newBuilder()
+                                                                        .setInt(1))
+                                                                .addItems(VariableValue.newBuilder()
+                                                                        .setInt(2))
+                                                                .addItems(VariableValue.newBuilder()
+                                                                        .setInt(3))))
+                                                .build())))
+                .build();
+        VariableValueModel value = VariableValueModel.fromProto(structValue, context);
+
+        TypeDefinitionModel expected = new TypeDefinitionModel(new StructDefIdModel("my-struct", -1));
+
+        IngressTypeUtils.applyExpectedTypeAndValidate(Optional.of(expected), value, metadataManager);
+
+        // The array field inside the struct must have its authoritative element type pinned to INT.
+        VariableValueModel numsField =
+                value.getStruct().getInlineStruct().getFields().get("nums").getValue();
+        assertThat(numsField.getArray().getElementType().getPrimitiveType()).isEqualTo(VariableType.INT);
+    }
+}


### PR DESCRIPTION
This is a PR to the 1.1 branch. This PR cherry-picks a fix for pinning the authoritative element type on nested structures (Arrays, Structs). On the master branch, we implemented this fix for Maps also, but Maps were not added in 1.1 so we had to remove that functionality during the cherry-pick.