### PR TITLE
perf(server): warm RocksDB block cache before forwarding bulk WfRun deletes

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/bulkjob/BulkDeleteWfRunModel.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/bulkjob/BulkDeleteWfRunModel.java
@@ -103,6 +103,7 @@ public class BulkDeleteWfRunModel extends LHSerializable<BulkDeleteWfRun> {
         Date lastSeenTimestamp = shardCursor.getLastSeenTimestamp();
         InternalScanPb.TagScanPb tagScan = buildScan();
         String startKey = resumeFromKey.isBlank() ? startKey(tagScan) : resumeFromKey;
+        ReadOnlyGetableManager getableManager = new ReadOnlyGetableManager(coreStore);
         try (LHKeyValueIterator<Tag> range = coreStore.range(startKey, endKey(tagScan), Tag.class)) {
             while (range.hasNext()) {
                 if (outOfBudget.getAsBoolean()) {
@@ -116,7 +117,6 @@ public class BulkDeleteWfRunModel extends LHSerializable<BulkDeleteWfRun> {
                         (WfRunIdModel) WfRunIdModel.fromString(tag.getDescribedObjectId(), WfRunIdModel.class);
                 // The resume key is included in the range; it was already processed, so skip it.
                 if (!resumeFromKey.isBlank() && tag.getStoreKey().equals(resumeFromKey)) {
-                    ReadOnlyGetableManager getableManager = new ReadOnlyGetableManager(coreStore);
                     WfRunModel wfRunModel = getableManager.get(wfRunIdToDelete);
                     if (wfRunModel != null) {
                         // Previous delete not processed yet — back off, keep scanCompleted == false,
@@ -125,6 +125,10 @@ public class BulkDeleteWfRunModel extends LHSerializable<BulkDeleteWfRun> {
                     }
                     continue;
                 }
+                // Point-get the WfRun to pull its `wrg/<wfRunId>/` block(s) into the RocksDB block cache.
+                // All of a WfRun's Getables share this prefix, so the delete command's prefix scan
+                // mostly hits cache.
+                getableManager.get(wfRunIdToDelete);
                 DeleteWfRunRequest delete = DeleteWfRunRequest.newBuilder()
                         .setId(wfRunIdToDelete.toProto())
                         .build();


### PR DESCRIPTION
`BulkDeleteWfRunModel.process` forwards multiple `InternalDeleteWfRunRequestModel` when processing bulk wfrun deletes. 