### PR TITLE
perf(server): Cache Micrometer counters in CommandProcessorMetrics

### DIFF
--- a/server-spotbugs-baseline.xml
+++ b/server-spotbugs-baseline.xml
@@ -10640,32 +10640,6 @@
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.LOCAL_NAME" value="trailer"/>
     <Property name="edu.umd.cs.findbugs.detect.DeadLocalStoreProperty.NO_LOADS" value="true"/>
   </BugInstance>
-  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="c22ef5474d8312d423a0012b0867ce85" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics.bindTo(MeterRegistry) may expose internal representation by storing an externally mutable object into CommandProcessorMetrics.registry</LongMessage>
-    <Class classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" primary="true">
-      <SourceLine classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" start="12" end="79" sourcefile="CommandProcessorMetrics.java" sourcepath="io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java" relSourcepath="src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java">
-        <Message>At CommandProcessorMetrics.java:[lines 12-79]</Message>
-      </SourceLine>
-      <Message>In class io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics</Message>
-    </Class>
-    <Method classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" name="bindTo" signature="(Lio/micrometer/core/instrument/MeterRegistry;)V" isStatic="false" primary="true">
-      <SourceLine classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" start="25" end="40" startBytecode="0" endBytecode="315" sourcefile="CommandProcessorMetrics.java" sourcepath="io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java" relSourcepath="src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java"/>
-      <Message>In method io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics.bindTo(MeterRegistry)</Message>
-    </Method>
-    <Field classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" name="registry" signature="Lio/micrometer/core/instrument/MeterRegistry;" isStatic="false" primary="true">
-      <SourceLine classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" sourcefile="CommandProcessorMetrics.java" sourcepath="io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java" relSourcepath="src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java">
-        <Message>In CommandProcessorMetrics.java</Message>
-      </SourceLine>
-      <Message>Field io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics.registry</Message>
-    </Field>
-    <LocalVariable name="registry" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
-      <Message>Local variable named registry</Message>
-    </LocalVariable>
-    <SourceLine classname="io.littlehorse.server.monitoring.metrics.CommandProcessorMetrics" primary="true" start="25" end="25" startBytecode="2" endBytecode="2" sourcefile="CommandProcessorMetrics.java" sourcepath="io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java" relSourcepath="src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java">
-      <Message>At CommandProcessorMetrics.java:[line 25]</Message>
-    </SourceLine>
-  </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="38d81174438b0fb687dca4137c539659" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new io.littlehorse.server.monitoring.metrics.InstanceState(KafkaStreams, BackendInternalComms) may expose internal representation by storing an externally mutable object into InstanceState.streams</LongMessage>

