### PR TITLE
fix(dashboard): keep node selection and viewport across WfRun polling refreshes

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Diagram.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Diagram.tsx
@@ -20,12 +20,19 @@ import { LHStatus, WfRun, WfSpec } from 'littlehorse-client/proto'
 import { PlayCircleIcon, RotateCcwIcon, StopCircleIcon } from 'lucide-react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { FC, ReactNode, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import ReactFlow, { Controls, Node as RFNode, useEdgesState, useNodesState, type Viewport } from 'reactflow'
+import ReactFlow, {
+  Controls,
+  Node as RFNode,
+  useEdgesState,
+  useNodesState,
+  type OnSelectionChangeParams,
+  type Viewport,
+} from 'reactflow'
 import 'reactflow/dist/base.css'
 import { DiagramProvider, NodeInContext, ThreadType } from '../context'
 import edgeTypes from './EdgeTypes'
 import { extractEdges } from './EdgeTypes/extractEdges'
-import { LayoutManager } from './LayoutManager'
+import { getNodeRunsList, LayoutManager } from './LayoutManager'
 import nodeTypes from './NodeTypes'
 import { extractNodes, getCycleNodes, getNodeAfterEntrypoint } from './NodeTypes/extractNodes'
 import { Sidebar } from './Sidebar'
@@ -116,7 +123,14 @@ export const Diagram: FC<Props> = ({ spec, wfRun, onThreadChange, headerActions 
     [wfRun, threadSpec, thread.name, setNodes]
   )
 
+  const resetKey = `${spec.id ? `${spec.id.name}/${spec.id.majorVersion}/${spec.id.revision}` : ''}|${
+    wfRun?.id ? JSON.stringify(wfRun.id) : ''
+  }|${thread.name}`
+  const appliedResetKey = useRef<string | null>(null)
+
   useLayoutEffect(() => {
+    if (appliedResetKey.current === resetKey) return
+    appliedResetKey.current = resetKey
     lastAppliedThread.current = null
     const extractedNodes = extractNodes(threadSpec)
     const extractedEdges = extractEdges(threadSpec)
@@ -138,7 +152,18 @@ export const Diagram: FC<Props> = ({ spec, wfRun, onThreadChange, headerActions 
     setNode(undefined)
     setNodes(extractedNodes)
     setEdges(extractedEdges)
-  }, [thread.name, threadSpec, setNodes, setEdges, wfRun])
+  }, [resetKey, thread.name, threadSpec, setNodes, setEdges, wfRun])
+
+  useEffect(() => {
+    if (!wfRun) return
+    const withNodeRuns = <T extends RFNode>(n: T): T => {
+      const nodeRunsList = getNodeRunsList(n.id, threadNodeRuns)
+      const fade = nodeRunsList !== undefined && nodeRunsList.length === 0
+      return { ...n, data: { ...n.data, fade, nodeRunsList } }
+    }
+    setNodes(current => current.map(withNodeRuns))
+    setNode(current => (current ? withNodeRuns(current) : current))
+  }, [threadNodeRuns, wfRun, setNodes])
 
   useEffect(() => {
     onThreadChange?.(thread)
@@ -152,6 +177,10 @@ export const Diagram: FC<Props> = ({ spec, wfRun, onThreadChange, headerActions 
     },
     [viewportKey]
   )
+
+  const onSelectionChange = useCallback(({ nodes: selectedNodes }: OnSelectionChangeParams) => {
+    if (selectedNodes.length === 0) setNode(undefined)
+  }, [])
 
   const verb =
     wfRun?.status === LHStatus.RUNNING
@@ -238,6 +267,7 @@ export const Diagram: FC<Props> = ({ spec, wfRun, onThreadChange, headerActions 
             edgeTypes={edgeTypes}
             snapToGrid={true}
             onMoveEnd={onMoveEnd}
+            onSelectionChange={onSelectionChange}
           >
             <Controls />
           </ReactFlow>

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/LayoutManager.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/LayoutManager.tsx
@@ -5,6 +5,15 @@ import { Edge, Node, useOnViewportChange, useReactFlow, useStore, type Viewport 
 
 const elk = new ELK()
 
+export const getNodeRunsList = (nodeId: string, nodeRuns?: NodeRun[]): NodeRun[] | undefined =>
+  nodeRuns
+    ?.filter(nodeRun => nodeRun.nodeName === nodeId)
+    .sort((a, b) => {
+      const aPos = a.id?.position ?? 0
+      const bPos = b.id?.position ?? 0
+      return bPos - aPos
+    })
+
 type LayoutManagerProps = {
   nodeRuns?: NodeRun[]
   viewportKey: string
@@ -67,13 +76,7 @@ export const LayoutManager: FC<LayoutManagerProps> = ({ nodeRuns, viewportKey, s
         // Layout the original workflow nodes
         const laidOutNodes = nodes.map(node => {
           const elkNode = laidOutGraph.children?.find(n => n.id === node.id)
-          const nodeRunsList = nodeRuns
-            ?.filter(nodeRun => nodeRun.nodeName === node.id)
-            .sort((a, b) => {
-              const aPos = a.id?.position ?? 0
-              const bPos = b.id?.position ?? 0
-              return bPos - aPos
-            })
+          const nodeRunsList = getNodeRunsList(node.id, nodeRuns)
           const fade = nodeRunsList !== undefined && nodeRunsList.length === 0
           if (node.type === 'cycle' && elkNode?.x !== undefined) {
             const initialNode = laidOutGraph.children?.find(n => n.id === node.data.outgoingEdges[0].sinkNodeName)


### PR DESCRIPTION
Fixes #2421

The Diagram reset effect keyed on the wfRun/spec object identities, which change on every SWR poll that returns updated data. Each refresh therefore cleared the selected node, closed the details sidebar, and re-laid-out and re-positioned the graph while a WfRun was being inspected.

Implemented guarding the reset with the immutable identities (WfSpec id, WfRun id, thread name) so the graph is only rebuilt when the user actually navigates, and refresh nodeRun data in place on the laid-out nodes and the selected node so statuses and sidebar diagnostics keep updating between rebuilds. And now clear the selected node from context when the canvas selection empties, so the sidebar no longer relied on the periodic reset to close after deselecting or navigating.
