### PR TITLE
feat(server): Send failed ReportTaskRun when these subcommands fail at the command producer level

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/ReportTaskRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/corecommand/subcommand/ReportTaskRunModel.java
@@ -13,6 +13,7 @@ import io.littlehorse.common.model.getable.core.taskrun.TaskRunModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.model.getable.objectId.TaskRunIdModel;
 import io.littlehorse.common.util.LHUtil;
+import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.sdk.common.proto.ReportTaskRun;
 import io.littlehorse.sdk.common.proto.TaskStatus;
 import io.littlehorse.server.streams.topology.core.CoreProcessorContext;
@@ -102,6 +103,18 @@ public class ReportTaskRunModel extends CoreSubCommand<ReportTaskRun> {
     public static ReportTaskRunModel fromProto(ReportTaskRun proto, ExecutionContext context) {
         ReportTaskRunModel out = new ReportTaskRunModel();
         out.initFrom(proto, context);
+        return out;
+    }
+
+    public ReportTaskRunModel toErrorReport(LHApiException apiException) {
+        ReportTaskRunModel out = new ReportTaskRunModel();
+        out.taskRunId = this.taskRunId;
+        out.time = this.time;
+        out.status = TaskStatus.TASK_OUTPUT_SERDE_ERROR;
+        out.attemptNumber = this.attemptNumber;
+        out.error = new LHTaskErrorModel(apiException.getMessage(), LHErrorType.TASK_ERROR);
+        out.totalCheckpoints = this.totalCheckpoints;
+        out.logOutput = new VariableValueModel(apiException.getMessage());
         return out;
     }
 }