--- a/server/src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java
+++ b/server/src/main/java/io/littlehorse/server/monitoring/metrics/CommandProcessorMetrics.java
@@ -4,8 +4,11 @@ import io.littlehorse.common.model.corecommand.CommandModel;
 import io.littlehorse.common.model.metadatacommand.MetadataCommandModel;
 import io.littlehorse.common.proto.Command;
 import io.littlehorse.common.proto.MetadataCommand;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.EnumMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,63 +21,65 @@ public class CommandProcessorMetrics implements MeterBinder {
     static final String METRIC_NAME = "lh.commands.processed";
     static final String METRIC_NAME_BY_TYPE = "lh.subcommands.processed";
     static final String COMMAND_TYPE_TAG = "type";
-    private MeterRegistry registry;
+
+    private final Map<Command.CommandCase, Counter> coreCountersByType = new EnumMap<>(Command.CommandCase.class);
+    private final Map<MetadataCommand.MetadataCommandCase, Counter> metadataCountersByType =
+            new EnumMap<>(MetadataCommand.MetadataCommandCase.class);
+
+    private volatile Counter coreCommandCounter;
+    private volatile Counter metadataCommandCounter;
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        this.registry = registry;
-        registry.counter(METRIC_NAME, COMMAND_TYPE_TAG, CORE_COMMAND_TYPE);
-        registry.counter(METRIC_NAME, COMMAND_TYPE_TAG, METADATA_COMMAND_TYPE);
         // Register core subcommands
         for (Command.CommandCase commandType : Command.CommandCase.values()) {
             if (commandType != Command.CommandCase.COMMAND_NOT_SET) {
-                registry.counter(METRIC_NAME_BY_TYPE, COMMAND_TYPE_TAG, commandType.name());
+                coreCountersByType.put(
+                        commandType, registry.counter(METRIC_NAME_BY_TYPE, COMMAND_TYPE_TAG, commandType.name()));
             }
         }
         // Register metadata subcommands
         for (MetadataCommand.MetadataCommandCase metadataCommandType : MetadataCommand.MetadataCommandCase.values()) {
             if (metadataCommandType != MetadataCommand.MetadataCommandCase.METADATACOMMAND_NOT_SET) {
-                registry.counter(METRIC_NAME_BY_TYPE, COMMAND_TYPE_TAG, metadataCommandType.name());
+                metadataCountersByType.put(
+                        metadataCommandType,
+                        registry.counter(METRIC_NAME_BY_TYPE, COMMAND_TYPE_TAG, metadataCommandType.name()));
             }
         }
+        // Assigned last: these act as the "metrics are initialized" flag for observe()
+        coreCommandCounter = registry.counter(METRIC_NAME, COMMAND_TYPE_TAG, CORE_COMMAND_TYPE);
+        metadataCommandCounter = registry.counter(METRIC_NAME, COMMAND_TYPE_TAG, METADATA_COMMAND_TYPE);
     }
 
     public void observe(CommandModel command) {
-        if (registry == null) {
-            logger.warn("Ignoring command: " + command.getType().name() + " because metrics are initialized yet.");
+        Counter total = coreCommandCounter;
+        if (total == null) {
+            logger.warn("Ignoring command: {} because metrics are not initialized yet.", command.getType());
             return;
         }
-        if (command.getType() != Command.CommandCase.COMMAND_NOT_SET) {
-            // Increase both the general counter and the counter for the specific command type
-            registry.get(METRIC_NAME)
-                    .tag(COMMAND_TYPE_TAG, CORE_COMMAND_TYPE)
-                    .counter()
-                    .increment();
-            registry.counter(
-                            METRIC_NAME_BY_TYPE,
-                            COMMAND_TYPE_TAG,
-                            command.getType().name())
-                    .increment();
+        // Increase both the general counter and the counter for the specific command type
+        Counter byType = coreCountersByType.get(command.getType());
+        if (byType == null) {
+            // COMMAND_NOT_SET
+            return;
         }
+        total.increment();
+        byType.increment();
     }
 
     public void observe(MetadataCommandModel metadataCommand) {
-        if (registry == null) {
-            logger.warn(
-                    "Ignoring command: " + metadataCommand.getType().name() + " because metrics are initialized yet.");
+        Counter total = metadataCommandCounter;
+        if (total == null) {
+            logger.warn("Ignoring command: {} because metrics are not initialized yet.", metadataCommand.getType());
             return;
         }
-        if (metadataCommand.getType() != MetadataCommand.MetadataCommandCase.METADATACOMMAND_NOT_SET) {
-            // Increase both the general counter and the counter for the specific command type
-            registry.get(METRIC_NAME)
-                    .tag(COMMAND_TYPE_TAG, METADATA_COMMAND_TYPE)
-                    .counter()
-                    .increment();
-            registry.counter(
-                            METRIC_NAME_BY_TYPE,
-                            COMMAND_TYPE_TAG,
-                            metadataCommand.getType().name())
-                    .increment();
+        // Increase both the general counter and the counter for the specific command type
+        Counter byType = metadataCountersByType.get(metadataCommand.getType());
+        if (byType == null) {
+            // METADATACOMMAND_NOT_SET
+            return;
         }
+        total.increment();
+        byType.increment();
     }
 }


### PR DESCRIPTION
Profiling the server's command processing path showed that a significant
share of time was being spent inside `CommandProcessorMetrics.observe(...)`,
specifically in the meter-resolution calls. 

Before the server was doing a `registry.get(METRIC_NAME).tag(COMMAND_TYPE_TAG, ...).counter()` — Micrometer's
   `RequiredSearch` is **not** a hash lookup. It iterates over *every* meter
   registered in the `MeterRegistry` and filters by name and tags. That's an O(n) scan
   executed once per command.

This PR now resolve the `Counter` instances once, at `bindTo(...)` time, and reuse the
references:

- The two aggregate `lh.commands.processed` counters (`core` / `metadata`) are
  held in instance field.
- The per-subcommand `lh.subcommands.processed` counters are held in `EnumMap`s
  keyed by `Command.CommandCase` / `MetadataCommand.MetadataCommandCase`, so
  lookup is an array index.

`observe(...)` is now an `EnumMap` lookup plus two `increment()` calls (a
`DoubleAdder` add), instead of a full registry scan and an allocation.


## Testing

- All 10 existing tests in `CommandProcessorMetricsTest` pass unchanged,
  including `shouldNotThrowWhenObserveIsCalledBeforeBindTo`,
  `shouldIncrementBothGeneralAndTagSpecificMetrics`, and the Prometheus
  `scrape()` assertions — confirming the emitted metrics are byte-for-byte
  identical.