### PR TITLE
fix(sdk-java): resolve InlineStruct StructDef type before Array or Map

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutor.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutor.java
@@ -175,13 +175,25 @@ public class ScheduledTaskExecutor {
     }
 
     /**
-     * Bridges the reflection boundary: Method.getReturnType() is a raw Class<?>, so
-     * the cast to Class<T> is unchecked but safe—returnType always matches the actual object.
+     * Serializes a task's return value into a {@link VariableValue}, dispatching on the return type.
+     *
+     * <p>The return type is resolved from two different sources depending on the case:
+     * <ul>
+     *   <li>{@code InlineStruct} -> the server-registered {@link TaskDef} return type;
+     *       the task method's {@code @LHType} annotation is intentionally ignored here.</li>
+     *   <li>{@code @LHType(isLHArray = true)} -> native LittleHorse Array.</li>
+     *   <li>{@code @LHType(isLHMap = true)} -> native LittleHorse Map.</li>
+     *   <li>otherwise -> reflection on the method's return type via {@code objToVarVal}.</li>
+     * </ul>
      */
-    private VariableValue serializeResult(Object result, Method taskMethod) {
+    VariableValue serializeResult(Object result, Method taskMethod) {
         Class<?> returnType = taskMethod.getReturnType();
 
-        LHTypeMetadata metadata = LHTypeMetadata.from(taskMethod, Map.of());
+        if (InlineStruct.class.equals(returnType)) {
+            return serializeInlineStructResult(result);
+        }
+
+        LHTypeMetadata metadata = LHTypeMetadata.from(taskMethod, placeholderValues);
         if (metadata.isLHArray()) {
             return LHLibUtil.objToVarValAsNativeArray(result, returnType, typeAdapterRegistry);
         }
@@ -190,9 +202,6 @@ public class ScheduledTaskExecutor {
             return LHLibUtil.objToVarValAsNativeMap(result, typeAdapterRegistry);
         }
 
-        if (InlineStruct.class.equals(returnType)) {
-            return serializeInlineStructResult(result);
-        }
         return LHLibUtil.objToVarVal(result, returnType, typeAdapterRegistry, placeholderValues);
     }
 
@@ -211,6 +220,8 @@ public class ScheduledTaskExecutor {
             throw new LHSerdeException("InlineStruct task return requires a StructDef return type in TaskDef.");
         }
 
+        // The StructDefId comes from the server-registered TaskDef, whose name was already
+        // placeholder-resolved at registration time.
         StructDefId structDefId = taskDef.getReturnType().getReturnType().getStructDefId();
         return LHLibUtil.inlineStructToVarVal((InlineStruct) result, structDefId);
     }

--- a/sdk-java/src/test/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutorTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/worker/internal/ScheduledTaskExecutorTest.java
@@ -3,6 +3,12 @@ package io.littlehorse.sdk.worker.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.littlehorse.sdk.common.adapter.LHTypeAdapterRegistry;
+import io.littlehorse.sdk.common.proto.InlineStruct;
+import io.littlehorse.sdk.common.proto.ReturnType;
+import io.littlehorse.sdk.common.proto.StructDefId;
+import io.littlehorse.sdk.common.proto.StructField;
+import io.littlehorse.sdk.common.proto.TaskDef;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
 import io.littlehorse.sdk.common.proto.VariableValue;
 import io.littlehorse.sdk.worker.LHStructDef;
 import io.littlehorse.sdk.worker.LHType;
@@ -27,6 +33,27 @@ public class ScheduledTaskExecutorTest {
             out.setName("Eve");
             return out;
         }
+
+        public InlineStruct returnInlineStruct() {
+            return InlineStruct.newBuilder()
+                    .putFields(
+                            "name",
+                            StructField.newBuilder()
+                                    .setValue(VariableValue.newBuilder().setStr("Han"))
+                                    .build())
+                    .build();
+        }
+
+        @LHType(structDefName = "${customerStructName}")
+        public InlineStruct returnInlineStructWithPlaceholderAnnotation() {
+            return InlineStruct.newBuilder()
+                    .putFields(
+                            "name",
+                            StructField.newBuilder()
+                                    .setValue(VariableValue.newBuilder().setStr("Leia"))
+                                    .build())
+                    .build();
+        }
     }
 
     @LHStructDef("${company}-customer")
@@ -45,13 +72,9 @@ public class ScheduledTaskExecutorTest {
     @Test
     void shouldSerializeReturnAsNativeArrayWhenAnnotated() throws Exception {
         ScheduledTaskExecutor executor = new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), null);
-        Method serializeResult =
-                ScheduledTaskExecutor.class.getDeclaredMethod("serializeResult", Object.class, Method.class);
-        serializeResult.setAccessible(true);
 
         Method method = ReturnTasks.class.getMethod("nativeArrayReturn");
-        VariableValue out =
-                (VariableValue) serializeResult.invoke(executor, new ReturnTasks().nativeArrayReturn(), method);
+        VariableValue out = executor.serializeResult(new ReturnTasks().nativeArrayReturn(), method);
 
         assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.ARRAY);
         assertThat(out.getArray().getItemsCount()).isEqualTo(3);
