### PR TITLE
fix(server): bump StructDef version when description changes

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
@@ -86,19 +86,17 @@ public class PutStructDefRequestModel extends MetadataSubCommand<PutStructDefReq
         if (latestVersion == null) {
             spec.setId(new StructDefIdModel(name, 0));
         } else {
-            if (InlineStructDefUtil.equals(spec.getStructDef(), latestVersion.getStructDef())) {
-                boolean descriptionChanged = !Objects.equals(description, latestVersion.getDescription());
+            boolean schemaChanged = !InlineStructDefUtil.equals(spec.getStructDef(), latestVersion.getStructDef());
+            boolean descriptionChanged = !Objects.equals(description, latestVersion.getDescription());
 
-                if (!descriptionChanged) {
-                    return latestVersion.toProto().build();
-                }
-
-                spec.setId(latestVersion.getObjectId().bumpVersion());
-                metadataManager.put(spec);
-                return spec.toProto().build();
+            if (!schemaChanged && !descriptionChanged) {
+                return latestVersion.toProto().build();
             }
 
-            verifyUpdateType(allowedUpdateType, spec.getStructDef(), latestVersion.getStructDef());
+            if (schemaChanged) {
+                verifyUpdateType(allowedUpdateType, spec.getStructDef(), latestVersion.getStructDef());
+            }
+
             spec.setId(latestVersion.getObjectId().bumpVersion());
         }
 

--- a/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/metadatacommand/subcommand/PutStructDefRequestModel.java
@@ -93,9 +93,9 @@ public class PutStructDefRequestModel extends MetadataSubCommand<PutStructDefReq
                     return latestVersion.toProto().build();
                 }
 
-                latestVersion.setDescription(description);
-                metadataManager.put(latestVersion);
-                return latestVersion.toProto().build();
+                spec.setId(latestVersion.getObjectId().bumpVersion());
+                metadataManager.put(spec);
+                return spec.toProto().build();
             }
 
             verifyUpdateType(allowedUpdateType, spec.getStructDef(), latestVersion.getStructDef());

--- a/server/src/test/java/e2e/StructDefLifecycleTest.java
+++ b/server/src/test/java/e2e/StructDefLifecycleTest.java
@@ -73,7 +73,7 @@ public class StructDefLifecycleTest {
     }
 
     @Test
-    void shouldUpdateDescriptionWithoutBumpingVersion() {
+    void shouldUpdateDescriptionByBumpingVersion() {
         String structDefName = UUID.randomUUID().toString();
         InlineStructDef schema = InlineStructDef.newBuilder()
                 .putFields(
@@ -97,14 +97,17 @@ public class StructDefLifecycleTest {
                 .setDescription("Updated description")
                 .build());
 
-        // Version must not be bumped — only description changed
-        assertThat(result.getId().getVersion()).isEqualTo(0);
+        assertThat(result.getId().getVersion()).isEqualTo(1);
         assertThat(result.getDescription()).isEqualTo("Updated description");
+
+        StructDef originalVersion = client.getStructDef(
+                StructDefId.newBuilder().setName(structDefName).setVersion(0).build());
+        assertThat(originalVersion.getDescription()).isEqualTo("Original description");
 
         Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
             StructDef fetched = client.getStructDef(StructDefId.newBuilder()
                     .setName(structDefName)
-                    .setVersion(0)
+                    .setVersion(1)
                     .build());
             assertThat(fetched.getDescription()).isEqualTo("Updated description");
         });


### PR DESCRIPTION
This PR bumps the StructDef version when the description changes, making StructDef descriptions behave more similarly to other schema registries.