### PR TITLE
fix(server): Avoid sending output topic records when the output topic is missing 

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -40,9 +40,12 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.serialization.Serdes;
@@ -1158,6 +1161,14 @@ public class LHServerConfig extends ConfigBase {
                 throw e;
             }
         }
+    }
+
+    public Map<String, KafkaFuture<TopicDescription>> outputTopicExistsFor(TenantIdModel tenant) {
+        String metadataOutputTopicName = getMetadataOutputTopicName(tenant);
+        String coreCmdTopicName = getCoreCmdTopicName();
+        DescribeTopicsResult describeTopicsResult =
+                kafkaAdmin.describeTopics(List.of(metadataOutputTopicName, coreCmdTopicName));
+        return describeTopicsResult.topicNameValues();
     }
 
     private void initRocksdbSingletons() {

--- a/server/src/main/java/io/littlehorse/common/model/CoreOutputTopicGetable.java
+++ b/server/src/main/java/io/littlehorse/common/model/CoreOutputTopicGetable.java
@@ -1,7 +1,7 @@
 package io.littlehorse.common.model;
 
 import com.google.protobuf.Message;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.sdk.common.proto.OutputTopicConfig.OutputTopicRecordingLevel;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyGetableManager;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
@@ -20,7 +20,7 @@ public interface CoreOutputTopicGetable<T extends Message> {
             T previousValue,
             ReadOnlyMetadataManager metadataManager,
             ReadOnlyGetableManager getableManager,
-            OutputTopicConfigModel config) {
-        return config.getDefaultRecordingLevel() == OutputTopicRecordingLevel.ALL_ENTITY_EVENTS;
+            OutputTopicConfig.OutputTopicRecordingLevel outputTopicRecordingLevel) {
+        return outputTopicRecordingLevel == OutputTopicRecordingLevel.ALL_ENTITY_EVENTS;
     }
 }

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/variable/VariableModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/variable/VariableModel.java
@@ -13,9 +13,9 @@ import io.littlehorse.common.model.getable.global.wfspec.thread.ThreadVarDefMode
 import io.littlehorse.common.model.getable.objectId.VariableIdModel;
 import io.littlehorse.common.model.getable.objectId.WfRunIdModel;
 import io.littlehorse.common.model.getable.objectId.WfSpecIdModel;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.proto.TagStorageType;
 import io.littlehorse.common.util.LHUtil;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.sdk.common.proto.OutputTopicConfig.OutputTopicRecordingLevel;
 import io.littlehorse.sdk.common.proto.TypeDefinition.DefinedTypeCase;
 import io.littlehorse.sdk.common.proto.Variable;
@@ -175,8 +175,8 @@ public class VariableModel extends CoreGetable<Variable> implements CoreOutputTo
             Variable previousValue,
             ReadOnlyMetadataManager metadataManager,
             ReadOnlyGetableManager getableManager,
-            OutputTopicConfigModel config) {
-        if (config.getDefaultRecordingLevel() == OutputTopicRecordingLevel.NO_ENTITY_EVENTS) {
+            OutputTopicConfig.OutputTopicRecordingLevel recordingLevel) {
+        if (recordingLevel == OutputTopicRecordingLevel.NO_ENTITY_EVENTS) {
             return false;
         }
 

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/InactiveThreadRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/InactiveThreadRunModel.java
@@ -5,10 +5,10 @@ import io.littlehorse.common.model.AbstractGetable;
 import io.littlehorse.common.model.CoreGetable;
 import io.littlehorse.common.model.CoreOutputTopicGetable;
 import io.littlehorse.common.model.getable.objectId.InactiveThreadRunIdModel;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.proto.TagStorageType;
 import io.littlehorse.sdk.common.exception.LHSerdeException;
 import io.littlehorse.sdk.common.proto.InactiveThreadRun;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.server.streams.storeinternals.GetableIndex;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyGetableManager;
 import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
@@ -77,7 +77,7 @@ public class InactiveThreadRunModel extends CoreGetable<InactiveThreadRun>
             InactiveThreadRun previousValue,
             ReadOnlyMetadataManager metadataManager,
             ReadOnlyGetableManager getableManager,
-            OutputTopicConfigModel config) {
+            OutputTopicConfig.OutputTopicRecordingLevel recordingLevel) {
         return false;
     }
 }

