### PR TITLE
test(server): remove race condition in RejectMixedTypedArray e2e

### DIFF
--- a/server/src/test/java/e2e/ArraysTest.java
+++ b/server/src/test/java/e2e/ArraysTest.java
@@ -9,6 +9,7 @@ import io.littlehorse.common.LHServerConfig;
 import io.littlehorse.sdk.common.LHLibUtil;
 import io.littlehorse.sdk.common.adapter.LHTypeAdapterRegistry;
 import io.littlehorse.sdk.common.proto.Array;
+import io.littlehorse.sdk.common.proto.GetLatestWfSpecRequest;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.RunWfRequest;
@@ -27,8 +28,11 @@ import io.littlehorse.sdk.worker.LHType;
 import io.littlehorse.test.LHTest;
 import io.littlehorse.test.LHWorkflow;
 import io.littlehorse.test.WorkflowVerifier;
+import io.littlehorse.test.exception.LHTestExceptionUtil;
+import java.time.Duration;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 @LHTest
@@ -87,11 +91,8 @@ public class ArraysTest {
 
     @Test
     public void shouldRejectMixedTypedArrayInputOnRunWf() {
-        // Ensure WfSpec is registered
-        workflowVerifier
-                .prepareRun(emptyArrayWf)
-                .waitForStatus(LHStatus.COMPLETED)
-                .start();
+        emptyArrayWf.registerWfSpec(client);
+        waitForWfSpec(emptyArrayWf.getName());
 
         String wfRunId = UUID.randomUUID().toString();
 
@@ -482,5 +483,15 @@ public class ArraysTest {
     @LHType(isLHArray = true)
     public Long[] produceArray() {
         return new Long[] {1L, 2L, 3L};
+    }
+
+    private void waitForWfSpec(String name) {
+        Awaitility.await()
+                .atMost(Duration.ofMillis(500))
+                .ignoreExceptionsMatching(exn -> LHTestExceptionUtil.isNotFoundException(exn))
+                .until(() -> {
+                    client.getLatestWfSpec(GetLatestWfSpecRequest.newBuilder().setName(name).build());
+                    return true;
+                });
     }
 }

--- a/server/src/test/java/e2e/ArraysTest.java
+++ b/server/src/test/java/e2e/ArraysTest.java
@@ -490,7 +490,8 @@ public class ArraysTest {
                 .atMost(Duration.ofMillis(500))
                 .ignoreExceptionsMatching(exn -> LHTestExceptionUtil.isNotFoundException(exn))
                 .until(() -> {
-                    client.getLatestWfSpec(GetLatestWfSpecRequest.newBuilder().setName(name).build());
+                    client.getLatestWfSpec(
+                            GetLatestWfSpecRequest.newBuilder().setName(name).build());
                     return true;
                 });
     }


### PR DESCRIPTION
This PR makes an improvement to the `shouldRejectMixedTypedArrayInputOnRunWf` e2e test that will hopefully resolve the flakiness of this test.

Previously, the test was designed to run a `WfRun` and verify its completeness before continuing. I want to test if this was what caused the flakiness by changing the semantics of this test to instead register the WfSpec and then busy wait for 500ms to see if the `WfSpec` was registered. 