### PR TITLE
feat(server): add Map comparison logic, ignore entry order

### DIFF
--- a/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/node/Comparer.java
+++ b/server/src/main/java/io/littlehorse/common/model/getable/global/wfspec/node/Comparer.java
@@ -6,7 +6,9 @@ import io.littlehorse.common.model.getable.core.variable.MapModel;
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.common.util.LHUtil;
 import io.littlehorse.sdk.common.proto.VariableValue.ValueCase;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -18,6 +20,10 @@ public class Comparer {
             if (right.getVal() == null && left.getVal() != null) return 1;
             if (right.getVal() == null && left.getVal() == null) return 0;
 
+            if (left.getValueType() == ValueCase.MAP && right.getValueType() == ValueCase.MAP) {
+                return mapsEqual(left.getMap(), right.getMap()) ? 0 : 1;
+            }
+
             @SuppressWarnings("all")
             int result = ((Comparable) left.getVal()).compareTo((Comparable) right.getVal());
 
@@ -25,6 +31,24 @@ public class Comparer {
         } catch (Exception exn) {
             throw new LHVarSubError(exn, "Failed comparing the provided values.");
         }
+    }
+
+    private static boolean mapsEqual(MapModel left, MapModel right) throws LHVarSubError {
+        List<MapModel.MapEntryModel> leftEntries = left.getEntries();
+        List<MapModel.MapEntryModel> rightEntries = right.getEntries();
+        if (leftEntries.size() != rightEntries.size()) return false;
+
+        Map<VariableValueModel, VariableValueModel> rightValuesByKey = new HashMap<>();
+        for (MapModel.MapEntryModel rightEntry : rightEntries) {
+            if (rightValuesByKey.containsKey(rightEntry.getKey())) return false;
+            rightValuesByKey.put(rightEntry.getKey(), rightEntry.getValue());
+        }
+
+        for (MapModel.MapEntryModel leftEntry : leftEntries) {
+            VariableValueModel rightValue = rightValuesByKey.remove(leftEntry.getKey());
+            if (rightValue == null || compare(leftEntry.getValue(), rightValue) != 0) return false;
+        }
+        return true;
     }
 
     public static boolean contains(VariableValueModel left, VariableValueModel right) throws LHVarSubError {

--- a/server/src/test/java/e2e/MapsTest.java
+++ b/server/src/test/java/e2e/MapsTest.java
@@ -7,9 +7,13 @@ import e2e.Struct.Person;
 import e2e.Struct.PhoneNumbers;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.littlehorse.sdk.common.LHLibUtil;
+import io.littlehorse.sdk.common.adapter.LHTypeAdapterRegistry;
+import io.littlehorse.sdk.common.proto.InlineMapDef;
 import io.littlehorse.sdk.common.proto.LHStatus;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc.LittleHorseBlockingStub;
 import io.littlehorse.sdk.common.proto.RunWfRequest;
+import io.littlehorse.sdk.common.proto.TypeDefinition;
 import io.littlehorse.sdk.common.proto.VariableType;
 import io.littlehorse.sdk.common.proto.VariableValue;
 import io.littlehorse.sdk.common.proto.VariableValue.ValueCase;
@@ -26,6 +30,7 @@ import io.littlehorse.test.LHWorkflow;
 import io.littlehorse.test.WithStructDefs;
 import io.littlehorse.test.WorkflowVerifier;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -87,6 +92,9 @@ public class MapsTest {
 
     @LHWorkflow("map-nullable-wf")
     private Workflow mapNullableWf;
+
+    @LHWorkflow("map-equality-wf")
+    private Workflow mapEqualityWf;
 
     private LittleHorseBlockingStub client;
     private WorkflowVerifier workflowVerifier;
@@ -229,6 +237,40 @@ public class MapsTest {
                                     .getStr())
                             .isEqualTo("null-value");
                 })
+                .start();
+    }
+
+    @Test
+    public void shouldTreatReorderedMapEntriesAsEqualInWorkflow() throws Exception {
+        Map<String, Long> left = new LinkedHashMap<>();
+        left.put("first", 1L);
+        left.put("second", 2L);
+        Map<String, Long> right = new LinkedHashMap<>();
+        right.put("second", 2L);
+        right.put("first", 1L);
+
+        workflowVerifier
+                .prepareRun(mapEqualityWf, Arg.of("left", nativeMap(left)), Arg.of("right", nativeMap(right)))
+                .waitForStatus(LHStatus.COMPLETED)
+                .thenVerifyVariable(0, "are-equal", variableValue -> assertThat(variableValue.getBool())
+                        .isTrue())
+                .start();
+    }
+
+    @Test
+    public void shouldTreatMapsWithDifferentValuesAsUnequalInWorkflow() throws Exception {
+        Map<String, Long> left = new LinkedHashMap<>();
+        left.put("first", 1L);
+        left.put("second", 2L);
+        Map<String, Long> right = new LinkedHashMap<>();
+        right.put("second", 3L);
+        right.put("first", 1L);
+
+        workflowVerifier
+                .prepareRun(mapEqualityWf, Arg.of("left", nativeMap(left)), Arg.of("right", nativeMap(right)))
+                .waitForStatus(LHStatus.COMPLETED)
+                .thenVerifyVariable(0, "are-equal", variableValue -> assertThat(variableValue.getBool())
+                        .isFalse())
                 .start();
     }
 
