### PR TITLE
fix(sdk-java): apply Struct placeholders on Task Workers

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/LHLibUtil.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/LHLibUtil.java
@@ -372,6 +372,15 @@ public class LHLibUtil {
 
     public static Object varValToObj(VariableValue val, Class<?> targetClazz, LHTypeAdapterRegistry typeAdapterRegistry)
             throws LHSerdeException {
+        return varValToObj(val, targetClazz, typeAdapterRegistry, Map.of());
+    }
+
+    public static Object varValToObj(
+            VariableValue val,
+            Class<?> targetClazz,
+            LHTypeAdapterRegistry typeAdapterRegistry,
+            Map<String, String> placeholderValues)
+            throws LHSerdeException {
         Optional<LHTypeAdapter<?>> maybeAdapter = getTypeAdapterForClass(targetClazz, typeAdapterRegistry);
 
         if (maybeAdapter.isPresent()) {
@@ -416,7 +425,7 @@ public class LHLibUtil {
                 return val.getWfRunId();
             case STRUCT:
                 Struct struct = val.getStruct();
-                return deserializeStructToObject(struct, targetClazz, typeAdapterRegistry);
+                return deserializeStructToObject(struct, targetClazz, typeAdapterRegistry, placeholderValues);
             case ARRAY:
                 return deserializeNativeArrayToObject(val, targetClazz, typeAdapterRegistry);
             case MAP:
@@ -602,8 +611,12 @@ public class LHLibUtil {
     }
 
     private static Object deserializeStructToObject(
-            Struct struct, Class<?> clazz, LHTypeAdapterRegistry typeAdapterRegistry) throws LHSerdeException {
-        LHClassType lhClassType = LHClassType.fromJavaClass(clazz, typeAdapterRegistry);
+            Struct struct,
+            Class<?> clazz,
+            LHTypeAdapterRegistry typeAdapterRegistry,
+            Map<String, String> placeholderValues)
+            throws LHSerdeException {
+        LHClassType lhClassType = LHClassType.fromJavaClass(clazz, typeAdapterRegistry, placeholderValues);
 
         if (!(lhClassType instanceof LHStructDefType)) {
             throw new LHSerdeException("Failed deserializing Struct into class of type: " + lhClassType);
@@ -629,7 +642,7 @@ public class LHLibUtil {
                 VariableValue fieldValue =
                         struct.getStruct().getFieldsMap().get(fieldName).getValue();
 
-                property.setValueTo(structObject, fieldValue, typeAdapterRegistry);
+                property.setValueTo(structObject, fieldValue, typeAdapterRegistry, placeholderValues);
             }
 
             return structObject;
@@ -664,6 +677,15 @@ public class LHLibUtil {
 
     public static VariableValue objToVarVal(Object o, Class<?> declaredClass, LHTypeAdapterRegistry typeAdapterRegistry)
             throws LHSerdeException {
+        return objToVarVal(o, declaredClass, typeAdapterRegistry, Map.of());
+    }
+
+    public static VariableValue objToVarVal(
+            Object o,
+            Class<?> declaredClass,
+            LHTypeAdapterRegistry typeAdapterRegistry,
+            Map<String, String> placeholderValues)
+            throws LHSerdeException {
         if (o == null) {
             return VariableValue.newBuilder().build();
         }
@@ -682,7 +704,7 @@ public class LHLibUtil {
             return objToVarValViaAdapter(o, maybeAdapter.get());
         }
 
-        return objToVarValWithoutTypeAdapter(o, typeAdapterRegistry);
+        return objToVarValWithoutTypeAdapter(o, typeAdapterRegistry, placeholderValues);
     }
 
     /**
@@ -832,6 +854,12 @@ public class LHLibUtil {
 
     private static VariableValue objToVarValWithoutTypeAdapter(Object o, LHTypeAdapterRegistry typeAdapterRegistry)
             throws LHSerdeException {
+        return objToVarValWithoutTypeAdapter(o, typeAdapterRegistry, Map.of());
+    }
+
+    private static VariableValue objToVarValWithoutTypeAdapter(
+            Object o, LHTypeAdapterRegistry typeAdapterRegistry, Map<String, String> placeholderValues)
+            throws LHSerdeException {
         if (o instanceof VariableValue) return (VariableValue) o;
         if (o instanceof InlineStruct) {
             throw new LHSerdeException(
@@ -858,7 +886,7 @@ public class LHLibUtil {
         } else if (o instanceof WfRunId) {
             out.setWfRunId((WfRunId) o);
         } else if (o.getClass().isAnnotationPresent(LHStructDef.class)) {
-            out.setStruct(serializeToStruct(o, typeAdapterRegistry));
+            out.setStruct(serializeToStruct(o, typeAdapterRegistry, placeholderValues));
         } else if (o instanceof Instant) {
             out.setUtcTimestamp(fromInstant((Instant) o));
         } else if (o instanceof Timestamp) {
@@ -932,7 +960,12 @@ public class LHLibUtil {
     }
 
     public static Struct serializeToStruct(Object o, LHTypeAdapterRegistry typeAdapterRegistry) {
-        LHClassType lhClassType = LHClassType.fromJavaClass(o.getClass(), typeAdapterRegistry);
+        return serializeToStruct(o, typeAdapterRegistry, Map.of());
+    }
+
+    public static Struct serializeToStruct(
+            Object o, LHTypeAdapterRegistry typeAdapterRegistry, Map<String, String> placeholderValues) {
+        LHClassType lhClassType = LHClassType.fromJavaClass(o.getClass(), typeAdapterRegistry, placeholderValues);
 
         if (!(lhClassType instanceof LHStructDefType))
             throw new IllegalStateException("Cannot serialize given object to Struct");
@@ -949,7 +982,7 @@ public class LHLibUtil {
             List<LHStructProperty> lhStructProperties = structDefType.getStructProperties();
 
             for (LHStructProperty property : lhStructProperties) {
-                VariableValue fieldValue = property.getValueFrom(o, typeAdapterRegistry);
+                VariableValue fieldValue = property.getValueFrom(o, typeAdapterRegistry, placeholderValues);
 
                 if (fieldValue == null) {
                     fieldValue = VariableValue.newBuilder().build();

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/structdefutil/LHStructProperty.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/structdefutil/LHStructProperty.java
@@ -55,6 +55,12 @@ public class LHStructProperty {
     }
 
     public VariableValue getValueFrom(Object o, LHTypeAdapterRegistry typeAdapterRegistry) throws LHSerdeException {
+        return getValueFrom(o, typeAdapterRegistry, java.util.Map.of());
+    }
+
+    public VariableValue getValueFrom(
+            Object o, LHTypeAdapterRegistry typeAdapterRegistry, java.util.Map<String, String> placeholderValues)
+            throws LHSerdeException {
         if (pd.getReadMethod() == null) {
             throw new IllegalStateException(
                     "No read method for property " + this.fieldName + " found on object of type: " + o.getClass());
@@ -72,7 +78,7 @@ public class LHStructProperty {
                 return LHLibUtil.objToVarValAsNativeMap(val, typeAdapterRegistry);
             }
 
-            return LHLibUtil.objToVarVal(val, pd.getPropertyType(), typeAdapterRegistry);
+            return LHLibUtil.objToVarVal(val, pd.getPropertyType(), typeAdapterRegistry, placeholderValues);
         } catch (LHSerdeException | IllegalAccessException | InvocationTargetException e) {
             throw new LHSerdeException(
                     e, "Failed getting value of property " + this.fieldName + "from object of type: " + o.getClass());
@@ -85,13 +91,23 @@ public class LHStructProperty {
 
     public void setValueTo(Object o, VariableValue v, LHTypeAdapterRegistry typeAdapterRegistry)
             throws LHSerdeException {
+        setValueTo(o, v, typeAdapterRegistry, java.util.Map.of());
+    }
+
+    public void setValueTo(
+            Object o,
+            VariableValue v,
+            LHTypeAdapterRegistry typeAdapterRegistry,
+            java.util.Map<String, String> placeholderValues)
+            throws LHSerdeException {
         if (pd.getWriteMethod() == null) {
             throw new IllegalStateException(String.format(
                     "No write method for property [%s] found on object of type [%s]", this.fieldName, o.getClass()));
         }
 
         try {
-            pd.getWriteMethod().invoke(o, LHLibUtil.varValToObj(v, pd.getPropertyType(), typeAdapterRegistry));
+            pd.getWriteMethod()
+                    .invoke(o, LHLibUtil.varValToObj(v, pd.getPropertyType(), typeAdapterRegistry, placeholderValues));
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new LHSerdeException(
                     e,

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/LHTaskWorker.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/LHTaskWorker.java
@@ -165,7 +165,8 @@ public class LHTaskWorker implements Closeable {
                     taskMethod,
                     mappings,
                     executable,
-                    config);
+                    config,
+                    placeholderValues);
         }
     }
 
@@ -323,7 +324,10 @@ public class LHTaskWorker implements Closeable {
 
         for (LHTaskParameter lhTaskParameter : taskSignature.getVariableDefs()) {
             VariableMapping mapping = new VariableMapping(
-                    lhTaskParameter.getVariableDef(), lhTaskParameter, config.getTypeAdapterRegistry());
+                    lhTaskParameter.getVariableDef(),
+                    lhTaskParameter,
+                    config.getTypeAdapterRegistry(),
+                    placeholderValues);
             mappings.add(mapping);
         }
     }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/LHServerConnectionManager.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/LHServerConnectionManager.java
@@ -7,6 +7,7 @@ import io.littlehorse.sdk.worker.LHTaskWorkerHealth;
 import io.littlehorse.sdk.worker.internal.util.VariableMapping;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 
 public class LHServerConnectionManager {
 
@@ -23,7 +24,8 @@ public class LHServerConnectionManager {
             Method taskMethod,
             List<VariableMapping> mappings,
             Object executable,
-            LHConfig config) {
+            LHConfig config,
+            Map<String, String> placeholderValues) {
         this.rebalanceThread = new RebalanceThread(
                 bootstrapStub,
                 taskWorkerId,
@@ -40,7 +42,11 @@ public class LHServerConnectionManager {
                         executable,
                         taskMethod,
                         new ScheduledTaskExecutor(
-                                bootstrapStub, config.getBlockingStub(), config.getTypeAdapterRegistry(), taskDef)));
+                                bootstrapStub,
+                                config.getBlockingStub(),
+                                config.getTypeAdapterRegistry(),
+                                taskDef,
+                                placeholderValues)));
         this.livenessController = livenessController;
         this.taskDef = taskDef;
     }

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutor.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutor.java
@@ -40,6 +40,7 @@ public class ScheduledTaskExecutor {
     private final LittleHorseGrpc.LittleHorseBlockingStub blockingStub;
     private final LHTypeAdapterRegistry typeAdapterRegistry;
     private final TaskDef taskDef;
+    private final Map<String, String> placeholderValues;
 
     public ScheduledTaskExecutor(
             final LittleHorseGrpc.LittleHorseStub retriesStub, final LittleHorseBlockingStub blockingStub) {
@@ -65,10 +66,20 @@ public class ScheduledTaskExecutor {
             final LittleHorseBlockingStub blockingStub,
             final LHTypeAdapterRegistry typeAdapterRegistry,
             final TaskDef taskDef) {
+        this(retriesStub, blockingStub, typeAdapterRegistry, taskDef, Map.of());
+    }
+
+    public ScheduledTaskExecutor(
+            final LittleHorseGrpc.LittleHorseStub retriesStub,
+            final LittleHorseBlockingStub blockingStub,
+            final LHTypeAdapterRegistry typeAdapterRegistry,
+            final TaskDef taskDef,
+            final Map<String, String> placeholderValues) {
         this.retriesStub = retriesStub;
         this.blockingStub = blockingStub;
         this.typeAdapterRegistry = Objects.requireNonNull(typeAdapterRegistry, "Type adapter registry cannot be null");
         this.taskDef = taskDef;
+        this.placeholderValues = placeholderValues == null ? Map.of() : Map.copyOf(placeholderValues);
     }
 
     public void doTask(
@@ -182,7 +193,7 @@ public class ScheduledTaskExecutor {
         if (InlineStruct.class.equals(returnType)) {
             return serializeInlineStructResult(result);
         }
-        return LHLibUtil.objToVarVal(result, returnType, typeAdapterRegistry);
+        return LHLibUtil.objToVarVal(result, returnType, typeAdapterRegistry, placeholderValues);
     }
 
     private VariableValue serializeInlineStructResult(Object result) {

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/VariableMapping.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/VariableMapping.java
@@ -22,13 +22,24 @@ public class VariableMapping {
     private final Class<?> parameterJavaType;
     private final boolean expectsNativeLHArray;
     private final boolean expectsNativeLHMap;
+    private final Map<String, String> placeholderValues;
 
     public VariableMapping(
             VariableDef variableDef, LHTaskParameter lhTaskParameter, LHTypeAdapterRegistry typeAdapterRegistry)
             throws TaskSchemaMismatchError {
+        this(variableDef, lhTaskParameter, typeAdapterRegistry, Map.of());
+    }
+
+    public VariableMapping(
+            VariableDef variableDef,
+            LHTaskParameter lhTaskParameter,
+            LHTypeAdapterRegistry typeAdapterRegistry,
+            Map<String, String> placeholderValues)
+            throws TaskSchemaMismatchError {
         Objects.requireNonNull(variableDef, "VariableDef cannot be null");
         Objects.requireNonNull(lhTaskParameter, "LHTaskParameter cannot be null");
         this.typeAdapterRegistry = Objects.requireNonNull(typeAdapterRegistry, "Type adapter registry cannot be null");
+        this.placeholderValues = placeholderValues == null ? Map.of() : Map.copyOf(placeholderValues);
         this.variableName = variableDef.getName();
         this.parameterJavaType = lhTaskParameter.getParameterType();
         this.expectsNativeLHArray =
@@ -168,7 +179,7 @@ public class VariableMapping {
             if (expectsNativeLHMap && val.getValueCase() == VariableValue.ValueCase.MAP) {
                 return assignNativeMap(val);
             }
-            return LHLibUtil.varValToObj(val, this.parameterJavaType, this.typeAdapterRegistry);
+            return LHLibUtil.varValToObj(val, this.parameterJavaType, this.typeAdapterRegistry, this.placeholderValues);
         } catch (LHSerdeException e) {
             throw new InputVarSubstitutionException(
                     "Failed serializing Java object for variable: " + taskDefParamName, e);

--- a/sdk-java/src/test/java/io/littlehorse/sdk/common/LHLibUtilTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/common/LHLibUtilTest.java
@@ -515,4 +515,138 @@ public class LHLibUtilTest {
         VariableValue val = LHLibUtil.objToVarValAsNativeMap(null, LHTypeAdapterRegistry.empty());
         Assertions.assertThat(val.getValueCase()).isEqualTo(VariableValue.ValueCase.VALUE_NOT_SET);
     }
+
+    @LHStructDef("${company}-customer")
+    public static class PlaceholderCustomer {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void shouldResolvePlaceholdersWhenSerializingStructToStruct() {
+        PlaceholderCustomer pojo = new PlaceholderCustomer();
+        pojo.setName("Alice");
+
+        Struct struct = LHLibUtil.serializeToStruct(pojo, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+
+        Assertions.assertThat(struct.getStructDefId().getName()).isEqualTo("acme-customer");
+        Assertions.assertThat(
+                        struct.getStruct().getFieldsMap().get("name").getValue().getStr())
+                .isEqualTo("Alice");
+    }
+
+    @Test
+    void shouldResolvePlaceholdersWhenSerializingStructViaObjToVarVal() {
+        PlaceholderCustomer pojo = new PlaceholderCustomer();
+        pojo.setName("Bob");
+
+        VariableValue val = LHLibUtil.objToVarVal(
+                pojo, PlaceholderCustomer.class, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+
+        Assertions.assertThat(val.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
+        Assertions.assertThat(val.getStruct().getStructDefId().getName()).isEqualTo("acme-customer");
+    }
+
+    @Test
+    void shouldFailSerializingPlaceholderStructWithoutPlaceholderValues() {
+        PlaceholderCustomer pojo = new PlaceholderCustomer();
+        pojo.setName("Carol");
+
+        Assertions.assertThatThrownBy(() -> LHLibUtil.serializeToStruct(pojo, LHTypeAdapterRegistry.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("company");
+    }
+
+    @Test
+    void shouldRoundTripPlaceholderStructWithResolvedName() {
+        PlaceholderCustomer pojo = new PlaceholderCustomer();
+        pojo.setName("Dave");
+
+        Struct struct = LHLibUtil.serializeToStruct(pojo, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+        VariableValue structVal = VariableValue.newBuilder().setStruct(struct).build();
+
+        PlaceholderCustomer roundTripped = (PlaceholderCustomer) LHLibUtil.varValToObj(
+                structVal, PlaceholderCustomer.class, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+
+        Assertions.assertThat(roundTripped.getName()).isEqualTo("Dave");
+    }
+
+    @LHStructDef("${company}-order")
+    public static class PlaceholderOrder {
+        private String orderId;
+        private PlaceholderCustomer customer;
+
+        public String getOrderId() {
+            return orderId;
+        }
+
+        public void setOrderId(String orderId) {
+            this.orderId = orderId;
+        }
+
+        public PlaceholderCustomer getCustomer() {
+            return customer;
+        }
+
+        public void setCustomer(PlaceholderCustomer customer) {
+            this.customer = customer;
+        }
+    }
+
+    @Test
+    void shouldResolvePlaceholdersInNestedStruct() {
+        PlaceholderCustomer customer = new PlaceholderCustomer();
+        customer.setName("Frank");
+
+        PlaceholderOrder order = new PlaceholderOrder();
+        order.setOrderId("order-1");
+        order.setCustomer(customer);
+
+        Struct struct = LHLibUtil.serializeToStruct(order, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+
+        // Outer struct name is resolved.
+        Assertions.assertThat(struct.getStructDefId().getName()).isEqualTo("acme-order");
+
+        // Nested struct field is itself resolved to the correct StructDefId name.
+        VariableValue customerVal =
+                struct.getStruct().getFieldsMap().get("customer").getValue();
+        Assertions.assertThat(customerVal.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
+        Assertions.assertThat(customerVal.getStruct().getStructDefId().getName())
+                .isEqualTo("acme-customer");
+        Assertions.assertThat(customerVal
+                        .getStruct()
+                        .getStruct()
+                        .getFieldsMap()
+                        .get("name")
+                        .getValue()
+                        .getStr())
+                .isEqualTo("Frank");
+    }
+
+    @Test
+    void shouldRoundTripNestedPlaceholderStruct() {
+        PlaceholderCustomer customer = new PlaceholderCustomer();
+        customer.setName("Grace");
+
+        PlaceholderOrder order = new PlaceholderOrder();
+        order.setOrderId("order-2");
+        order.setCustomer(customer);
+
+        Struct struct = LHLibUtil.serializeToStruct(order, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+        VariableValue structVal = VariableValue.newBuilder().setStruct(struct).build();
+
+        PlaceholderOrder roundTripped = (PlaceholderOrder) LHLibUtil.varValToObj(
+                structVal, PlaceholderOrder.class, LHTypeAdapterRegistry.empty(), Map.of("company", "acme"));
+
+        Assertions.assertThat(roundTripped.getOrderId()).isEqualTo("order-2");
+        Assertions.assertThat(roundTripped.getCustomer()).isNotNull();
+        Assertions.assertThat(roundTripped.getCustomer().getName()).isEqualTo("Grace");
+    }
 }

--- a/sdk-java/src/test/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutorTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutorTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.littlehorse.sdk.common.adapter.LHTypeAdapterRegistry;
 import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.worker.LHStructDef;
 import io.littlehorse.sdk.worker.LHType;
 import java.lang.reflect.Method;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class ScheduledTaskExecutorTest {
@@ -18,6 +20,25 @@ public class ScheduledTaskExecutorTest {
 
         public Long[] jsonArrayReturn() {
             return new Long[] {1L, 2L, 3L};
+        }
+
+        public PlaceholderStruct placeholderStructReturn() {
+            PlaceholderStruct out = new PlaceholderStruct();
+            out.setName("Eve");
+            return out;
+        }
+    }
+
+    @LHStructDef("${company}-customer")
+    public static class PlaceholderStruct {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
     }
 
@@ -49,5 +70,28 @@ public class ScheduledTaskExecutorTest {
                 (VariableValue) serializeResult.invoke(executor, new ReturnTasks().jsonArrayReturn(), method);
 
         assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.JSON_ARR);
+    }
+
+    @Test
+    void shouldResolvePlaceholderInStructReturn() throws Exception {
+        ScheduledTaskExecutor executor =
+                new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), null, Map.of("company", "acme"));
+        Method serializeResult =
+                ScheduledTaskExecutor.class.getDeclaredMethod("serializeResult", Object.class, Method.class);
+        serializeResult.setAccessible(true);
+
+        Method method = ReturnTasks.class.getMethod("placeholderStructReturn");
+        VariableValue out =
+                (VariableValue) serializeResult.invoke(executor, new ReturnTasks().placeholderStructReturn(), method);
+
+        assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
+        assertThat(out.getStruct().getStructDefId().getName()).isEqualTo("acme-customer");
+        assertThat(out.getStruct()
+                        .getStruct()
+                        .getFieldsMap()
+                        .get("name")
+                        .getValue()
+                        .getStr())
+                .isEqualTo("Eve");
     }
 }


### PR DESCRIPTION
This adds the appropriate Struct placeholder support to Task Workers. Before, they were only designed to work on LHStructDefTypes for Struct definitions and registrations, but this PR adds runtime support for handling PollTasks and converting the runtime values to the appropriate StructDefs.