### PR TITLE
fix(dashboard): gracefully handle ListVariables responses over the gRPC max message size

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/Variables.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/Variables.tsx
@@ -9,11 +9,12 @@ import { TypeDisplay } from '../../../../components/TypeDisplay'
 type VariablesProps = {
   variableDefs: ThreadVarDef[]
   variables: Variable[]
+  variablesTooLarge?: boolean
   thread: ThreadType
   wfRunId?: WfRunId
 }
 
-export const Variables: FC<VariablesProps> = ({ variableDefs, variables, thread, wfRunId }) => {
+export const Variables: FC<VariablesProps> = ({ variableDefs, variables, variablesTooLarge, thread, wfRunId }) => {
   const currentWfRunPath = wfRunId ? wfRunIdToPath(wfRunId) : ''
   const threadVariables = useMemo(() => {
     return variables.filter(v => {
@@ -30,6 +31,11 @@ export const Variables: FC<VariablesProps> = ({ variableDefs, variables, thread,
   return (
     <div>
       <h2 className="text-md mb-2 font-bold">Variables ({threadLabel})</h2>
+      {variablesTooLarge && (
+        <div className="mb-2 flex items-center gap-3 rounded border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-900">
+          The variables of this WfRun are too large to display.
+        </div>
+      )}
       {variableDefs.map(variable => (
         <div key={variable.varDef?.name} className="mb-1 flex items-center gap-1">
           {variable.varDef?.name && <IdentifierBadge name={variable.varDef.name} />}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/wfRun/[...ids]/components/WfRun.tsx
@@ -21,7 +21,7 @@ export const WfRun: FC<WfRunResponse> = wfRunData => {
   const { data } = useSWR(swrKey, async () => await getWfRun({ wfRunId: wfRunId!, tenantId }), {
     fallbackData: wfRunData,
   })
-  const { wfSpec, wfRun, variables } = data ?? wfRunData
+  const { wfSpec, wfRun, variables, variablesTooLarge } = data ?? wfRunData
 
   const initialThread = useMemo<ThreadType>(() => {
     const tr = wfRun.threadRuns.find(t => t.number === wfRun.greatestThreadrunNumber)
@@ -64,7 +64,13 @@ export const WfRun: FC<WfRunResponse> = wfRunData => {
 
       {wfRun.id && (
         <>
-          <Variables variableDefs={variableDefs} variables={variables} thread={selectedThread} wfRunId={wfRun.id} />
+          <Variables
+            variableDefs={variableDefs}
+            variables={variables}
+            variablesTooLarge={variablesTooLarge}
+            thread={selectedThread}
+            wfRunId={wfRun.id}
+          />
           <Separator className="mb-4 mt-4" />
           <ChildWorkflows parentWfRunId={wfRun.id} spec={wfSpec} />
         </>

--- a/dashboard/src/app/actions/getInheritedVariables.ts
+++ b/dashboard/src/app/actions/getInheritedVariables.ts
@@ -1,22 +1,29 @@
 'use server'
 
+import { isResourceExhausted } from 'littlehorse-client'
 import { ThreadVarDef, Variable, WfRunId, WfRunVariableAccessLevel } from 'littlehorse-client/proto'
 import { lhClient } from '../lhClient'
+
+export type InheritedVariablesResult = {
+  variables: Variable[]
+  tooLarge: boolean
+}
 
 export const getInheritedVariables = async (
   wfRunId: WfRunId,
   variableDefs: ThreadVarDef[],
   tenantId: string
-): Promise<Variable[]> => {
+): Promise<InheritedVariablesResult> => {
   const client = await lhClient({ tenantId })
 
   const inheritedDefs = variableDefs.filter(v => v.accessLevel === WfRunVariableAccessLevel.INHERITED_VAR)
 
   const namesToFind = new Set(inheritedDefs.map(v => v.varDef?.name).filter(n => !!n))
-  if (namesToFind.size === 0) return []
+  if (namesToFind.size === 0) return { variables: [], tooLarge: false }
 
   const foundByName = new Map<string, Variable>()
   let current: WfRunId | undefined = wfRunId.parentWfRunId
+  let tooLarge = false
 
   while (current && namesToFind.size > 0) {
     try {
@@ -28,10 +35,14 @@ export const getInheritedVariables = async (
         namesToFind.delete(name)
       }
     } catch (e) {
-      console.error('Error getting variables for wfRunId', current, e)
+      if (isResourceExhausted(e)) {
+        tooLarge = true
+      } else {
+        console.error('Error getting variables for wfRunId', current, e)
+      }
     }
     current = current.parentWfRunId
   }
 
-  return Array.from(foundByName.values())
+  return { variables: Array.from(foundByName.values()), tooLarge }
 }

--- a/dashboard/src/app/actions/getWfRun.ts
+++ b/dashboard/src/app/actions/getWfRun.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { lhClient } from '@/app/lhClient'
+import { isResourceExhausted } from 'littlehorse-client'
 import { NodeRun, ThreadRun, Variable, WfRun, WfRunId, WfSpec } from 'littlehorse-client/proto'
 import { getInheritedVariables } from './getInheritedVariables'
 
@@ -15,18 +16,23 @@ export type WfRunResponse = {
   wfRun: WfRun & { threadRuns: ThreadRunWithNodeRuns[] }
   wfSpec: WfSpec
   variables: Variable[]
+  variablesTooLarge: boolean
 }
 export const getWfRun = async ({ wfRunId, tenantId }: Props): Promise<WfRunResponse> => {
   const client = await lhClient({ tenantId })
   const wfRun = await client.getWfRun(wfRunId)
-  const [wfSpec, { results: nodeRuns }, { results: variables }] = await Promise.all([
+  const [wfSpec, { results: nodeRuns }, ownVariables] = await Promise.all([
     client.getWfSpec(wfRun.wfSpecId!),
     client.listNodeRuns({
       wfRunId,
     }),
-    client.listVariables({
-      wfRunId,
-    }),
+    client.listVariables({ wfRunId }).then(
+      ({ results }) => ({ results, tooLarge: false }),
+      error => {
+        if (isResourceExhausted(error)) return { results: [] as Variable[], tooLarge: true }
+        throw error
+      }
+    ),
   ])
 
   const entrypointThreadRun =
@@ -38,10 +44,15 @@ export const getWfRun = async ({ wfRunId, tenantId }: Props): Promise<WfRunRespo
         wfSpec.threadSpecs[entrypointThreadRun.threadSpecName].variableDefs,
         tenantId
       )
-    : []
+    : { variables: [], tooLarge: false }
 
   const threadRuns = wfRun.threadRuns.map(threadRun => mergeThreadRunsWithNodeRuns(threadRun, nodeRuns))
-  return { wfRun: { ...wfRun, threadRuns }, wfSpec, variables: [...variables, ...inheritedVariables] }
+  return {
+    wfRun: { ...wfRun, threadRuns },
+    wfSpec,
+    variables: [...ownVariables.results, ...inheritedVariables.variables],
+    variablesTooLarge: ownVariables.tooLarge || inheritedVariables.tooLarge,
+  }
 }
 
 const mergeThreadRunsWithNodeRuns = (threadRun: ThreadRun, nodeRuns: NodeRun[]): ThreadRunWithNodeRuns => {

--- a/dashboard/src/lhConfig.ts
+++ b/dashboard/src/lhConfig.ts
@@ -7,6 +7,7 @@ const CONFIG = {
   caCert: process.env.LHC_CA_CERT,
   clientCert: process.env.LHC_CLIENT_CERT,
   clientKey: process.env.LHC_CLIENT_KEY,
+  grpcMaxReceiveMessageLength: process.env.LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH,
 }
 
 export const getClient = ({ tenantId, accessToken }: { tenantId?: string; accessToken?: string }) => {

--- a/sdk-js/src/LHConfig.test.ts
+++ b/sdk-js/src/LHConfig.test.ts
@@ -94,4 +94,40 @@ describe('LHConfig', () => {
 
     expect(config.getResourceExhaustedRetryEnabled()).toBe(false)
   })
+
+  it('leaves max receive message length unset by default', () => {
+    const config = LHConfig.from({})
+
+    expect(config.getGrpcMaxReceiveMessageLength()).toBeUndefined()
+  })
+
+  it('parses max receive message length', () => {
+    const config = LHConfig.from({
+      grpcMaxReceiveMessageLength: '8388608',
+    })
+
+    expect(config.getGrpcMaxReceiveMessageLength()).toBe(8388608)
+  })
+
+  it('accepts -1 as unlimited max receive message length', () => {
+    const config = LHConfig.from({
+      grpcMaxReceiveMessageLength: '-1',
+    })
+
+    expect(config.getGrpcMaxReceiveMessageLength()).toBe(-1)
+  })
+
+  it('rejects an invalid max receive message length', () => {
+    expect(() =>
+      LHConfig.from({
+        grpcMaxReceiveMessageLength: 'lots',
+      })
+    ).toThrow(/LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH/)
+
+    expect(() =>
+      LHConfig.from({
+        grpcMaxReceiveMessageLength: '0',
+      })
+    ).toThrow(/LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH/)
+  })
 })

--- a/sdk-js/src/LHConfig.ts
+++ b/sdk-js/src/LHConfig.ts
@@ -13,6 +13,7 @@ export const CONFIG_NAMES = [
   'LHC_API_PORT',
   'LHC_API_PROTOCOL',
   'LHC_GRPC_RESOURCE_EXHAUSTED_RETRY',
+  'LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH',
   'LHC_TENANT_ID',
   'LHC_CA_CERT',
   'LHC_CLIENT_CERT',
@@ -25,6 +26,19 @@ export type Config = {
 
 function isResourceExhaustedRetryEnabled(config?: string): boolean {
   return config?.toLowerCase() !== 'false'
+}
+
+function parseGrpcMaxReceiveMessageLength(config?: string): number | undefined {
+  if (config === undefined || config === '') {
+    return undefined
+  }
+  const value = Number(config)
+  if (!Number.isInteger(value) || (value <= 0 && value !== -1)) {
+    throw new Error(
+      `Invalid LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH "${config}": expected a positive number of bytes, or -1 for unlimited`
+    )
+  }
+  return value
 }
 export type ConfigName = (typeof CONFIG_NAMES)[number]
 
@@ -44,6 +58,7 @@ export class LHConfig {
   private clientCert?: string
   private clientKey?: string
   private resourceExhaustedRetryEnabled: boolean = true
+  private grpcMaxReceiveMessageLength?: number
 
   private channelCredentials: ChannelCredentials
 
@@ -57,6 +72,9 @@ export class LHConfig {
     this.clientCert = mergedConfig.LHC_CLIENT_CERT
     this.clientKey = mergedConfig.LHC_CLIENT_KEY
     this.resourceExhaustedRetryEnabled = isResourceExhaustedRetryEnabled(mergedConfig.LHC_GRPC_RESOURCE_EXHAUSTED_RETRY)
+    this.grpcMaxReceiveMessageLength = parseGrpcMaxReceiveMessageLength(
+      mergedConfig.LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH
+    )
 
     if (this.protocol === 'TLS') {
       const rootCa = this.caCert ? readFileSync(this.caCert) : null
@@ -108,6 +126,9 @@ export class LHConfig {
     return new GrpcTransport({
       host: `${host}:${port}`,
       channelCredentials: this.channelCredentials,
+      ...(this.grpcMaxReceiveMessageLength !== undefined && {
+        clientOptions: { 'grpc.max_receive_message_length': this.grpcMaxReceiveMessageLength },
+      }),
     })
   }
 
@@ -124,6 +145,13 @@ export class LHConfig {
 
   getResourceExhaustedRetryEnabled(): boolean {
     return this.resourceExhaustedRetryEnabled
+  }
+
+  /**
+   * Returns the configured max gRPC receive message length in bytes, if any.
+   */
+  getGrpcMaxReceiveMessageLength(): number | undefined {
+    return this.grpcMaxReceiveMessageLength
   }
 
   private getMetadata(accessToken?: string): RpcMetadata {

--- a/sdk-js/src/grpcRetry.test.ts
+++ b/sdk-js/src/grpcRetry.test.ts
@@ -1,5 +1,6 @@
 import { BinaryWriter, WireType } from '@protobuf-ts/runtime'
-import { extractRetryDelayMsFromMetadata } from './grpcRetry'
+import { RpcError } from '@protobuf-ts/runtime-rpc'
+import { extractRetryDelayMsFromMetadata, getRetryDelayMs } from './grpcRetry'
 
 function encodeStatusDetails(delaySeconds: number, delayNanos = 0): string {
   const duration = new BinaryWriter().tag(1, WireType.Varint).int64(delaySeconds)
@@ -33,5 +34,40 @@ describe('grpcRetry', () => {
     const retryDelayMs = extractRetryDelayMsFromMetadata({})
 
     expect(retryDelayMs).toBeUndefined()
+  })
+
+  describe('getRetryDelayMs', () => {
+    it('honors the RetryInfo delay from a server throttle error', () => {
+      const error = new RpcError('Quota exceeded. Retry after 1500ms.', 'RESOURCE_EXHAUSTED', {
+        'grpc-status-details-bin': encodeStatusDetails(1, 500_000_000),
+      })
+
+      expect(getRetryDelayMs(error)).toBe(1500)
+    })
+
+    it('does not retry client-generated message-size errors', () => {
+      const error = new RpcError('Received message larger than max (4500420 vs 4194304)', 'RESOURCE_EXHAUSTED', {})
+
+      expect(getRetryDelayMs(error)).toBeUndefined()
+    })
+
+    it('falls back to the default delay when server details lack RetryInfo', () => {
+      const otherDetail = new BinaryWriter()
+        .tag(1, WireType.LengthDelimited)
+        .string('type.googleapis.com/google.rpc.ErrorInfo')
+        .finish()
+      const status = new BinaryWriter().tag(3, WireType.LengthDelimited).bytes(otherDetail).finish()
+      const error = new RpcError('Quota exceeded.', 'RESOURCE_EXHAUSTED', {
+        'grpc-status-details-bin': Buffer.from(status).toString('base64'),
+      })
+
+      expect(getRetryDelayMs(error)).toBe(500)
+    })
+
+    it('does not retry other error codes', () => {
+      const error = new RpcError('not found', 'NOT_FOUND', {})
+
+      expect(getRetryDelayMs(error)).toBeUndefined()
+    })
   })
 })

--- a/sdk-js/src/grpcRetry.ts
+++ b/sdk-js/src/grpcRetry.ts
@@ -19,15 +19,21 @@ export function isResourceExhausted(error: unknown): boolean {
 
 /**
  * Computes how long to wait before retrying a RESOURCE_EXHAUSTED error. Honors
- * the server-provided `google.rpc.RetryInfo` when present, otherwise falls back
- * to a default delay.
+ * the server-provided `google.rpc.RetryInfo` when present. Errors without any
+ * server-sent status details are generated locally by grpc-js (e.g. a response
+ * over `grpc.max_receive_message_length`) and are never retried.
  */
 export function getRetryDelayMs(error: unknown): number | undefined {
   if (!isResourceExhausted(error)) {
     return undefined
   }
 
-  const fromMetadata = extractRetryDelayMsFromMetadata((error as RpcError).meta)
+  const meta = (error as RpcError).meta
+  if (getStatusDetails(meta) === undefined) {
+    return undefined
+  }
+
+  const fromMetadata = extractRetryDelayMsFromMetadata(meta)
   if (fromMetadata !== undefined) {
     return fromMetadata
   }

--- a/sdk-js/src/index.ts
+++ b/sdk-js/src/index.ts
@@ -1,4 +1,5 @@
 export { LHConfig } from './LHConfig'
+export { isResourceExhausted } from './grpcRetry'
 export {
   createTaskWorker,
   LHTaskException,

--- a/sdk-js/src/utils/getPropertiesArgs.ts
+++ b/sdk-js/src/utils/getPropertiesArgs.ts
@@ -5,6 +5,7 @@ export type ConfigArgs = {
   apiPort: string
   protocol: string
   grpcResourceExhaustedRetry: string
+  grpcMaxReceiveMessageLength: string
   tenantId: string
   caCert: string
   clientCert: string
@@ -20,6 +21,7 @@ const argsMapping: Mapping = {
   apiPort: 'LHC_API_PORT',
   protocol: 'LHC_API_PROTOCOL',
   grpcResourceExhaustedRetry: 'LHC_GRPC_RESOURCE_EXHAUSTED_RETRY',
+  grpcMaxReceiveMessageLength: 'LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH',
   tenantId: 'LHC_TENANT_ID',
   caCert: 'LHC_CA_CERT',
   clientCert: 'LHC_CLIENT_CERT',


### PR DESCRIPTION
adds LHC_GRPC_MAX_RECEIVE_MESSAGE_LENGTH to sdk-js so the receive limit can be raised (or -1 for unlimited); the dashboard reads it from env

only retries RESOURCE_EXHAUSTED when the server actually attached RetryInfo, so message size errors fail fast instead of looping

catches the error in getWfRun / getInheritedVariables and shows a "variables too large to display" banner instead of taking down the page

Reproduced against a standalone server with a run whose variables total ~4.5MB: fails fast by default, shows the banner, and renders values normally once the limit is bumped to 8MB.