### PR TITLE
feat(sdk-java): Support default values for placeholder template strings

### DIFF
--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/PlaceholderUtil.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/PlaceholderUtil.java
@@ -30,8 +30,8 @@ public final class PlaceholderUtil {
             final String replacement = values.containsKey(placeholderKey) ? values.get(placeholderKey) : defaultValue;
 
             if (replacement == null) {
-                throw new IllegalArgumentException(
-                        "No value has been provided for the placeholder with key: " + placeholderKey);
+                throw new IllegalArgumentException("No value has been provided for the placeholder with key: "
+                        + placeholderKey + ". No default value supplied for the placeholder either.");
             }
 
             matcher.appendReplacement(resultingText, Matcher.quoteReplacement(replacement));

--- a/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/PlaceholderUtil.java
+++ b/sdk-java/src/main/java/io/littlehorse/sdk/worker/internal/util/PlaceholderUtil.java
@@ -14,8 +14,20 @@ public final class PlaceholderUtil {
         final Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
 
         while (matcher.find()) {
-            final String placeholderKey = matcher.group(1);
-            final String replacement = values.get(placeholderKey);
+            final String placeholderToken = matcher.group(1);
+            final String placeholderKey;
+            final String defaultValue;
+
+            final int separatorIndex = placeholderToken.indexOf(':');
+            if (separatorIndex >= 0) {
+                placeholderKey = placeholderToken.substring(0, separatorIndex);
+                defaultValue = placeholderToken.substring(separatorIndex + 1);
+            } else {
+                placeholderKey = placeholderToken;
+                defaultValue = null;
+            }
+
+            final String replacement = values.containsKey(placeholderKey) ? values.get(placeholderKey) : defaultValue;
 
             if (replacement == null) {
                 throw new IllegalArgumentException(

--- a/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/structdefutil/LHStructDefPlaceholderTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/wfsdk/internal/structdefutil/LHStructDefPlaceholderTest.java
@@ -48,6 +48,12 @@ public class LHStructDefPlaceholderTest {
         public String street;
     }
 
+    @LHStructDef("${company:acme-default}-address")
+    @Getter
+    static class AddressWithDefault {
+        public String street;
+    }
+
     @Test
     public void shouldResolvePlaceholderInStructDefId() {
         LHStructDefType type = new LHStructDefType(Address.class, LHTypeAdapterRegistry.empty(), PLACEHOLDERS);
@@ -131,6 +137,13 @@ public class LHStructDefPlaceholderTest {
     }
 
     @Test
+    public void shouldUseDefaultValueWhenStructDefPlaceholderMissing() {
+        LHStructDefType type = new LHStructDefType(AddressWithDefault.class, LHTypeAdapterRegistry.empty(), Map.of());
+
+        assertThat(type.getStructDefId().getName()).isEqualTo("acme-default-address");
+    }
+
+    @Test
     public void shouldResolvePlaceholderInDeclareStructWithClass() {
         Workflow wf = Workflow.newWorkflow(
                 "placeholder-struct-wf", thread -> thread.declareStruct("my-address", Address.class), PLACEHOLDERS);
@@ -150,6 +163,18 @@ public class LHStructDefPlaceholderTest {
         VariableDef varDef = declaredVarDef(wf);
 
         assertThat(varDef.getTypeDef().getStructDefId().getName()).isEqualTo("acme-address");
+    }
+
+    @Test
+    public void shouldUseDefaultValueInDeclareStructWithStringNameWhenPlaceholderMissing() {
+        Workflow wf = Workflow.newWorkflow(
+                "placeholder-struct-default-name-wf",
+                thread -> thread.declareStruct("my-address", "${company:acme-default}-address"),
+                Map.of());
+
+        VariableDef varDef = declaredVarDef(wf);
+
+        assertThat(varDef.getTypeDef().getStructDefId().getName()).isEqualTo("acme-default-address");
     }
 
     private static VariableDef declaredVarDef(Workflow wf) {

--- a/sdk-java/src/test/java/io/littlehorse/sdk/worker/LHTaskWorkerTest.java
+++ b/sdk-java/src/test/java/io/littlehorse/sdk/worker/LHTaskWorkerTest.java
@@ -87,6 +87,15 @@ public class LHTaskWorkerTest {
     }
 
     @Test
+    public void shouldUseDefaultValueWhenPlaceholderKeyMissing() {
+        String taskDefName = "${defaultTaskName:default-task}";
+
+        LHTaskWorker task = new LHTaskWorker(new TaskWorker(), taskDefName, new LHConfig(), Map.of());
+
+        assertThat(task.getTaskDefName()).isEqualTo("default-task");
+    }
+
+    @Test
     public void shouldFailWithClearMessageWhenTaskDefIsNotRegistered() {
         LHConfig config = mock(LHConfig.class);
         LittleHorseBlockingStub grpcClient = mock(LittleHorseBlockingStub.class);
@@ -191,6 +200,34 @@ public class LHTaskWorkerTest {
         assertThat(request.getReturnType().getReturnType().getPrimitiveType()).isEqualTo(VariableType.STR);
         verify(grpcClient).putTaskDef(any(PutTaskDefRequest.class));
     }
+
+    @Test
+    public void shouldResolveTaskMethodWithDefaultPlaceholderValue() {
+        LHConfig config = mock(LHConfig.class);
+        when(config.getTypeAdapterRegistry()).thenReturn(LHTypeAdapterRegistry.empty());
+        LittleHorseBlockingStub grpcClient = mock(LittleHorseBlockingStub.class);
+        AtomicReference<PutTaskDefRequest> capturedRequest = new AtomicReference<>();
+
+        when(config.getBlockingStub()).thenReturn(grpcClient);
+        doAnswer(invocation -> {
+                    PutTaskDefRequest request = invocation.getArgument(0);
+                    capturedRequest.set(request);
+                    return TaskDef.newBuilder()
+                            .setId(TaskDefId.newBuilder()
+                                    .setName(request.getName())
+                                    .build())
+                            .build();
+                })
+                .when(grpcClient)
+                .putTaskDef(any(PutTaskDefRequest.class));
+
+        LHTaskWorker task = new LHTaskWorker(new TaskWorker(), "default-task", config, Map.of());
+        task.registerTaskDef();
+
+        PutTaskDefRequest request = capturedRequest.get();
+        assertThat(request.getName()).isEqualTo("default-task");
+        verify(grpcClient).putTaskDef(any(PutTaskDefRequest.class));
+    }
 }
 
 class TaskWorker {
@@ -222,6 +259,11 @@ class TaskWorker {
     @LHTaskMethod("${CLUSTER_NAME}")
     public String onlyWithPlaceHolder(String name) {
         return "task only with placeholder " + name;
+    }
+
+    @LHTaskMethod("${defaultTaskName:default-task}")
+    public String withDefaultPlaceholderInTaskName(String name) {
+        return "task with default placeholder " + name;
     }
 
     @LHTaskMethod("${taskName}")


### PR DESCRIPTION
This PR implements the feature request in #2449 by implementing default value support within placeholder template strings according to the format `${key:defaultValue}`.