### PR TITLE
fix(dashboard): prevent sidebar crash from stale attempt/noderun index

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Components/Attempts.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Components/Attempts.tsx
@@ -20,6 +20,9 @@ export const Attempts = ({
 }) => {
   const attempt = attempts[attemptIndex]
   const attemptLength = attempts.length
+  if (!attempt) {
+    return null
+  }
   return (
     <div className="mb-4 mt-4 rounded-lg border border-gray-200 bg-gray-50">
       <Accordion type="single" collapsible defaultValue="attempts">

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/Failures.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/Failures.tsx
@@ -16,6 +16,9 @@ export const Failures: FC<{ nodeRunIndex: number }> = ({ nodeRunIndex }) => {
     return null
   }
   const nodeRun = selectedNode.data.nodeRunsList[nodeRunIndex]
+  if (!nodeRun) {
+    return null
+  }
   const failures = nodeRun.failures
 
   return (

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/NodeRunComponent.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/NodeRunInfo/NodeRunComponent.tsx
@@ -25,9 +25,14 @@ export const NodeRunComponent: FC<{ nodeRunIndex: number }> = ({ nodeRunIndex })
   }
 
   const nodeRun = selectedNode.data.nodeRunsList[nodeRunIndex]
+  if (!nodeRun) {
+    return null
+  }
 
   const nodeType = nodeRun.nodeType!
-  if (nodeType.oneofKind === 'task') return <TaskNodeRun node={nodeType.task} />
+  // Key by taskGuid so switching to a different TaskRun remounts TaskNodeRun and
+  // resets its internal attemptIndex, instead of reusing the previous node's index.
+  if (nodeType.oneofKind === 'task') return <TaskNodeRun key={nodeType.task.taskRunId?.taskGuid} node={nodeType.task} />
   if (nodeType.oneofKind === 'externalEvent') return <ExternalEventNodeRun node={nodeType.externalEvent} />
   if (nodeType.oneofKind === 'userTask') return <UserTaskNodeRun node={nodeType.userTask} />
   if (nodeType.oneofKind === 'sleep') return <SleepNodeRun node={nodeType.sleep} />

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Sidebar.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { FC, useMemo, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import { useDiagram } from '../../hooks/useDiagram'
 import { Node } from './Node'
 import { NodeInfo } from './NodeInfo/NodeInfo'
@@ -12,6 +12,12 @@ export const Sidebar: FC<{ showNodeRun?: boolean }> = ({ showNodeRun }) => {
   const { selectedNode } = useDiagram()
   const [currentTab, setCurrentTab] = useState('overview')
   const [nodeRunIndex, setNodeRunIndex] = useState<number>(0)
+
+  // Reset the selected NodeRun whenever a different node is picked. Without this the
+  // index survives into a node with fewer NodeRuns and indexes past the end of the list.
+  useEffect(() => {
+    setNodeRunIndex(0)
+  }, [selectedNode?.id])
 
   const isValidNode = useMemo(() => {
     if (!selectedNode) return false


### PR DESCRIPTION
Fixes the sidebar crash on completed WfRuns: open a TaskRun with multiple attempts, switch to a later attempt, then click a different node and the sidebar dies with "Something went wrong".

The attempt index lives in `TaskNodeRun`, which isn't keyed by node, so React reuses the instance and the old index carries into a TaskRun with fewer attempts. `nodeRunIndex` in `Sidebar` has the same issue when you jump between nodes with different noderun counts.

Added key `TaskNodeRun` by taskGuid so it remounts, reset `nodeRunIndex` when the selected node changes, and guard the three list reads (`Attempts`, `NodeRunComponent`, `Failures`) so a stale index returns null instead of white screening.
