### PR TITLE
fix(dashboard): enforce required variables in the execute wfrun form

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/__test__/requiredVariables.test.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/__test__/requiredVariables.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ThreadVarDef, VariableType, WfSpec } from 'littlehorse-client/proto'
+import React, { createRef } from 'react'
+import { FormValues, WfRunForm, WfRunFormSubmitMeta } from '../WfRunForm'
+
+jest.mock('../components/StructDefGroup', () => ({ StructDefGroup: () => null }))
+
+const primitiveVariable = (name: string, primitiveType: VariableType, required: boolean): ThreadVarDef =>
+  ({
+    varDef: {
+      name,
+      typeDef: { definedType: { oneofKind: 'primitiveType', primitiveType }, masked: false },
+      jsonIndexes: [],
+    },
+    required,
+    searchable: false,
+    jsonIndexes: [],
+  }) as unknown as ThreadVarDef
+
+const arrayVariable = (name: string, required: boolean): ThreadVarDef =>
+  ({
+    varDef: {
+      name,
+      typeDef: {
+        definedType: {
+          oneofKind: 'inlineArrayDef',
+          inlineArrayDef: {
+            elementType: { definedType: { oneofKind: 'primitiveType', primitiveType: VariableType.STR } },
+          },
+        },
+        masked: false,
+      },
+      jsonIndexes: [],
+    },
+    required,
+    searchable: false,
+    jsonIndexes: [],
+  }) as unknown as ThreadVarDef
+
+const wfSpec = { id: { name: 'test-wf', majorVersion: 0, revision: 0 } } as unknown as WfSpec
+
+const renderForm = (variables: ThreadVarDef[]) => {
+  const onSubmit = jest.fn<void, [FormValues, WfRunFormSubmitMeta]>()
+  const formRef = createRef<HTMLFormElement>()
+  const { container } = render(
+    <WfRunForm wfSpecVariables={variables} wfSpec={wfSpec} onSubmit={onSubmit} ref={formRef} />
+  )
+  const fill = (name: string, value: string) =>
+    fireEvent.change(container.querySelector(`#${name}`)!, { target: { value } })
+  return { onSubmit, formRef, fill }
+}
+
+/**
+ * A variable flagged `required` in the WfSpec must never reach the server as an empty value.
+ *
+ * The `Required` badge and the validation rule are driven by two different props on FormField
+ * (`protoRequired` / `formRequired`), so they can drift apart silently: in #2459 every primitive
+ * was labelled `Required` yet submitted `""` without complaint, while TIMESTAMP and inline
+ * containers — which build their rule from a prop that was actually passed — kept working.
+ */
+describe('required WfSpec variables', () => {
+  const primitives: [string, VariableType][] = [
+    ['STR', VariableType.STR],
+    ['BOOL', VariableType.BOOL],
+    ['INT', VariableType.INT],
+    ['DOUBLE', VariableType.DOUBLE],
+    ['BYTES', VariableType.BYTES],
+    ['WF_RUN_ID', VariableType.WF_RUN_ID],
+    ['TIMESTAMP', VariableType.TIMESTAMP],
+    ['JSON_OBJ', VariableType.JSON_OBJ],
+    ['JSON_ARR', VariableType.JSON_ARR],
+  ]
+
+  it.each(primitives)('blocks submission when a required %s variable is blank', async (_label, primitiveType) => {
+    const { onSubmit, formRef } = renderForm([primitiveVariable('needs-value', primitiveType, true)])
+
+    fireEvent.submit(formRef.current!)
+
+    await waitFor(() => expect(screen.getByText('needs-value is required')).toBeInTheDocument())
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('blocks submission when a required inline container variable is blank', async () => {
+    const { onSubmit, formRef } = renderForm([arrayVariable('needs-list', true)])
+
+    fireEvent.submit(formRef.current!)
+
+    await waitFor(() => expect(screen.getByText('needs-list is required')).toBeInTheDocument())
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits once every required variable has a value', async () => {
+    const { onSubmit, formRef, fill } = renderForm([
+      primitiveVariable('needs-value', VariableType.STR, true),
+      primitiveVariable('optional-value', VariableType.STR, false),
+    ])
+
+    fill('needs-value', 'jake')
+    fireEvent.submit(formRef.current!)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText('needs-value is required')).not.toBeInTheDocument()
+    expect(onSubmit.mock.calls[0][0]['needs-value']).toBe('jake')
+  })
+
+  it('does not block submission on blank optional variables', async () => {
+    const { onSubmit, formRef } = renderForm([
+      primitiveVariable('optional-str', VariableType.STR, false),
+      primitiveVariable('optional-int', VariableType.INT, false),
+    ])
+
+    fireEvent.submit(formRef.current!)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText('optional-str is required')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/VariableFormField.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Forms/components/VariableFormField.tsx
@@ -120,6 +120,7 @@ const VariableFormField: FC<VariableFormFieldProps> = ({ variable }) => {
         inputMode={inputMode}
         validate={validate}
         protoRequired={variable.required}
+        formRequired={variable.required}
         accessLevel={variable.accessLevel}
         variableType={definedType.primitiveType}
         masked={varDef.typeDef?.masked}

--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/__test__/ExecuteWorkflowRun.test.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Modals/__test__/ExecuteWorkflowRun.test.tsx
@@ -146,8 +146,8 @@ describe('ExecuteWorkflowRun variables payload', () => {
     expect((await sentVariables())['greeting'].value).toEqual({ oneofKind: 'str', str: 'howdy' })
   })
 
-  it('still sends a required variable the user leaves blank', async () => {
-    const { fill, submit, sentVariables } = setup([
+  it('blocks submit when a required variable is left blank', async () => {
+    const { fill, submit } = setup([
       primitive('required-str', VariableType.STR, true),
       primitive('required-blank', VariableType.STR, true),
     ])
@@ -155,8 +155,23 @@ describe('ExecuteWorkflowRun variables payload', () => {
     fill('required-str', 'req')
     submit()
 
+    await waitFor(() => expect(document.body.textContent).toContain('required-blank is required'))
+    expect(runWfSpec).not.toHaveBeenCalled()
+  })
+
+  it('sends a required variable the user left at its WfSpec default', async () => {
+    const { fill, submit, sentVariables } = setup([
+      primitive('required-str', VariableType.STR, true),
+      primitive('required-defaulted', VariableType.STR, true, {
+        defaultValue: { value: { oneofKind: 'str', str: 'from-wfspec' } },
+      }),
+    ])
+
+    fill('required-str', 'req')
+    submit()
+
     const variables = await sentVariables()
-    expect(variables['required-blank'].value).toEqual({ oneofKind: 'str', str: '' })
+    expect(variables['required-defaulted'].value).toEqual({ oneofKind: 'str', str: 'from-wfspec' })
   })
 
   it('sends JSON and Map values entered in a textarea', async () => {


### PR DESCRIPTION
Fixes #2459.

## Problem

A variable marked `required` in the WfSpec was labelled `Required` in the **Execute WfRun** modal but had no validation rule attached. Clicking **Execute Workflow** with the field blank submitted the form and started a WfRun with an empty value:

```json
"variables": { "user-id": { "value": { "oneofKind": "str", "str": "" } } }
```

## Cause

`FormField` drives the badge from `protoRequired` and the react-hook-form rule from `formRequired`:

```tsx
{...register(id, { required: formRequired ? `${label} is required` : false, validate })}
```

The primitive branch of `VariableFormField` only passed `protoRequired`, so every `STR` / `INT` / `DOUBLE` / `BOOL` / `BYTES` / `WF_RUN_ID` / `JSON_OBJ` / `JSON_ARR` field registered with `required: false`. `TimestampVariableField`, `ContainerVariableField` and `StructDefGroup` build their rule from a prop that is actually passed, which is why those kept validating — the same `required` flag behaved differently depending on the variable's type.

Regressed in #1933, which replaced `FormInput` (that component registered the rule straight off the WfSpec flag). Shipping since v1.0.0.

## Fix

One line — pass the flag through in the primitive branch:

```tsx
protoRequired={variable.required}
formRequired={variable.required}
```

## Tests

`Forms/__test__/requiredVariables.test.tsx` covers every primitive type plus an inline container: a blank required field must block `onSubmit` and surface `<name> is required`, blank optional fields must not, and a filled form must still submit. Reverting the one-line change fails 8 of the 12.

One existing case in `ExecuteWorkflowRun.test.tsx` asserted the old behaviour (*"still sends a required variable the user leaves blank"* → `str: ""`). It now asserts that the submit is blocked. Its original intent — required variables bypass the `dirtyFields` filter — is preserved by a new case covering a required variable left at its WfSpec default, which is still sent.

Full dashboard suite: 197 passed / 37 suites.

## Verification

Verified against a local `lh-standalone:master` with a `variables-example` WfSpec (`user-id` STR required, `user-obj` JSON_OBJ, `age` INT) driven by Playwright:

- blank submit → `user-id is required`, modal stays open, **zero** `RunWfRequest`s leave the browser
- `user-obj` / `age` still submit blank
- filling `user-id` → payload carries `"str":"jake"` and the WfRun reaches `COMPLETED`


### Before


https://github.com/user-attachments/assets/e9e7141d-04c2-4549-a12e-63da8853ecf0


Blank `user-id` (tagged `Required`) submits, the `Workflow has been executed` toast fires, and the WfRun lands in `EXCEPTION` because `fetch-user` received `""`:

<!-- drop 1-bug-required-str-not-enforced.mp4 here -->

### After


https://github.com/user-attachments/assets/f321dbfd-f5c5-479a-8fde-7d0a832c641f



The same submit is blocked with `user-id is required`; filling it in runs the workflow to `COMPLETED`:

<!-- drop 3-after-fix.mp4 here -->
