### PR TITLE
chore: update 1.3.0 release notes and bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.3.0-SNAPSHOT
+version=1.3.1-SNAPSHOT
 group=io.littlehorse
 kafkaVersion=4.3.1
 lombokVersion=1.18.42

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.3.1-SNAPSHOT
+version=1.4.0-SNAPSHOT
 group=io.littlehorse
 kafkaVersion=4.3.1
 lombokVersion=1.18.42

--- a/release_notes/1.3.0.md
+++ b/release_notes/1.3.0.md
@@ -7,6 +7,7 @@ LittleHorse 1.3.0 brings the JavaScript/TypeScript SDK to broad feature parity w
 ### Server
 
 - Added a per-`WfRun` thread queue. When a workflow reaches its configured active `ThreadRun` limit, additional threads are queued instead of failing the run; completed thread details can also be archived to bound the active run state. #2379
+- Added inline `StructDef` type definitions, allowing schemas to be embedded directly in workflow and task definitions or nested within other Structs without registering a separate, named `StructDef`. #2519
 - Added inline Map construction and Map mutation support, including key-based `put` operations and Map comparisons in `WfSpec` conditions. #2442, #2443
 - Struct variables can now evolve to newer compatible `StructDef` versions without requiring every referencing `WfSpec` to be updated first. #2487
 - `StructFieldDef` fields can now include descriptions, with support across the server, SDK annotations, generated types, and dashboard forms. #2485
@@ -25,11 +26,14 @@ LittleHorse 1.3.0 brings the JavaScript/TypeScript SDK to broad feature parity w
 ### Java SDK
 
 - Added `LHMapBuilder` and Map `put` operations for constructing and mutating Map values directly in workflows. #2443
+- Unannotated POJOs can now be inferred, serialized, and deserialized as inline `StructDef` values for workflow variables, task inputs and outputs, and nested Struct fields. #2519
 - Struct placeholder templates now support default field values. #2450
 
 ### Dashboard
 
 - Upgraded the dashboard to Next.js 16 and React 19. #2419
+- Added a quota usage page with charts for inspecting applicable limits and consumption over selectable time windows. #2510
+- Added support for displaying and entering inline Struct values in workflow execution forms and type views. #2519
 - Improved Struct input forms to display field descriptions and type information. #2485
 - Child workflow nodes now use a distinct box shape, making workflow diagrams easier to read. #2470
 
@@ -42,6 +46,7 @@ LittleHorse 1.3.0 brings the JavaScript/TypeScript SDK to broad feature parity w
 
 ### Server
 
+- Metadata searches now preserve complete composite global object IDs, ensuring results such as principal-scoped Quota IDs are returned correctly. #2513
 - StructDef descriptions can now be updated, and updates correctly bump the StructDef version. #2452, #2454
 - Edge compare expressions are evaluated against buffered mutations, preventing out-of-order mutation results. #2448
 - The metadata cache now uses bounded LRU eviction to prevent unbounded memory growth. #2397


### PR DESCRIPTION
This PR updates the 1.3.0 release notes and bumps the `gradle.properties` snapshot version