### PR TITLE
fix(server): allow updating StructDef descriptions

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/structdef/StructDefModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/structdef/StructDefModel.java
@@ -26,6 +26,7 @@ public class StructDefModel extends MetadataGetable<StructDef> {
     @Setter
     private StructDefIdModel id;
 
+    @Getter
     @Setter
     private String description;
 

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
@@ -19,6 +19,7 @@ import io.littlehorse.server.streams.topology.core.ExecutionContext;
 import io.littlehorse.server.streams.topology.core.MetadataProcessorContext;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 public class PutStructDefRequestModel extends MetadataSubCommand<PutStructDefRequest> {
@@ -86,6 +87,14 @@ public class PutStructDefRequestModel extends MetadataSubCommand<PutStructDefReq
             spec.setId(new StructDefIdModel(name, 0));
         } else {
             if (InlineStructDefUtil.equals(spec.getStructDef(), latestVersion.getStructDef())) {
+                boolean descriptionChanged = !Objects.equals(description, latestVersion.getDescription());
+
+                if (!descriptionChanged) {
+                    return latestVersion.toProto().build();
+                }
+
+                latestVersion.setDescription(description);
+                metadataManager.put(latestVersion);
                 return latestVersion.toProto().build();
             }
 

--- a/server/src/test/java/e2e/StructDefLifecycleTest.java
+++ b/server/src/test/java/e2e/StructDefLifecycleTest.java
@@ -73,6 +73,40 @@ public class StructDefLifecycleTest {
     }
 
     @Test
+    void shouldUpdateDescriptionWithoutBumpingVersion() {
+        String structDefName = UUID.randomUUID().toString();
+        InlineStructDef schema = InlineStructDef.newBuilder()
+                .putFields(
+                        "model",
+                        StructFieldDef.newBuilder()
+                                .setFieldType(TypeDefinition.newBuilder().setPrimitiveType(VariableType.STR))
+                                .build())
+                .build();
+
+        client.putStructDef(PutStructDefRequest.newBuilder()
+                .setName(structDefName)
+                .setStructDef(schema)
+                .setDescription("Original description")
+                .build());
+
+        waitForStructDef(structDefName, 0);
+
+        StructDef result = client.putStructDef(PutStructDefRequest.newBuilder()
+                .setName(structDefName)
+                .setStructDef(schema)
+                .setDescription("Updated description")
+                .build());
+
+        // Version must not be bumped — only description changed
+        assertThat(result.getId().getVersion()).isEqualTo(0);
+        assertThat(result.getDescription()).isEqualTo("Updated description");
+
+        StructDef fetched = client.getStructDef(
+                StructDefId.newBuilder().setName(structDefName).setVersion(0).build());
+        assertThat(fetched.getDescription()).isEqualTo("Updated description");
+    }
+
+    @Test
     void shouldBumpVersionWhenPuttingCompatibleStructDefChanges() {
         client.putStructDef(PutStructDefRequest.newBuilder()
                 .setName("car-0")

--- a/server/src/test/java/e2e/StructDefLifecycleTest.java
+++ b/server/src/test/java/e2e/StructDefLifecycleTest.java
@@ -101,9 +101,13 @@ public class StructDefLifecycleTest {
         assertThat(result.getId().getVersion()).isEqualTo(0);
         assertThat(result.getDescription()).isEqualTo("Updated description");
 
-        StructDef fetched = client.getStructDef(
-                StructDefId.newBuilder().setName(structDefName).setVersion(0).build());
-        assertThat(fetched.getDescription()).isEqualTo("Updated description");
+        Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            StructDef fetched = client.getStructDef(StructDefId.newBuilder()
+                    .setName(structDefName)
+                    .setVersion(0)
+                    .build());
+            assertThat(fetched.getDescription()).isEqualTo("Updated description");
+        });
     }
 
     @Test


### PR DESCRIPTION
This PR adds logic to allow for updating an existing StructDef's description.