### PR TITLE
fix(server): fully parse composite global object IDs in metadata search

### DIFF
--- a/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
+++ b/server/src/main/java/io/littlehorse/server/streams/BackendInternalComms.java
@@ -812,8 +812,9 @@ public class BackendInternalComms implements Closeable {
                         ObjectIdModel.fromString(objectIdStr, idCls).toBytes());
             } else {
                 // search for global getables
-                return ByteString.copyFrom(ObjectIdModel.fromString(storeableKey.split("/")[1], idCls)
-                        .toBytes());
+                String objectIdStr = storeableKey.substring(storeableKey.indexOf('/') + 1);
+                return ByteString.copyFrom(
+                        ObjectIdModel.fromString(objectIdStr, idCls).toBytes());
             }
         } else {
             throw new RuntimeException("Impossible: unknown result type");

--- a/server/src/test/java/e2e/QuotaTest.java
+++ b/server/src/test/java/e2e/QuotaTest.java
@@ -173,6 +173,33 @@ public class QuotaTest {
                 DeletePrincipalRequest.newBuilder().setId(principalId).build());
     }
 
+    @Test
+    void shouldIncludePrincipalInQuotaIdWhenSearchingAllQuotas() {
+        String principalName = "search-all-principal-" + UUID.randomUUID();
+        PrincipalId principalId = PrincipalId.newBuilder().setId(principalName).build();
+
+        client.putPrincipal(PutPrincipalRequest.newBuilder()
+                .setId(principalName)
+                .setOverwrite(true)
+                .build());
+
+        Quota principalQuota = client.putQuota(PutQuotaRequest.newBuilder()
+                .setTenant(TenantId.newBuilder().setId(tenantId()))
+                .setPrincipal(principalId)
+                .setWriteRequestsPerSecond(50)
+                .build());
+
+        Awaitility.await().atMost(Duration.ofSeconds(4)).untilAsserted(() -> {
+            QuotaIdList results = client.searchQuota(SearchQuotaRequest.getDefaultInstance());
+            assertThat(results.getResultsList()).contains(principalQuota.getId());
+        });
+
+        client.deleteQuota(
+                DeleteQuotaRequest.newBuilder().setId(principalQuota.getId()).build());
+        client.deletePrincipal(
+                DeletePrincipalRequest.newBuilder().setId(principalId).build());
+    }
+
     /**
      * Sends a burst via a raw client (no retry interceptor), asserts some are throttled,
      * and verifies the first throttled response contains a valid RetryInfo.


### PR DESCRIPTION
This PR fixes global metadata search result parsing in `BackendInternalComms` so composite object IDs are fully preserved. Previously, unfiltered quota searches weren't detecting the Principal of a QuotaId, only the Tenant.

Resolves #2512.