### PR TITLE
fix(dashboard): end the keycloak session when signing out

### DIFF
--- a/dashboard/src/app/(authenticated)/[tenantId]/components/Principal.tsx
+++ b/dashboard/src/app/(authenticated)/[tenantId]/components/Principal.tsx
@@ -14,6 +14,19 @@ import { FC } from 'react'
 export const Principal: FC = () => {
   const { user } = useWhoAmI()
 
+  const handleSignOut = async () => {
+    let logoutUrl: string | null = null
+
+    try {
+      const response = await fetch('/api/auth/federated-logout')
+      if (response.ok) logoutUrl = (await response.json()).url
+    } catch {}
+
+    await signOut({ redirect: !logoutUrl })
+
+    if (logoutUrl) window.location.href = logoutUrl
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="inline-flex w-full justify-center gap-x-1.5 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm">
@@ -24,7 +37,7 @@ export const Principal: FC = () => {
       <DropdownMenuContent className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
         <DropdownMenuLabel>{user?.name}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => signOut()} className="block w-full px-4 py-2 text-left text-sm">
+        <DropdownMenuItem onClick={handleSignOut} className="block w-full px-4 py-2 text-left text-sm">
           Sign out
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/dashboard/src/app/api/auth/[...nextauth]/authOptions.ts
+++ b/dashboard/src/app/api/auth/[...nextauth]/authOptions.ts
@@ -42,10 +42,4 @@ export const authOptions: AuthOptions = {
       }
     },
   },
-  events: {
-    signOut: async ({ token }: any) => {
-      const url = `${process.env.KEYCLOAK_ISSUER_URI}/protocol/openid-connect/logout?id_token_hint=${token.idToken}`
-      await fetch(url, { method: 'GET', headers: { Accept: 'application/json' } })
-    },
-  },
 }

--- a/dashboard/src/app/api/auth/federated-logout/__test__/route.test.ts
+++ b/dashboard/src/app/api/auth/federated-logout/__test__/route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+import { getToken } from 'next-auth/jwt'
+import { NextRequest } from 'next/server'
+import { GET } from '../route'
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }))
+
+const mockedGetToken = jest.mocked(getToken)
+
+const request = () => new NextRequest('http://localhost:3000/api/auth/federated-logout')
+
+const call = async () => (await GET(request())).json()
+
+describe('federated logout', () => {
+  const env = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    process.env = {
+      ...env,
+      KEYCLOAK_ISSUER_URI: 'http://keycloak:8888/realms/lh',
+      NEXTAUTH_URL: 'http://localhost:3000',
+    }
+  })
+
+  afterAll(() => {
+    process.env = env
+  })
+
+  it('sends the browser to the provider so its SSO cookies are cleared', async () => {
+    mockedGetToken.mockResolvedValue({ idToken: 'an-id-token' })
+
+    const { url } = await call()
+    const logout = new URL(url)
+
+    expect(logout.origin + logout.pathname).toBe('http://keycloak:8888/realms/lh/protocol/openid-connect/logout')
+    expect(logout.searchParams.get('id_token_hint')).toBe('an-id-token')
+    expect(logout.searchParams.get('post_logout_redirect_uri')).toBe('http://localhost:3000/api/auth/signin')
+  })
+
+  it('does nothing when authentication is disabled', async () => {
+    delete process.env.KEYCLOAK_ISSUER_URI
+    mockedGetToken.mockResolvedValue({ idToken: 'an-id-token' })
+
+    await expect(call()).resolves.toEqual({ url: null })
+  })
+
+  it('does nothing when the session has no id token', async () => {
+    mockedGetToken.mockResolvedValue({})
+
+    await expect(call()).resolves.toEqual({ url: null })
+  })
+
+  it('does nothing when there is no session at all', async () => {
+    mockedGetToken.mockResolvedValue(null)
+
+    await expect(call()).resolves.toEqual({ url: null })
+  })
+})

--- a/dashboard/src/app/api/auth/federated-logout/route.ts
+++ b/dashboard/src/app/api/auth/federated-logout/route.ts
@@ -1,0 +1,21 @@
+import { getToken } from 'next-auth/jwt'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+  const issuer = process.env.KEYCLOAK_ISSUER_URI
+
+  if (!issuer) return NextResponse.json({ url: null })
+
+  const token = await getToken({ req: request })
+
+  if (!token?.idToken) return NextResponse.json({ url: null })
+
+  const logoutUrl = new URL(`${issuer}/protocol/openid-connect/logout`)
+  logoutUrl.searchParams.set('id_token_hint', token.idToken)
+  logoutUrl.searchParams.set(
+    'post_logout_redirect_uri',
+    `${process.env.NEXTAUTH_URL ?? request.nextUrl.origin}/api/auth/signin`
+  )
+
+  return NextResponse.json({ url: logoutUrl.toString() })
+}

--- a/dashboard/src/types/next-auth.d.ts
+++ b/dashboard/src/types/next-auth.d.ts
@@ -5,11 +5,13 @@ declare module 'next-auth/jwt' {
   interface JWT {
     accessToken?: string
     expiresAt?: number
+    idToken?: string
   }
 }
 
 declare module 'next-auth' {
   interface Session {
     accessToken: string
+    idToken?: string
   }
 }


### PR DESCRIPTION
Sign out now redirects the browser through Keycloak's end-session endpoint so Keycloak clears its own SSO cookies, instead of calling that endpoint from the server where it cannot.

Adds an `/api/auth/federated-logout` route that builds the logout URL from the session's ID token, and tests for it.