### PR TITLE
refactor(sdk-java, server): refactor use of LHMisconfigurationException

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/common/exception/LHWfSpecBuilderException.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/common/exception/LHWfSpecBuilderException.java
@@ -1,0 +1,16 @@
+package io.littlehorse.sdk.common.exception;
+
+/**
+ * Thrown when a LittleHorse WfSpec is built incorrectly via the SDK DSL.
+ * Indicates a programming error in the workflow definition code.
+ */
+public class LHWfSpecBuilderException extends RuntimeException {
+
+    public LHWfSpecBuilderException(String message) {
+        super(message);
+    }
+
+    public LHWfSpecBuilderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/InterruptHandlerImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/InterruptHandlerImpl.java
@@ -1,6 +1,6 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.wfsdk.InterruptHandler;
 
 public class InterruptHandlerImpl implements InterruptHandler {
@@ -17,7 +17,7 @@ public class InterruptHandlerImpl implements InterruptHandler {
     @Override
     public void withEventType(Class<?> eventType) {
         if (eventTypeRegistered) {
-            throw new LHMisconfigurationException("Interrupt event type already registered: " + interruptName);
+            throw new LHWfSpecBuilderException("Interrupt event type already registered: " + interruptName);
         }
         eventTypeRegistered = true;
         parentThread.registerExternalEventDef(new InterruptExternalEventDefRegistration(

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/NodeOutputImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/NodeOutputImpl.java
@@ -1,6 +1,6 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.LHPath.Selector;
 import io.littlehorse.sdk.wfsdk.NodeOutput;
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ class NodeOutputImpl implements NodeOutput {
 
     public NodeOutputImpl get(String index) {
         if (jsonPath != null) {
-            throw new LHMisconfigurationException("Cannot use jsonPath() and get() on same var!");
+            throw new LHWfSpecBuilderException("Cannot use jsonPath() and get() on same var!");
         }
         NodeOutputImpl out = new NodeOutputImpl(nodeName, parent);
         out.getLhPath().add(Selector.newBuilder().setKey(index).build());

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImpl.java
@@ -1,8 +1,8 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
 import io.littlehorse.sdk.common.LHLibUtil;
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
 import io.littlehorse.sdk.common.exception.LHSerdeException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.Comparator;
 import io.littlehorse.sdk.common.proto.JsonIndex;
 import io.littlehorse.sdk.common.proto.LHPath.Selector;
@@ -99,15 +99,15 @@ class WfRunVariableImpl implements WfRunVariable {
     @Override
     public WfRunVariableImpl jsonPath(String path) {
         if (jsonPath != null) {
-            throw new LHMisconfigurationException("Cannot use jsonpath() twice on same var!");
+            throw new LHWfSpecBuilderException("Cannot use jsonpath() twice on same var!");
         }
         if (typeDef.getDefinedTypeCase() != DefinedTypeCase.PRIMITIVE_TYPE) {
-            throw new LHMisconfigurationException(
+            throw new LHWfSpecBuilderException(
                     String.format("JsonPath not allowed in a %s variable", typeDef.getDefinedTypeCase()));
         }
         if (!typeDef.getPrimitiveType().equals(VariableType.JSON_OBJ)
                 && !typeDef.getPrimitiveType().equals(VariableType.JSON_ARR)) {
-            throw new LHMisconfigurationException(String.format(
+            throw new LHWfSpecBuilderException(String.format(
                     "JsonPath not allowed in a %s variable",
                     typeDef.getPrimitiveType().name()));
         }
@@ -119,7 +119,7 @@ class WfRunVariableImpl implements WfRunVariable {
     @Override
     public WfRunVariableImpl get(String key) {
         if (jsonPath != null) {
-            throw new LHMisconfigurationException("Cannot use jsonPath() and get() on same var!");
+            throw new LHWfSpecBuilderException("Cannot use jsonPath() and get() on same var!");
         }
         switch (typeDef.getDefinedTypeCase()) {
             case STRUCT_DEF_ID:
@@ -127,12 +127,12 @@ class WfRunVariableImpl implements WfRunVariable {
             case PRIMITIVE_TYPE:
                 if (typeDef.getPrimitiveType() != VariableType.JSON_ARR
                         && typeDef.getPrimitiveType() != VariableType.JSON_OBJ) {
-                    throw new LHMisconfigurationException(
+                    throw new LHWfSpecBuilderException(
                             "Can only use get(String key) on JSON_OBJ, JSON_ARR, Map, or Struct variables");
                 }
                 break;
             case INLINE_ARRAY_DEF:
-                throw new LHMisconfigurationException(
+                throw new LHWfSpecBuilderException(
                         "Can only use get(String key) on JSON_OBJ, JSON_ARR, Map, or Struct variables");
             case INLINE_MAP_DEF:
                 // Typed inline maps (e.g. declareMap("x", String.class, Long.class)) are allowed
@@ -150,7 +150,7 @@ class WfRunVariableImpl implements WfRunVariable {
     @Override
     public WfRunVariableImpl get(int index) {
         if (jsonPath != null) {
-            throw new LHMisconfigurationException("Cannot use jsonPath() and get() on same var!");
+            throw new LHWfSpecBuilderException("Cannot use jsonPath() and get() on same var!");
         }
         switch (typeDef.getDefinedTypeCase()) {
             case STRUCT_DEF_ID:
@@ -158,7 +158,7 @@ class WfRunVariableImpl implements WfRunVariable {
             case PRIMITIVE_TYPE:
                 if (typeDef.getPrimitiveType() != VariableType.JSON_ARR
                         && typeDef.getPrimitiveType() != VariableType.JSON_OBJ) {
-                    throw new LHMisconfigurationException(
+                    throw new LHWfSpecBuilderException(
                             "Can only use get() on JSON_OBJ, JSON_ARR, Map, or Struct variables");
                 }
                 break;
@@ -247,11 +247,11 @@ class WfRunVariableImpl implements WfRunVariable {
     @Override
     public WfRunVariable searchableOn(String fieldPath, VariableType fieldType) {
         if (!fieldPath.startsWith("$.")) {
-            throw new LHMisconfigurationException(String.format("Invalid JsonPath: %s", fieldPath));
+            throw new LHWfSpecBuilderException(String.format("Invalid JsonPath: %s", fieldPath));
         }
         if (!typeDef.getPrimitiveType().equals(VariableType.JSON_OBJ)
                 && !typeDef.getPrimitiveType().equals(VariableType.JSON_ARR)) {
-            throw new LHMisconfigurationException(String.format("Non-Json %s variable contains jsonIndex", name));
+            throw new LHWfSpecBuilderException(String.format("Non-Json %s variable contains jsonIndex", name));
         }
         this.jsonIndexes.add(JsonIndex.newBuilder()
                 .setFieldPath(fieldPath)

--- a/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowImpl.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/wfsdk/internal/WorkflowImpl.java
@@ -2,7 +2,7 @@ package io.littlehorse.sdk.wfsdk.internal;
 
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.config.LHConfig;
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.ExponentialBackoffRetryPolicy;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.PutExternalEventDefRequest;
@@ -200,7 +200,7 @@ public class WorkflowImpl extends Workflow {
     public String addSubThread(String subThreadName, ThreadFunc subThreadFunc) {
         for (Pair<String, ThreadFunc> pair : threadFuncs) {
             if (pair.getKey().equals(subThreadName)) {
-                throw new LHMisconfigurationException(String.format("Thread %s already exists", subThreadName));
+                throw new LHWfSpecBuilderException(String.format("Thread %s already exists", subThreadName));
             }
         }
         threadFuncs.add(Pair.of(subThreadName, subThreadFunc));

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/ThreadVariablesTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/ThreadVariablesTest.java
@@ -1,6 +1,6 @@
 package io.littlehorse.sdk.wfsdk.internal;
 
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.PutWfSpecRequest;
 import io.littlehorse.sdk.common.proto.ThreadVarDef;
 import io.littlehorse.sdk.common.proto.VariableType;
@@ -20,7 +20,7 @@ public class ThreadVariablesTest {
         });
         Throwable throwable = Assertions.catchThrowable(wf::compileWorkflow);
         Assertions.assertThat(throwable)
-                .isInstanceOf(LHMisconfigurationException.class)
+                .isInstanceOf(LHWfSpecBuilderException.class)
                 .hasMessage("Non-Json my-var variable contains jsonIndex");
     }
 
@@ -33,7 +33,7 @@ public class ThreadVariablesTest {
         });
         Throwable throwable = Assertions.catchThrowable(wf::compileWorkflow);
         Assertions.assertThat(throwable)
-                .isInstanceOf(LHMisconfigurationException.class)
+                .isInstanceOf(LHWfSpecBuilderException.class)
                 .hasMessage("Invalid JsonPath: somePath");
     }
 

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImplTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WfRunVariableImplTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.Edge;
 import io.littlehorse.sdk.common.proto.InlineMapDef;
 import io.littlehorse.sdk.common.proto.Node;
@@ -33,8 +33,7 @@ public class WfRunVariableImplTest {
         WorkflowThreadImpl wfThread = new WorkflowThreadImpl("wf-thread", workflow, threadFunction);
         WfRunVariableImpl variable = WfRunVariableImpl.createPrimitiveVar("my-var", VariableType.STR, wfThread);
 
-        LHMisconfigurationException e =
-                assertThrows(LHMisconfigurationException.class, () -> variable.jsonPath("&.myPath"));
+        LHWfSpecBuilderException e = assertThrows(LHWfSpecBuilderException.class, () -> variable.jsonPath("&.myPath"));
         assertThat(e.getMessage()).isEqualTo("JsonPath not allowed in a STR variable");
     }
 

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowCompilationTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/WorkflowCompilationTest.java
@@ -2,7 +2,7 @@ package io.littlehorse.sdk.wfsdk.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
+import io.littlehorse.sdk.common.exception.LHWfSpecBuilderException;
 import io.littlehorse.sdk.common.proto.*;
 import io.littlehorse.sdk.wfsdk.WfRunVariable;
 import java.util.Map;
@@ -37,7 +37,7 @@ public class WorkflowCompilationTest {
         Throwable throwable = Assertions.catchThrowable(() -> wf.compileWorkflow());
         Assertions.assertThat(throwable).isNotNull();
         Assertions.assertThat(throwable)
-                .isInstanceOf(LHMisconfigurationException.class)
+                .isInstanceOf(LHWfSpecBuilderException.class)
                 .hasMessage("Thread my-thread already exists");
     }
 

--- a/server/src/main/java/io/littlehorse/server/LHServer.java
+++ b/server/src/main/java/io/littlehorse/server/LHServer.java
@@ -7,7 +7,6 @@ import io.littlehorse.common.model.getable.core.taskworkergroup.HostModel;
 import io.littlehorse.common.model.getable.objectId.TaskDefIdModel;
 import io.littlehorse.common.model.getable.objectId.TaskRunIdModel;
 import io.littlehorse.common.model.getable.objectId.TenantIdModel;
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
 import io.littlehorse.sdk.common.proto.LHHostInfo;
 import io.littlehorse.server.auth.RequestAuthorizer;
 import io.littlehorse.server.auth.internalport.InternalCallCredentials;
@@ -73,7 +72,7 @@ public class LHServer {
         return contextKey.get();
     }
 
-    public LHServer(LHServerConfig config) throws LHMisconfigurationException {
+    public LHServer(LHServerConfig config) {
         this.metadataCache = new MetadataCache();
         this.config = config;
         this.networkThreadpool = Executors.newVirtualThreadPerTaskExecutor();
@@ -191,7 +190,7 @@ public class LHServer {
             }
 
         } catch (IOException exn) {
-            throw new LHMisconfigurationException("Failed overriding Streams Process ID", exn);
+            throw new IllegalStateException("Failed overriding Streams Process ID", exn);
         }
     }
 

--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -51,7 +51,6 @@ import io.littlehorse.common.proto.WaitForCommandRequest;
 import io.littlehorse.common.proto.WaitForCommandResponse;
 import io.littlehorse.common.util.LHProducer;
 import io.littlehorse.common.util.LHUtil;
-import io.littlehorse.sdk.common.exception.LHMisconfigurationException;
 import io.littlehorse.sdk.common.exception.LHSerdeException;
 import io.littlehorse.sdk.common.proto.LHHostInfo;
 import io.littlehorse.sdk.common.proto.WorkflowEvent;
@@ -889,7 +888,7 @@ public class BackendInternalComms implements Closeable {
 
     private HostInfo getHostForPartition(int partition) {
         if (partition >= config.getClusterPartitions()) {
-            throw new LHMisconfigurationException("Unrecognized partition");
+            throw new IllegalStateException("Unrecognized partition");
         }
 
         Collection<StreamsMetadata> all = coreStreams.metadataForAllStreamsClients();


### PR DESCRIPTION
Split the LHMisconfigurationException into three different exceptions matching the actual use cases: WfSpec DSL misuse, server config validation, and internal runtime errors.

Resolves #2387