@@ -61,13 +84,9 @@ public class ScheduledTaskExecutorTest {
     @Test
     void shouldKeepJsonArraySerializationWhenNotAnnotated() throws Exception {
         ScheduledTaskExecutor executor = new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), null);
-        Method serializeResult =
-                ScheduledTaskExecutor.class.getDeclaredMethod("serializeResult", Object.class, Method.class);
-        serializeResult.setAccessible(true);
 
         Method method = ReturnTasks.class.getMethod("jsonArrayReturn");
-        VariableValue out =
-                (VariableValue) serializeResult.invoke(executor, new ReturnTasks().jsonArrayReturn(), method);
+        VariableValue out = executor.serializeResult(new ReturnTasks().jsonArrayReturn(), method);
 
         assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.JSON_ARR);
     }
@@ -76,13 +95,9 @@ public class ScheduledTaskExecutorTest {
     void shouldResolvePlaceholderInStructReturn() throws Exception {
         ScheduledTaskExecutor executor =
                 new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), null, Map.of("company", "acme"));
-        Method serializeResult =
-                ScheduledTaskExecutor.class.getDeclaredMethod("serializeResult", Object.class, Method.class);
-        serializeResult.setAccessible(true);
 
         Method method = ReturnTasks.class.getMethod("placeholderStructReturn");
-        VariableValue out =
-                (VariableValue) serializeResult.invoke(executor, new ReturnTasks().placeholderStructReturn(), method);
+        VariableValue out = executor.serializeResult(new ReturnTasks().placeholderStructReturn(), method);
 
         assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
         assertThat(out.getStruct().getStructDefId().getName()).isEqualTo("acme-customer");
@@ -93,5 +108,57 @@ public class ScheduledTaskExecutorTest {
                         .getValue()
                         .getStr())
                 .isEqualTo("Eve");
+    }
+
+    @Test
+    void shouldSerializeInlineStructReturnValueUsingTaskDefReturnType() throws Exception {
+        TaskDef taskDef = taskDefWithStructReturn("acme-customer");
+        ScheduledTaskExecutor executor =
+                new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), taskDef, Map.of());
+
+        Method method = ReturnTasks.class.getMethod("returnInlineStruct");
+        VariableValue out = executor.serializeResult(new ReturnTasks().returnInlineStruct(), method);
+
+        assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
+        assertThat(out.getStruct().getStructDefId().getName()).isEqualTo("acme-customer");
+        assertThat(out.getStruct()
+                        .getStruct()
+                        .getFieldsMap()
+                        .get("name")
+                        .getValue()
+                        .getStr())
+                .isEqualTo("Han");
+    }
+
+    @Test
+    void shouldSerializeInlineStructReturnWithUnresolvedPlaceholderAnnotation() throws Exception {
+        // Regression: the InlineStruct return path serializes using the server-registered TaskDef
+        // return type, so it must not attempt to resolve the "${...}" placeholder on the return-type
+        // annotation. Even with an empty placeholder map, serialization must succeed rather than throw.
+        TaskDef taskDef = taskDefWithStructReturn("acme-customer");
+        ScheduledTaskExecutor executor =
+                new ScheduledTaskExecutor(null, null, LHTypeAdapterRegistry.empty(), taskDef, Map.of());
+
+        Method method = ReturnTasks.class.getMethod("returnInlineStructWithPlaceholderAnnotation");
+        VariableValue out =
+                executor.serializeResult(new ReturnTasks().returnInlineStructWithPlaceholderAnnotation(), method);
+
+        assertThat(out.getValueCase()).isEqualTo(VariableValue.ValueCase.STRUCT);
+        assertThat(out.getStruct().getStructDefId().getName()).isEqualTo("acme-customer");
+        assertThat(out.getStruct()
+                        .getStruct()
+                        .getFieldsMap()
+                        .get("name")
+                        .getValue()
+                        .getStr())
+                .isEqualTo("Leia");
+    }
+
+    private static TaskDef taskDefWithStructReturn(String structDefName) {
+        return TaskDef.newBuilder()
+                .setReturnType(ReturnType.newBuilder()
+                        .setReturnType(TypeDefinition.newBuilder()
+                                .setStructDefId(StructDefId.newBuilder().setName(structDefName))))
+                .build();
     }
 }


### PR DESCRIPTION
This PR reorders the handling of Task Method result serialization so that `InlineStruct`s are serialized before `Array`s and `Maps.

## Background

Initially, `InlineStruct`s were being serialized after `Array`s and `Maps`, which led to a code path where `LHLibUtil.varValToObj` was called without a map of `placeholderValues` and the result serialization would fail.

## Further Work

Further work needs to be done to make `LHLibUtil` easier to read. For the sake of preventing breaking changes, there are a lot of methods added around `varValToObj` and `objToVarVal` that add Struct, Array, and Map support, but as time goes on we should work towards combining these methods again and reducing the complexity of this class. That is out of scope for this PR, as this is just a quick fix.