@@ -552,6 +594,26 @@ public class MapsTest {
         result.put("hello", 100L);
         result.put("brand-new", 7L);
         return result;
+    }
+
+    @LHWorkflow("map-equality-wf")
+    public Workflow buildMapEqualityWf() {
+        return new WorkflowImpl("map-equality-wf", thread -> {
+            WfRunVariable left =
+                    thread.declareMap("left", String.class, Long.class).required();
+            WfRunVariable right =
+                    thread.declareMap("right", String.class, Long.class).required();
+            WfRunVariable areEqual = thread.declareBool("are-equal");
+            areEqual.assign(left.isEqualTo(right));
+        });
+    }
+
+    private static VariableValue nativeMap(Map<String, Long> map) throws Exception {
+        InlineMapDef mapType = InlineMapDef.newBuilder()
+                .setKeyType(TypeDefinition.newBuilder().setPrimitiveType(VariableType.STR))
+                .setValueType(TypeDefinition.newBuilder().setPrimitiveType(VariableType.INT))
+                .build();
+        return LHLibUtil.objToVarValAsNativeMap(map, mapType, LHTypeAdapterRegistry.empty());
     }
 
     @LHWorkflow("map-nullable-wf")

--- a/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/node/ComparerTest.java
+++ b/server/src/test/java/io/littlehorse/common/model/getable/global/wfspec/node/ComparerTest.java
@@ -1,10 +1,14 @@
 package io.littlehorse.common.model.getable.global.wfspec.node;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.littlehorse.common.model.getable.core.variable.VariableValueModel;
 import io.littlehorse.sdk.common.proto.Array;
+import io.littlehorse.sdk.common.proto.Map;
 import io.littlehorse.sdk.common.proto.VariableValue;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class ComparerTest {
@@ -24,5 +28,81 @@ public class ComparerTest {
         VariableValueModel right = VariableValueModel.fromProto(rightProto, null);
 
         assertTrue(Comparer.contains(left, right));
+    }
+
+    @Test
+    public void shouldConsiderMapsWithReorderedEntriesEqual() throws Exception {
+        VariableValueModel left =
+                mapModelOf(mapEntry(stringValue("first"), intValue(1)), mapEntry(stringValue("second"), intValue(2)));
+        VariableValueModel right =
+                mapModelOf(mapEntry(stringValue("second"), intValue(2)), mapEntry(stringValue("first"), intValue(1)));
+
+        assertEquals(0, Comparer.compare(left, right));
+    }
+
+    @Test
+    public void shouldConsiderMapsWithDifferentContentsUnequal() throws Exception {
+        VariableValueModel left =
+                mapModelOf(mapEntry(stringValue("first"), intValue(1)), mapEntry(stringValue("second"), intValue(2)));
+        VariableValueModel right =
+                mapModelOf(mapEntry(stringValue("second"), intValue(3)), mapEntry(stringValue("first"), intValue(1)));
+
+        assertNotEquals(0, Comparer.compare(left, right));
+    }
+
+    @Test
+    public void shouldCompareMapsWithNullValues() throws Exception {
+        VariableValueModel left = mapModelOf(mapEntry(stringValue("optional"), nullValue()));
+        VariableValueModel equalRight = mapModelOf(mapEntry(stringValue("optional"), nullValue()));
+        VariableValueModel unequalRight = mapModelOf(mapEntry(stringValue("optional"), intValue(1)));
+
+        assertEquals(0, Comparer.compare(left, equalRight));
+        assertNotEquals(0, Comparer.compare(left, unequalRight));
+    }
+
+    @Test
+    public void shouldConsiderNestedMapsWithReorderedEntriesEqual() throws Exception {
+        VariableValueModel left = mapModelOf(
+                mapEntry(
+                        stringValue("outer-a"),
+                        mapValueOf(
+                                mapEntry(stringValue("inner-a"), intValue(1)),
+                                mapEntry(stringValue("inner-b"), intValue(2)))),
+                mapEntry(stringValue("outer-b"), mapValueOf(mapEntry(stringValue("inner-c"), intValue(3)))));
+        VariableValueModel right = mapModelOf(
+                mapEntry(stringValue("outer-b"), mapValueOf(mapEntry(stringValue("inner-c"), intValue(3)))),
+                mapEntry(
+                        stringValue("outer-a"),
+                        mapValueOf(
+                                mapEntry(stringValue("inner-b"), intValue(2)),
+                                mapEntry(stringValue("inner-a"), intValue(1)))));
+
+        assertEquals(0, Comparer.compare(left, right));
+    }
+
+    private static VariableValueModel mapModelOf(Map.Entry... entries) throws Exception {
+        return VariableValueModel.fromProto(mapValueOf(entries), null);
+    }
+
+    private static VariableValue mapValueOf(Map.Entry... entries) {
+        return VariableValue.newBuilder()
+                .setMap(Map.newBuilder().addAllEntries(Arrays.asList(entries)))
+                .build();
+    }
+
+    private static Map.Entry mapEntry(VariableValue key, VariableValue value) {
+        return Map.Entry.newBuilder().setKey(key).setValue(value).build();
+    }
+
+    private static VariableValue stringValue(String value) {
+        return VariableValue.newBuilder().setStr(value).build();
+    }
+
+    private static VariableValue intValue(long value) {
+        return VariableValue.newBuilder().setInt(value).build();
+    }
+
+    private static VariableValue nullValue() {
+        return VariableValue.newBuilder().build();
     }
 }


### PR DESCRIPTION
This PR adds logic to the Comparer class to support Map comparison in LittleHorse. This allows users to compare Map equality in WfSpecs. At the protobuf level Maps store `Entry`s in an ordered list but in this implementation we ignore the ordering during Map comparison.