--- a/server/src/main/java/io/littlehorse/common/util/LHProducer.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHProducer.java
@@ -60,11 +60,11 @@ public class LHProducer implements Closeable {
         @Override
         public void onCompletion(RecordMetadata metadata, Exception exception) {
             if (exception != null) {
-                log.error("Error sending record to Kafka", exception);
                 if (exception instanceof RecordTooLargeException rtle) {
                     this.completeExceptionally(
                             new LHApiException(Status.RESOURCE_EXHAUSTED.withDescription(rtle.getMessage())));
                 } else {
+                    log.error("Error sending record to Kafka", exception);
                     this.completeExceptionally(exception);
                 }
             } else {

--- a/server/src/main/java/io/littlehorse/common/util/LHProducer.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHProducer.java
@@ -1,5 +1,7 @@
 package io.littlehorse.common.util;
 
+import io.grpc.Status;
+import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.AbstractCommand;
 import java.io.Closeable;
 import java.util.List;
@@ -11,6 +13,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.utils.Bytes;
 
@@ -44,7 +47,7 @@ public class LHProducer implements Closeable {
      */
     private CompletableFuture<RecordMetadata> sendRecord(ProducerRecord<String, Bytes> record) {
         CompletableFutureCallback out = new CompletableFutureCallback();
-        CompletableFuture.runAsync(() -> prod.send(record, out));
+        prod.send(record, out);
         return out;
     }
 
@@ -58,7 +61,12 @@ public class LHProducer implements Closeable {
         public void onCompletion(RecordMetadata metadata, Exception exception) {
             if (exception != null) {
                 log.error("Error sending record to Kafka", exception);
-                this.completeExceptionally(exception);
+                if (exception instanceof RecordTooLargeException rtle) {
+                    this.completeExceptionally(
+                            new LHApiException(Status.RESOURCE_EXHAUSTED.withDescription(rtle.getMessage())));
+                } else {
+                    this.completeExceptionally(exception);
+                }
             } else {
                 log.trace("Command sent {}", metadata);
                 this.complete(metadata);

--- a/server/src/main/java/io/littlehorse/server/LHServerListener.java
+++ b/server/src/main/java/io/littlehorse/server/LHServerListener.java
@@ -170,6 +170,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -177,6 +178,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 
@@ -740,7 +743,27 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
         ReportTaskRunModel reqModel = LHSerializable.fromProto(req, ReportTaskRunModel.class, requestContext);
         TenantIdModel tenantId = requestContext.authorization().tenantId();
         PrincipalIdModel principalId = requestContext.authorization().principalId();
-        commandSender.reportTaskAndDontWaitForResponse(reqModel, ctx, principalId, tenantId);
+        CompletableFuture<RecordMetadata> futureResponse =
+                commandSender.reportTaskAndDontWaitForResponse(reqModel, principalId, tenantId);
+        try {
+            waitForProcessing(futureResponse, Optional.empty());
+            ctx.onNext(Empty.getDefaultInstance());
+            ctx.onCompleted();
+        } catch (LHApiException e) {
+            if (e.getStatus().getCode().equals(Status.RESOURCE_EXHAUSTED.getCode())) {
+                CompletableFuture<RecordMetadata> failedTaskReport = commandSender.reportTaskAndDontWaitForResponse(
+                        reqModel.toErrorReport(e), principalId, tenantId);
+                try {
+                    waitForProcessing(failedTaskReport, Optional.empty());
+                } catch (Throwable t) {
+                    ctx.onError(t);
+                }
+            } else {
+                ctx.onError(new LHApiException(Status.INTERNAL, "Failed to send ReportTaskRun command"));
+            }
+        } catch (Throwable e) {
+            ctx.onError(new LHApiException(Status.INTERNAL, "Failed to send ReportTaskRun command"));
+        }
     }
 
     @Override
@@ -1324,26 +1347,39 @@ public class LHServerListener extends LittleHorseImplBase implements Closeable {
                 requestContext.authorization().tenantId(),
                 requestContext);
         try {
-            Message response =
-                    futureResponse.get(LHConstants.MAX_INCOMING_REQUEST_IDLE_TIME.getSeconds(), TimeUnit.SECONDS);
+            Message response = waitForProcessing(futureResponse, command.getCommandId());
             responseObserver.onNext((RC) response);
             responseObserver.onCompleted();
-        } catch (InterruptedException e) {
-            responseObserver.onError(new StatusRuntimeException(
-                    Status.UNAVAILABLE.withDescription("This Server instance shutting down")));
-        } catch (TimeoutException e) {
-            responseObserver.onError(new StatusRuntimeException(Status.DEADLINE_EXCEEDED.withDescription(
-                    "Could not process command in time id: %s".formatted(command.getCommandId()))));
         } catch (Throwable e) {
-            Throwable cause = e.getCause() == null ? e : e.getCause();
-            if (cause instanceof StatusRuntimeException) {
-                responseObserver.onError(cause);
-            } else {
-                responseObserver.onError(new StatusRuntimeException(Status.INTERNAL.withDescription("Internal error")));
-                log.error("Failed processing command", e);
-            }
+            responseObserver.onError(e);
         } finally {
             command.getCommandId().ifPresent(asyncWaiters::removeCommand);
+        }
+    }
+
+    private <T> T waitForProcessing(Future<T> futureResponse, Optional<String> commandId) {
+        try {
+            return futureResponse.get(LHConstants.MAX_INCOMING_REQUEST_IDLE_TIME.getSeconds(), TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new StatusRuntimeException(Status.UNAVAILABLE.withDescription("This Server instance shutting down"));
+        } catch (TimeoutException e) {
+            throw new StatusRuntimeException(Status.DEADLINE_EXCEEDED.withDescription(
+                    "Could not process command in time id: %s".formatted(commandId.orElse(""))));
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof LHApiException apiException) {
+                throw apiException;
+            } else if (e.getCause() instanceof RecordTooLargeException) {
+                throw new LHApiException(Status.RESOURCE_EXHAUSTED.withDescription("Record too large"));
+            } else {
+                throw new RuntimeException(e);
+            }
+        } catch (Throwable e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            if (cause instanceof StatusRuntimeException sre) {
+                throw sre;
+            } else {
+                throw new StatusRuntimeException(Status.INTERNAL.withDescription("Internal error"));
+            }
         }
     }
 

--- a/server/src/main/java/io/littlehorse/server/streams/CommandSender.java
+++ b/server/src/main/java/io/littlehorse/server/streams/CommandSender.java
@@ -2,11 +2,9 @@ package io.littlehorse.server.streams;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
 import io.littlehorse.common.LHServerConfig;
 import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.AbstractCommand;
@@ -139,27 +137,13 @@ public class CommandSender {
     }
 
     public CompletableFuture<RecordMetadata> reportTaskAndDontWaitForResponse(
-            ReportTaskRunModel reportTaskRun,
-            StreamObserver<Empty> client,
-            PrincipalIdModel principalId,
-            TenantIdModel tenantId) {
+            ReportTaskRunModel reportTaskRun, PrincipalIdModel principalId, TenantIdModel tenantId) {
         CommandModel commandToSend = new CommandModel(reportTaskRun);
-        BiFunction<RecordMetadata, Throwable, RecordMetadata> completeReportTask = (recordMetadata, exception) -> {
-            if (exception != null) {
-                client.onError(new LHApiException(Status.UNAVAILABLE, "Failed recording task claim to Kafka"));
-            } else {
-                client.onNext(Empty.getDefaultInstance());
-                client.onCompleted();
-            }
-            return recordMetadata;
-        };
-        return taskClaimProducer
-                .send(
-                        commandToSend.getPartitionKey(),
-                        commandToSend,
-                        commandToSend.getTopic(serverConfig),
-                        HeadersUtil.metadataHeadersFor(tenantId, principalId).toArray())
-                .handleAsync(completeReportTask, networkThreadpool);
+        return taskClaimProducer.send(
+                commandToSend.getPartitionKey(),
+                commandToSend,
+                commandToSend.getTopic(serverConfig),
+                HeadersUtil.metadataHeadersFor(tenantId, principalId).toArray());
     }
 
     private CompletableFuture<Message> waitForCommand(

--- a/server/src/test/java/e2e/TaskOutputTooLargeTest.java
+++ b/server/src/test/java/e2e/TaskOutputTooLargeTest.java
@@ -1,0 +1,59 @@
+package e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.TaskAttempt;
+import io.littlehorse.sdk.common.proto.TaskStatus;
+import io.littlehorse.sdk.common.proto.VariableType;
+import io.littlehorse.sdk.common.proto.VariableValue;
+import io.littlehorse.sdk.common.util.Arg;
+import io.littlehorse.sdk.wfsdk.WfRunVariable;
+import io.littlehorse.sdk.wfsdk.Workflow;
+import io.littlehorse.sdk.worker.LHTaskMethod;
+import io.littlehorse.test.LHTest;
+import io.littlehorse.test.LHWorkflow;
+import io.littlehorse.test.WorkflowVerifier;
+import org.junit.jupiter.api.Test;
+
+@LHTest
+public class TaskOutputTooLargeTest {
+
+    // Bigger than the default producer max request size (see LHServerConfig#getProducerMaxRequestSize()).
+    private static final int TWO_MIB = 2 * 1024 * 1024;
+
+    private WorkflowVerifier verifier;
+
+    @LHWorkflow("task-output-size")
+    private Workflow taskOutputSizeWf;
+
+    @LHWorkflow("task-output-size")
+    public Workflow getTaskOutputSizeWf() {
+        return Workflow.newWorkflow("task-output-size", wf -> {
+            WfRunVariable payloadSize =
+                    wf.addVariable("payload-size", VariableType.INT).required();
+            wf.execute("return-bytes-of-size", payloadSize);
+        });
+    }
+
+    @Test
+    void shouldNotAdvanceWhenTaskOutputExceedsMaxRecordSize() {
+        verifier.prepareRun(taskOutputSizeWf, Arg.of("payload-size", TWO_MIB))
+                // The task gets claimed and executed, so it reaches TASK_RUNNING on the server...
+                .waitForTaskStatus(0, 1, TaskStatus.TASK_OUTPUT_SERDE_ERROR)
+                .waitForStatus(LHStatus.ERROR)
+                .thenVerifyTaskRun(0, 1, taskRun -> {
+                    assertThat(taskRun.getAttemptsList()).hasSize(1);
+                    TaskAttempt taskAttempt = taskRun.getAttempts(0);
+                    assertThat(taskAttempt.getOutput().getValueCase()).isEqualTo(VariableValue.ValueCase.VALUE_NOT_SET);
+                    assertThat(taskAttempt.getStatus()).isEqualTo(TaskStatus.TASK_OUTPUT_SERDE_ERROR);
+                    assertThat(taskAttempt.getError().getMessage()).contains("RESOURCE_EXHAUSTED");
+                })
+                .start();
+    }
+
+    @LHTaskMethod("return-bytes-of-size")
+    public byte[] returnBytesOfSize(int size) {
+        return new byte[size];
+    }
+}

--- a/server/src/test/java/io/littlehorse/common/util/LHProducerTest.java
+++ b/server/src/test/java/io/littlehorse/common/util/LHProducerTest.java
@@ -3,15 +3,19 @@ package io.littlehorse.common.util;
 import static org.assertj.core.api.Assertions.*;
 
 import io.littlehorse.common.LHSerializable;
+import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.corecommand.CommandModel;
 import io.littlehorse.common.model.corecommand.subcommand.TaskWorkerHeartBeatRequestModel;
 import io.littlehorse.sdk.common.proto.TaskDefId;
 import io.littlehorse.sdk.common.proto.TaskWorkerHeartBeatRequest;
 import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Test;
@@ -19,8 +23,8 @@ import org.mockito.Mockito;
 
 public class LHProducerTest {
 
-    private MockProducer<String, Bytes> prod = new MockProducer<>(
-            true, null, Serdes.String().serializer(), Serdes.Bytes().serializer());
+    private final MockProducer<String, Bytes> prod = new MockProducer<>(
+            false, null, Serdes.String().serializer(), Serdes.Bytes().serializer());
     private final LHProducer lhProducer = new LHProducer(prod);
     private final TaskWorkerHeartBeatRequest heartBeat = TaskWorkerHeartBeatRequest.newBuilder()
             .setClientId("worker-id")
@@ -35,9 +39,27 @@ public class LHProducerTest {
     @Test
     public void shouldSendCommandToKafkaWithCallback() throws Exception {
         CompletableFuture<RecordMetadata> result = lhProducer.send("test", commandToProduce, "test-topic");
+        prod.completeNext();
         RecordMetadata recordMetadata = result.get(1, TimeUnit.SECONDS);
         assertThat(recordMetadata.topic()).isEqualTo("test-topic");
         assertThat(recordMetadata.partition()).isEqualTo(0);
         assertThat(recordMetadata.offset()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldPropagateRecordTooLargeExceptionAsLHApiException() {
+        final String expectedErrorMessage =
+                "The message is 1000 " + " bytes when serialized which is larger than 900 , which is the value of the "
+                        + ProducerConfig.MAX_REQUEST_SIZE_CONFIG
+                        + " configuration.";
+        CompletableFuture<RecordMetadata> result = lhProducer.send("test", commandToProduce, "test-topic");
+        RecordTooLargeException exception = new RecordTooLargeException(expectedErrorMessage);
+
+        prod.errorNext(exception);
+
+        assertThatThrownBy(() -> result.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(LHApiException.class)
+                .hasRootCauseMessage("RESOURCE_EXHAUSTED: " + expectedErrorMessage);
     }
 }

--- a/server/src/test/java/io/littlehorse/server/streams/CommandSenderTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/CommandSenderTest.java
@@ -11,7 +11,6 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.littlehorse.common.AuthorizationContext;
 import io.littlehorse.common.LHServerConfig;
-import io.littlehorse.common.TestStreamObserver;
 import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.ScheduledTaskModel;
 import io.littlehorse.common.model.corecommand.CommandModel;
@@ -121,14 +120,11 @@ class CommandSenderTest {
         PrincipalIdModel principalId = new PrincipalIdModel("test-principal");
         ReportTaskRunModel reportTaskRun = mock(ReportTaskRunModel.class);
         when(reportTaskRun.getPartitionKey()).thenReturn("test-partition-key");
-        TestStreamObserver<Empty> clientObserver = new TestStreamObserver<>();
         CompletableFuture<RecordMetadata> producerResult = CompletableFuture.completedFuture(recordMetadata);
         producerWithResult(taskClaimProducer, producerResult);
         CompletableFuture<RecordMetadata> future =
-                sender.reportTaskAndDontWaitForResponse(reportTaskRun, clientObserver, principalId, tenantId);
+                sender.reportTaskAndDontWaitForResponse(reportTaskRun, principalId, tenantId);
         assertThat(future.get()).isSameAs(recordMetadata);
-        assertThat(clientObserver.getValues()).hasSize(1);
-        assertThat(clientObserver.isCompleted()).isTrue();
     }
 
     @Test
@@ -138,17 +134,17 @@ class CommandSenderTest {
         PrincipalIdModel principalId = new PrincipalIdModel("test-principal");
         ReportTaskRunModel reportTaskRun = mock(ReportTaskRunModel.class);
         when(reportTaskRun.getPartitionKey()).thenReturn("test-partition-key");
-        TestStreamObserver<Empty> clientObserver = new TestStreamObserver<>();
-        CompletableFuture<RecordMetadata> producerResult = CompletableFuture.failedFuture(new TimeoutException());
+        CompletableFuture<RecordMetadata> producerResult = CompletableFuture.failedFuture(
+                new LHApiException(Status.UNAVAILABLE, "Failed reporting task run to Kafka"));
         producerWithResult(taskClaimProducer, producerResult);
         CompletableFuture<RecordMetadata> future =
-                sender.reportTaskAndDontWaitForResponse(reportTaskRun, clientObserver, principalId, tenantId);
-        future.get();
-        assertThat(clientObserver.getValues()).isEmpty();
-        assertThat(clientObserver.getThrowable())
-                .isNotNull()
-                .isInstanceOf(LHApiException.class)
-                .hasMessage("UNAVAILABLE: Failed recording task claim to Kafka");
+                sender.reportTaskAndDontWaitForResponse(reportTaskRun, principalId, tenantId);
+        assertThatException()
+                .isThrownBy(() -> future.get())
+                .withCauseInstanceOf(LHApiException.class)
+                .extracting(Throwable::getCause)
+                .extracting(Throwable::getMessage)
+                .isEqualTo("UNAVAILABLE: Failed reporting task run to Kafka");
     }
 
     @Test


### PR DESCRIPTION
Kafka producers might throw `RecordTooLarge` exceptions when sending batch records. This is the case to the server's command producers; sometimes users send commands that exceed the maximum request size configured via `LHServerConfig.PRODUCER_MAX_REQUEST_SIZE gRPC. The gRPC listeners transform these exceptions into internal errors, and they get propagated to the clients. 

Previously the exception was turned into an internal error and propagated to the client with no actionable meaning. Worse, for large commands like `ReportTaskRun` with a big task output, the command was never processed, so the WfRun never received its task result and hung until the task node handled the timeout command.

This PR only addresses the case when the command producers catch the RecordTooLarge exception. I'll create separate PRs to catch these errors in other places where these exceptions can be thrown. 

Solves one of the problem described in this issue #2303 