### PR TITLE
fix(dashboard): default WfRun diagram to the entrypoint threadrun

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Diagram.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/(diagram)/components/Diagram.tsx
@@ -58,10 +58,10 @@ const threadFromUrl = (
     const tr = wfRun.threadRuns.find(t => t.number === threadRunNumber)
     if (tr) return { name: tr.threadSpecName, number: tr.number }
   }
-  const greatest = wfRun.threadRuns.find(tr => tr.number === wfRun.greatestThreadrunNumber)
+  const entrypoint = wfRun.threadRuns.find(tr => tr.number === 0)
   return {
-    name: greatest?.threadSpecName ?? spec.entrypointThreadName,
-    number: wfRun.greatestThreadrunNumber ?? 0,
+    name: entrypoint?.threadSpecName ?? spec.entrypointThreadName,
+    number: entrypoint?.number ?? 0,
   }
 }
 


### PR DESCRIPTION
Opening a WfRun lands on the last spawned threadrun instead of the entrypoint. On a workflow with five child threads every run opens on `check-resource-availability #5`, so the diagram, tab and variables panel all start on a child thread and you have to click back to `entrypoint #0` each time.

`threadFromUrl` falls back to `greatestThreadrunNumber` when the URL has no `threadRunNumber`, so on any workflow that spawns threads the entrypoint never gets picked. The `?? spec.entrypointThreadName` next to it only fires when that lookup fails, so entrypoint looks like it was the intent.

Now defaults to threadrun 0.