--- a/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/core/wfrun/WfRunModel.java
@@ -36,13 +36,13 @@ import io.littlehorse.common.model.getable.objectId.InactiveThreadRunIdModel;
 import io.littlehorse.common.model.getable.objectId.WfRunIdModel;
 import io.littlehorse.common.model.getable.objectId.WfSpecIdModel;
 import io.littlehorse.common.model.getable.objectId.WorkflowMigrationPlanIdModel;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.proto.TagStorageType;
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.LHErrorType;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.MigrationVars;
 import io.littlehorse.sdk.common.proto.NodeRun.NodeTypeCase;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.sdk.common.proto.OutputTopicConfig.OutputTopicRecordingLevel;
 import io.littlehorse.sdk.common.proto.PendingFailureHandler;
 import io.littlehorse.sdk.common.proto.PendingInterrupt;
@@ -293,8 +293,8 @@ public class WfRunModel extends CoreGetable<WfRun> implements CoreOutputTopicGet
             WfRun previousValue,
             ReadOnlyMetadataManager metadataManager,
             ReadOnlyGetableManager getableManager,
-            OutputTopicConfigModel config) {
-        if (config.getDefaultRecordingLevel() == OutputTopicRecordingLevel.NO_ENTITY_EVENTS) {
+            OutputTopicConfig.OutputTopicRecordingLevel recordingLevel) {
+        if (recordingLevel == OutputTopicRecordingLevel.NO_ENTITY_EVENTS) {
             return false;
         }
 

--- a/server/src/main/java/io/littlehorse/common/util/LHUtil.java
+++ b/server/src/main/java/io/littlehorse/common/util/LHUtil.java
@@ -318,19 +318,13 @@ public class LHUtil {
                         PERMISSION_DENIED,
                         UNAUTHENTICATED,
                         FAILED_PRECONDITION,
+                        // ABORTED used to communicate that there is a misconfiguration on the tenant
+                        ABORTED,
                         // RESOURCE_EXHAUSTED used for quota violations.
                         RESOURCE_EXHAUSTED:
                     return true;
 
-                case OK,
-                        UNKNOWN,
-                        UNIMPLEMENTED,
-                        UNAVAILABLE,
-                        INTERNAL,
-                        DEADLINE_EXCEEDED,
-                        DATA_LOSS,
-                        ABORTED,
-                        CANCELLED:
+                case OK, UNKNOWN, UNIMPLEMENTED, UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED, DATA_LOSS, CANCELLED:
             }
         }
         return false;

--- a/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
+++ b/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
@@ -10,10 +10,10 @@ import io.littlehorse.common.model.getable.core.externalevent.ExternalEventModel
 import io.littlehorse.common.model.getable.core.wfrun.WfRunModel;
 import io.littlehorse.common.model.getable.objectId.ExternalEventIdModel;
 import io.littlehorse.common.model.getable.objectId.WfRunIdModel;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.model.outputtopic.OutputTopicRecordModel;
 import io.littlehorse.common.proto.StoreableType;
 import io.littlehorse.sdk.common.proto.LHStatus;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.server.streams.store.StoredGetable;
 import io.littlehorse.server.streams.stores.TenantScopedStore;
 import io.littlehorse.server.streams.topology.core.CommandProcessorOutput;
@@ -35,7 +35,7 @@ public class GetableManager extends ReadOnlyGetableManager {
     private final TenantScopedStore store;
     private final TagStorageManager tagStorageManager;
     private final CoreProcessorContext ctx;
-    private final OutputTopicConfigModel outputTopicConfig;
+    private final OutputTopicConfig.OutputTopicRecordingLevel outputTopicRecordingLevel;
     private final int maxRecordSizeInBytes;
 
     public GetableManager(
@@ -44,13 +44,13 @@ public class GetableManager extends ReadOnlyGetableManager {
             final LHServerConfig config,
             final CommandModel command,
             final CoreProcessorContext executionContext,
-            final OutputTopicConfigModel outputTopicConfig) {
+            final OutputTopicConfig.OutputTopicRecordingLevel outputTopicRecordingLevel) {
         super(store);
         this.store = store;
         this.command = command;
         this.tagStorageManager = new TagStorageManager(this.store, streamsContext, executionContext);
         this.ctx = executionContext;
-        this.outputTopicConfig = outputTopicConfig;
+        this.outputTopicRecordingLevel = outputTopicRecordingLevel;
         this.maxRecordSizeInBytes = config.getProducerMaxRequestSize();
     }
 
@@ -231,11 +231,11 @@ public class GetableManager extends ReadOnlyGetableManager {
             store.put(new StoredGetable<>(getable));
             tagStorageManager.store(getable.getIndexEntries(), entity.getTagsPresentBeforeUpdate());
 
-            if (outputTopicConfig != null && getable instanceof CoreOutputTopicGetable outputTopicCandidate) {
+            if (outputTopicRecordingLevel != null && getable instanceof CoreOutputTopicGetable outputTopicCandidate) {
                 U previouslyStoredProto = entity.getPreviouslyStoredProto();
 
                 if (outputTopicCandidate.shouldProduceToOutputTopic(
-                        previouslyStoredProto, ctx.metadataManager(), this, outputTopicConfig)) {
+                        previouslyStoredProto, ctx.metadataManager(), this, outputTopicRecordingLevel)) {
                     return Optional.of(new OutputTopicRecordModel(outputTopicCandidate, command.getTime()));
                 }
             }

--- a/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
+++ b/server/src/main/java/io/littlehorse/server/streams/storeinternals/GetableManager.java
@@ -18,7 +18,12 @@ import io.littlehorse.server.streams.store.StoredGetable;
 import io.littlehorse.server.streams.stores.TenantScopedStore;
 import io.littlehorse.server.streams.topology.core.CommandProcessorOutput;
 import io.littlehorse.server.streams.topology.core.CoreProcessorContext;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -226,8 +231,7 @@ public class GetableManager extends ReadOnlyGetableManager {
             store.put(new StoredGetable<>(getable));
             tagStorageManager.store(getable.getIndexEntries(), entity.getTagsPresentBeforeUpdate());
 
-            if (outputTopicConfig != null && getable instanceof CoreOutputTopicGetable) {
-                CoreOutputTopicGetable<U> outputTopicCandidate = (CoreOutputTopicGetable<U>) getable;
+            if (outputTopicConfig != null && getable instanceof CoreOutputTopicGetable outputTopicCandidate) {
                 U previouslyStoredProto = entity.getPreviouslyStoredProto();
 
                 if (outputTopicCandidate.shouldProduceToOutputTopic(

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
@@ -14,6 +14,7 @@ import io.littlehorse.common.model.corecommand.subcommand.PutExternalEventReques
 import io.littlehorse.common.model.getable.core.events.WorkflowEventModel;
 import io.littlehorse.common.model.getable.core.externalevent.CorrelatedEventModel;
 import io.littlehorse.common.model.getable.core.taskworkergroup.HostModel;
+import io.littlehorse.common.model.getable.global.acl.TenantModel;
 import io.littlehorse.common.model.getable.global.externaleventdef.CorrelatedEventConfigModel;
 import io.littlehorse.common.model.getable.global.externaleventdef.ExternalEventDefModel;
 import io.littlehorse.common.model.getable.objectId.CorrelatedEventIdModel;
@@ -21,7 +22,6 @@ import io.littlehorse.common.model.getable.objectId.ExternalEventIdModel;
 import io.littlehorse.common.model.getable.objectId.NodeRunIdModel;
 import io.littlehorse.common.model.getable.objectId.PrincipalIdModel;
 import io.littlehorse.common.model.getable.objectId.TenantIdModel;
-import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.model.outputtopic.OutputTopicRecordModel;
 import io.littlehorse.common.proto.Command;
 import io.littlehorse.common.util.LHUtil;
@@ -89,7 +89,7 @@ public class CoreProcessorContext extends ProcessingContext {
     private final PartitionLocalBuffer<PartitionMetricWindowModel> metricWindows;
     private final PartitionLocalBuffer<PartitionCountedTagModel> countedTags;
     private PartitionMetricsCollector metricsCollector;
-    private final OutputTopicConfigModel outputTopicConfig;
+    private final OutputTopicConfig.OutputTopicRecordingLevel outputTopicRecordingLevel;
     private final CompletableFuture<Boolean> validOutputTopicFuture;
 
     public CoreProcessorContext(
@@ -126,12 +126,15 @@ public class CoreProcessorContext extends ProcessingContext {
         this.authContext = this.authContextFor();
         this.currentCommand = LHSerializable.fromProto(currentCommand, CommandModel.class, this);
         this.eventsToThrow = new ArrayList<>();
-        this.outputTopicConfig = metadataManager.get(tenantId).getOutputTopicConfig();
-        if (outputTopicConfig != null
-                && outputTopicConfig.getDefaultRecordingLevel()
-                        == OutputTopicConfig.OutputTopicRecordingLevel.ALL_ENTITY_EVENTS) {
+        TenantModel storedTenant = metadataManager.get(tenantId);
+        if (storedTenant != null
+                && storedTenant.getOutputTopicConfig() != null
+                && storedTenant.getOutputTopicConfig().getDefaultRecordingLevel()
+                        != OutputTopicConfig.OutputTopicRecordingLevel.NO_ENTITY_EVENTS) {
+            outputTopicRecordingLevel = storedTenant.getOutputTopicConfig().getDefaultRecordingLevel();
             validOutputTopicFuture = outputTopicsExist();
         } else {
+            outputTopicRecordingLevel = OutputTopicConfig.OutputTopicRecordingLevel.NO_ENTITY_EVENTS;
             validOutputTopicFuture = CompletableFuture.completedFuture(true);
         }
     }
@@ -253,8 +256,8 @@ public class CoreProcessorContext extends ProcessingContext {
         if (storageManager != null) {
             return storageManager;
         }
-        storageManager =
-                new GetableManager(coreStore, processorContext, config, currentCommand, this, outputTopicConfig);
+        storageManager = new GetableManager(
+                coreStore, processorContext, config, currentCommand, this, outputTopicRecordingLevel);
         return storageManager;
     }
 

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/CoreProcessorContext.java
@@ -1,9 +1,11 @@
 package io.littlehorse.server.streams.topology.core;
 
+import io.grpc.Status;
 import io.littlehorse.common.AuthorizationContext;
 import io.littlehorse.common.AuthorizationContextImpl;
 import io.littlehorse.common.LHSerializable;
 import io.littlehorse.common.LHServerConfig;
+import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.LHTimer;
 import io.littlehorse.common.model.PartitionCountedTagModel;
 import io.littlehorse.common.model.PartitionMetricWindowModel;
@@ -19,10 +21,12 @@ import io.littlehorse.common.model.getable.objectId.ExternalEventIdModel;
 import io.littlehorse.common.model.getable.objectId.NodeRunIdModel;
 import io.littlehorse.common.model.getable.objectId.PrincipalIdModel;
 import io.littlehorse.common.model.getable.objectId.TenantIdModel;
+import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.model.outputtopic.OutputTopicRecordModel;
 import io.littlehorse.common.proto.Command;
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.LHHostInfo;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.server.LHServer;
 import io.littlehorse.server.auth.internalport.InternalCallCredentials;
 import io.littlehorse.server.streams.ServerTopology;
@@ -42,6 +46,10 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
@@ -55,7 +63,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  * scheduling WfRun's is actually done.
  */
 @Slf4j
-public class CoreProcessorContext implements ExecutionContext {
+public class CoreProcessorContext extends ProcessingContext {
 
     private final LHServerConfig config;
 
@@ -81,6 +89,8 @@ public class CoreProcessorContext implements ExecutionContext {
     private final PartitionLocalBuffer<PartitionMetricWindowModel> metricWindows;
     private final PartitionLocalBuffer<PartitionCountedTagModel> countedTags;
     private PartitionMetricsCollector metricsCollector;
+    private final OutputTopicConfigModel outputTopicConfig;
+    private final CompletableFuture<Boolean> validOutputTopicFuture;
 
     public CoreProcessorContext(
             Command currentCommand,
@@ -92,6 +102,7 @@ public class CoreProcessorContext implements ExecutionContext {
             LHServer server,
             PartitionLocalBuffer<PartitionMetricWindowModel> metricWindows,
             PartitionLocalBuffer<PartitionCountedTagModel> countedTags) {
+        super(config);
 
         this.processorContext = processorContext;
         this.metadataCache = metadataCache;
@@ -115,6 +126,14 @@ public class CoreProcessorContext implements ExecutionContext {
         this.authContext = this.authContextFor();
         this.currentCommand = LHSerializable.fromProto(currentCommand, CommandModel.class, this);
         this.eventsToThrow = new ArrayList<>();
+        this.outputTopicConfig = metadataManager.get(tenantId).getOutputTopicConfig();
+        if (outputTopicConfig != null
+                && outputTopicConfig.getDefaultRecordingLevel()
+                        == OutputTopicConfig.OutputTopicRecordingLevel.ALL_ENTITY_EVENTS) {
+            validOutputTopicFuture = outputTopicsExist();
+        } else {
+            validOutputTopicFuture = CompletableFuture.completedFuture(true);
+        }
     }
 
     public PartitionLocalBuffer<PartitionCountedTagModel> getCountedTagsAccumulator() {
@@ -234,13 +253,8 @@ public class CoreProcessorContext implements ExecutionContext {
         if (storageManager != null) {
             return storageManager;
         }
-        storageManager = new GetableManager(
-                coreStore,
-                processorContext,
-                config,
-                currentCommand,
-                this,
-                metadataManager.get(tenantId).getOutputTopicConfig());
+        storageManager =
+                new GetableManager(coreStore, processorContext, config, currentCommand, this, outputTopicConfig);
         return storageManager;
     }
 
@@ -263,6 +277,15 @@ public class CoreProcessorContext implements ExecutionContext {
      * decide when to call this method
      */
     public void endExecution() {
+        try {
+            // 20 milliseconds more to the network call.
+            Boolean validTopic = validOutputTopicFuture.get(20, TimeUnit.MILLISECONDS);
+            if (!validTopic) {
+                throw new LHApiException(Status.ABORTED.withDescription("Failed to send output topic"));
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new LHApiException(Status.ABORTED.withDescription("Failed to send output topic"));
+        }
         if (storageManager != null) {
             storageManager.commit();
         }

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
@@ -71,12 +71,15 @@ public class MetadataProcessorContext extends ProcessingContext {
         this.authContext = this.authContextFor(
                 HeadersUtil.tenantIdFromMetadata(recordMetadata), HeadersUtil.principalIdFromMetadata(recordMetadata));
         this.lhConfig = lhConfig;
-        this.outputTopicConfig = metadataManager.get(tenantId).getOutputTopicConfig();
-        if (outputTopicConfig != null
-                && !(outputTopicConfig.getDefaultRecordingLevel()
+        TenantModel storedTenant = metadataManager.get(tenantId);
+        if (storedTenant != null
+                && storedTenant.getOutputTopicConfig() != null
+                && !(storedTenant.getOutputTopicConfig().getDefaultRecordingLevel()
                         == OutputTopicConfig.OutputTopicRecordingLevel.NO_ENTITY_EVENTS)) {
+            this.outputTopicConfig = storedTenant.getOutputTopicConfig();
             this.outputTopicExistsFuture = outputTopicsExist();
         } else {
+            this.outputTopicConfig = null;
             this.outputTopicExistsFuture = CompletableFuture.completedFuture(true);
         }
     }

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/MetadataProcessorContext.java
@@ -1,8 +1,10 @@
 package io.littlehorse.server.streams.topology.core;
 
+import io.grpc.Status;
 import io.littlehorse.common.AuthorizationContext;
 import io.littlehorse.common.AuthorizationContextImpl;
 import io.littlehorse.common.LHServerConfig;
+import io.littlehorse.common.exceptions.LHApiException;
 import io.littlehorse.common.model.MetadataGetable;
 import io.littlehorse.common.model.corecommand.CommandModel;
 import io.littlehorse.common.model.corecommand.CoreSubCommand;
@@ -11,8 +13,10 @@ import io.littlehorse.common.model.getable.global.migrations.WorkflowMigrationPl
 import io.littlehorse.common.model.getable.objectId.PrincipalIdModel;
 import io.littlehorse.common.model.getable.objectId.TenantIdModel;
 import io.littlehorse.common.model.metadatacommand.MetadataCommandModel;
+import io.littlehorse.common.model.metadatacommand.OutputTopicConfigModel;
 import io.littlehorse.common.model.outputtopic.MetadataOutputTopicRecordModel;
 import io.littlehorse.common.proto.MetadataCommand;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.server.streams.ServerTopology;
 import io.littlehorse.server.streams.storeinternals.MetadataManager;
 import io.littlehorse.server.streams.stores.ClusterScopedStore;
@@ -21,6 +25,10 @@ import io.littlehorse.server.streams.util.HeadersUtil;
 import io.littlehorse.server.streams.util.MetadataCache;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.header.Headers;
@@ -29,7 +37,7 @@ import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
 
-public class MetadataProcessorContext implements ExecutionContext {
+public class MetadataProcessorContext extends ProcessingContext {
 
     private final ProcessorContext<String, CommandProcessorOutput> processorContext;
     private final MetadataCache metadataCache;
@@ -37,6 +45,8 @@ public class MetadataProcessorContext implements ExecutionContext {
     private MetadataManager metadataManager;
     private LHServerConfig lhConfig;
     private final MetadataCommandModel currentCommand;
+    private final OutputTopicConfigModel outputTopicConfig;
+    private final CompletableFuture<Boolean> outputTopicExistsFuture;
 
     public MetadataProcessorContext(
             Headers recordMetadata,
@@ -44,6 +54,7 @@ public class MetadataProcessorContext implements ExecutionContext {
             MetadataCache metadataCache,
             LHServerConfig lhConfig,
             MetadataCommand currentCommand) {
+        super(lhConfig);
         this.processorContext = processorContext;
 
         this.metadataCache = metadataCache;
@@ -60,6 +71,14 @@ public class MetadataProcessorContext implements ExecutionContext {
         this.authContext = this.authContextFor(
                 HeadersUtil.tenantIdFromMetadata(recordMetadata), HeadersUtil.principalIdFromMetadata(recordMetadata));
         this.lhConfig = lhConfig;
+        this.outputTopicConfig = metadataManager.get(tenantId).getOutputTopicConfig();
+        if (outputTopicConfig != null
+                && !(outputTopicConfig.getDefaultRecordingLevel()
+                        == OutputTopicConfig.OutputTopicRecordingLevel.NO_ENTITY_EVENTS)) {
+            this.outputTopicExistsFuture = outputTopicsExist();
+        } else {
+            this.outputTopicExistsFuture = CompletableFuture.completedFuture(true);
+        }
     }
 
     @Override
@@ -107,7 +126,14 @@ public class MetadataProcessorContext implements ExecutionContext {
     private void maybeForwardMetadataGetableToOutputTopic(TenantIdModel tenantId, MetadataGetable<?> getable) {
         TenantModel tenant = metadataManager.get(tenantId);
         if (tenant.getOutputTopicConfig() == null) return;
-
+        try {
+            Boolean valid = outputTopicExistsFuture.get(20, TimeUnit.MILLISECONDS);
+            if (!valid) {
+                return;
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new LHApiException(Status.ABORTED.withDescription(e.getMessage()));
+        }
         if (getable instanceof WorkflowMigrationPlanModel) return;
 
         MetadataOutputTopicRecordModel output = new MetadataOutputTopicRecordModel(getable);

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/ProcessingContext.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/ProcessingContext.java
@@ -1,0 +1,45 @@
+package io.littlehorse.server.streams.topology.core;
+
+import io.littlehorse.common.LHServerConfig;
+import io.littlehorse.common.model.getable.objectId.TenantIdModel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+
+public abstract class ProcessingContext implements ExecutionContext {
+
+    private final LHServerConfig serverConfig;
+
+    public ProcessingContext(LHServerConfig serverConfig) {
+        this.serverConfig = serverConfig;
+    }
+
+    public final CompletableFuture<Boolean> outputTopicsExist() {
+        TenantIdModel tenantId = authorization().tenantId();
+        if (tenantId == null) {
+            throw new IllegalStateException(
+                    "Execution context without a valid Tenant ID. This indicates a bug in the server");
+        }
+        Map<String, KafkaFuture<TopicDescription>> stringKafkaFutureMap = serverConfig.outputTopicExistsFor(tenantId);
+        List<CompletableFuture<Boolean>> topicsExist = new ArrayList<>();
+        topicsExist.add(CompletableFuture.completedFuture(true)); // at least one completed future with True
+        for (KafkaFuture<TopicDescription> value : stringKafkaFutureMap.values()) {
+            CompletableFuture<Boolean> futureTopicExistsAnswer = value.toCompletionStage()
+                    .thenApply(Objects::nonNull)
+                    // Ensure the future responses with a True value or exception
+                    .thenCompose(exists -> exists
+                            ? CompletableFuture.completedFuture(true)
+                            : CompletableFuture.failedFuture(
+                                    new IllegalStateException("Output topic does not exist for tenant " + tenantId)))
+                    .toCompletableFuture();
+            topicsExist.add(futureTopicExistsAnswer);
+        }
+        return CompletableFuture.allOf(topicsExist.toArray(new CompletableFuture[0]))
+                .thenApply(v -> true)
+                .exceptionally(ex -> false);
+    }
+}

--- a/server/src/test/java/io/littlehorse/server/streams/topology/core/ProcessingContextTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/topology/core/ProcessingContextTest.java
@@ -1,0 +1,145 @@
+package io.littlehorse.server.streams.topology.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import io.littlehorse.common.AuthorizationContext;
+import io.littlehorse.common.LHServerConfig;
+import io.littlehorse.common.model.getable.objectId.TenantIdModel;
+import io.littlehorse.server.streams.storeinternals.ReadOnlyMetadataManager;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessingContextTest {
+
+    @Mock
+    private LHServerConfig serverConfig;
+
+    @Mock
+    private AuthorizationContext authorizationContext;
+
+    @Mock
+    private TenantIdModel tenantId;
+
+    private TestProcessingContext processingContext;
+
+    @BeforeEach
+    void setUp() {
+        processingContext = new TestProcessingContext(serverConfig, authorizationContext);
+    }
+
+    @Test
+    void shouldReturnTrueWhenAllTopicsExist() throws Exception {
+        TopicDescription topicDescription = mock(TopicDescription.class);
+        KafkaFuture<TopicDescription> future1 = kafkaFutureOf(topicDescription);
+        KafkaFuture<TopicDescription> future2 = kafkaFutureOf(topicDescription);
+
+        when(authorizationContext.tenantId()).thenReturn(tenantId);
+        when(serverConfig.outputTopicExistsFor(tenantId)).thenReturn(Map.of("topic1", future1, "topic2", future2));
+
+        assertThat(processingContext.outputTopicsExist().get()).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenTopicMapIsEmpty() throws Exception {
+        when(authorizationContext.tenantId()).thenReturn(tenantId);
+        when(serverConfig.outputTopicExistsFor(tenantId)).thenReturn(Map.of());
+
+        assertThat(processingContext.outputTopicsExist().get()).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenATopicDescriptionIsNull() throws Exception {
+        KafkaFuture<TopicDescription> nullFuture = kafkaFutureOf(null);
+
+        when(authorizationContext.tenantId()).thenReturn(tenantId);
+        when(serverConfig.outputTopicExistsFor(tenantId)).thenReturn(Map.of("missingTopic", nullFuture));
+
+        assertThat(processingContext.outputTopicsExist().get()).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenATopicFutureCompletesExceptionally() throws Exception {
+        KafkaFuture<TopicDescription> failedFuture = kafkaFutureFailedWith(new RuntimeException("Kafka admin error"));
+
+        when(authorizationContext.tenantId()).thenReturn(tenantId);
+        when(serverConfig.outputTopicExistsFor(tenantId)).thenReturn(Map.of("errorTopic", failedFuture));
+
+        assertThat(processingContext.outputTopicsExist().get()).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenAtLeastOneTopicIsMissing() throws Exception {
+        TopicDescription topicDescription = mock(TopicDescription.class);
+        KafkaFuture<TopicDescription> existingFuture = kafkaFutureOf(topicDescription);
+        KafkaFuture<TopicDescription> missingFuture = kafkaFutureOf(null);
+
+        when(authorizationContext.tenantId()).thenReturn(tenantId);
+        when(serverConfig.outputTopicExistsFor(tenantId))
+                .thenReturn(Map.of("existingTopic", existingFuture, "missingTopic", missingFuture));
+
+        assertThat(processingContext.outputTopicsExist().get()).isFalse();
+    }
+
+    @Test
+    void shouldThrowIllegalStateExceptionWhenTenantIdIsNull() {
+        when(authorizationContext.tenantId()).thenReturn(null);
+
+        assertThatThrownBy(() -> processingContext.outputTopicsExist())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Execution context without a valid Tenant ID");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KafkaFuture<TopicDescription> kafkaFutureOf(TopicDescription value) {
+        KafkaFuture<TopicDescription> future = mock(KafkaFuture.class);
+        when(future.toCompletionStage()).thenReturn(CompletableFuture.completedFuture(value));
+        return future;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KafkaFuture<TopicDescription> kafkaFutureFailedWith(Throwable cause) {
+        KafkaFuture<TopicDescription> future = mock(KafkaFuture.class);
+        when(future.toCompletionStage()).thenReturn(CompletableFuture.failedFuture(cause));
+        return future;
+    }
+
+    /** Minimal concrete subclass to exercise the abstract {@link ProcessingContext}. */
+    private static class TestProcessingContext extends ProcessingContext {
+        private final AuthorizationContext authorizationContext;
+
+        TestProcessingContext(LHServerConfig serverConfig, AuthorizationContext authorizationContext) {
+            super(serverConfig);
+            this.authorizationContext = authorizationContext;
+        }
+
+        @Override
+        public AuthorizationContext authorization() {
+            return authorizationContext;
+        }
+
+        @Override
+        public WfService service() {
+            return null;
+        }
+
+        @Override
+        public ReadOnlyMetadataManager metadataManager() {
+            return null;
+        }
+
+        @Override
+        public LHServerConfig serverConfig() {
+            return null;
+        }
+    }
+}

--- a/server/src/test/java/io/littlehorse/storeinternals/GetableManagerTest.java
+++ b/server/src/test/java/io/littlehorse/storeinternals/GetableManagerTest.java
@@ -39,6 +39,7 @@ import io.littlehorse.common.model.repartitioncommand.repartitionsubcommand.Crea
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.NodeRun;
+import io.littlehorse.sdk.common.proto.OutputTopicConfig;
 import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.WfRunVariableAccessLevel;
 import io.littlehorse.server.streams.store.StoredGetable;
@@ -104,8 +105,13 @@ public class GetableManagerTest {
         when(executionContext.nativeCoreStore()).thenReturn(store);
         when(executionContext.getCountedTagsAccumulator()).thenReturn(countedTags);
         localStoreWrapper = TenantScopedStore.newInstance(store, new TenantIdModel(tenantId), executionContext);
-        getableManager =
-                new GetableManager(localStoreWrapper, mockProcessorContext, lhConfig, mock(), executionContext, null);
+        getableManager = new GetableManager(
+                localStoreWrapper,
+                mockProcessorContext,
+                lhConfig,
+                mock(),
+                executionContext,
+                OutputTopicConfig.OutputTopicRecordingLevel.NO_ENTITY_EVENTS);
         store.init(mockProcessorContext.getStateStoreContext(), store);
     }
 


### PR DESCRIPTION
Littlehorse server has the ability to send events to an output topic, so analytics users can consume these events and perform aggregations over these events (See proposal `001-output-topic.md`). This behavior is controlled by a configuration at the tenant level. When a tenant is configured to send events to the output topic, the Kafka Streams processor hopes that the topic was already created by Littlehorse server operators.

On local development, Littlehorse server automatically creates these topics, making it easy to test the output topic feature locally. However, this behavior is not recommended for production.

In production environments, operators must create the output topics before enabling the tenant-level configuration to send events. 

A missing output topic is catastrophic for the entire LHCluster, causing transaction timeouts and poison pill scenarios.

This PR verifies if the output topic actually exists on the kafka cluster before attempting to produce a record. The proposal includes an asynchronous call to the brokers using the kafka Admin API, the idea is to not block the Stream processors with a time-consuming operation. 
 