### PR TITLE
fix(server): do not publish bulkjob shard progress every punctuation

### DIFF
--- a/server/src/main/java/io/littlehorse/common/LHServerConfig.java
+++ b/server/src/main/java/io/littlehorse/common/LHServerConfig.java
@@ -1018,7 +1018,7 @@ public class LHServerConfig extends ConfigBase {
 
         // We want a request to be able to fail and be handled (if non-fatal) before a transaction times out.
         // Therefore, request timeout should be less than transaction timeout / session timeout.
-        props.put("request.timeout.ms", (int) (getStreamsSessionTimeout() * 0.75));
+        props.put("request.timeout.ms", (int) (getStreamsSessionTimeout() * 0.30));
         props.put("producer.acks", "all");
         props.put("replication.factor", (int) getReplicationFactor());
         props.put("num.standby.replicas", Integer.valueOf(getOrSetDefault(NUM_STANDBY_REPLICAS_KEY, "0")));

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/processors/BulkJobScanJob.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/processors/BulkJobScanJob.java
@@ -24,9 +24,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.streams.processor.api.Record;
@@ -60,6 +63,12 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
     private static final Duration INTERVAL = Duration.ofSeconds(1);
 
     /**
+     * BulkJob is metadata, so every shard report is sent through the single metadata partition.
+     * Keep the most recent progress in memory and publish it at a bounded rate.
+     */
+    private static final Duration PROGRESS_REPORT_INTERVAL = Duration.ofMinutes(1);
+
+    /**
      * Bounds how long a single pass may run. This no longer protects a Kafka transaction; it caps how
      * long the job holds IQ iterators open and how stale its enqueued actions can get before the
      * punctuator applies them.
@@ -75,10 +84,18 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
      */
     private final long maxCommandsPerRun;
 
-    /**
-     * Source of "now" for the budget. Injectable so tests can drive the deadline deterministically.
-     */
+    /** Source of "now" for the scan budget and report cadence. Injectable for deterministic tests. */
     private final Supplier<Instant> clock;
+
+    /**
+     * Latest report for each tenant/job pair on this core partition. These are retained after a
+     * timed send so {@link #flushPendingReports(Consumer)} can recover a report that was queued but
+     * not committed before partition revocation.
+     */
+    private final Map<String, ShardProgress> shardProgress = new HashMap<>();
+
+    /** Last time each shard's latest progress was queued for the metadata topology. */
+    private final Map<String, Instant> lastReportAt = new HashMap<>();
 
     public BulkJobScanJob(LHServerConfig config) {
         this(config, DEFAULT_SCAN_BUDGET, config.getMaxBulkJobCommandsPerTick(), Instant::now);
@@ -111,10 +128,11 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
         for (ActiveBulkJobModel runningJob : findRunningJobs(ctx)) {
             if (outOfBudget.getAsBoolean()) {
                 log.debug("Scan budget exhausted, will resume remaining jobs on next tick");
-                return;
+                break;
             }
             advanceShard(ctx, runningJob, outOfBudget, remainingCommandBudget);
         }
+        flushDueShardReports(ctx);
     }
 
     /**
@@ -150,10 +168,12 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
         StoredGetable<?, ?> storedJob = metadataStore.get(bulkJobId.getStoreableKey(), StoredGetable.class);
         if (storedJob == null) {
             // Metadata object not propagated yet; it will be picked up on a later tick.
+            discardProgress(tenantId, bulkJobId);
             return;
         }
         BulkJobModel job = (BulkJobModel) storedJob.getStoredObject();
         if (job.getStatus() != BulkJobStatus.BULK_JOB_RUNNING) {
+            discardProgress(tenantId, bulkJobId);
             return;
         }
 
@@ -161,6 +181,9 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
         BulkJobShardCursorModel cursor = coreStore.get(newCursor.getStoreKey(), BulkJobShardCursorModel.class);
         cursor = cursor == null ? newCursor : cursor;
         if (cursor.isScanCompleted()) {
+            // A prior owner may have committed this cursor before its deferred metadata report.
+            // Re-buffer it so the new owner can publish the completion immediately.
+            recordShardProgress(ctx, job, cursor, tenantId);
             return;
         }
 
@@ -173,25 +196,80 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
                 outOfBudget,
                 remainingCommandBudget);
 
-        ctx.forward(shardReport(ctx, job, cursor, tenantId));
+        recordShardProgress(ctx, job, cursor, tenantId);
         ctx.put(tenantId, cursor);
-        // One shard advance is one atomic unit: the delete commands, the shard report and the
-        // cursor must land together. A report claiming the shard is complete, applied without the
-        // deletes that back it up, would retire WfRuns that were never touched.
+        // One shard advance is one atomic unit: the delete commands and cursor must land together.
+        // The metadata report is intentionally published separately and may lag by up to a minute.
         ctx.submit();
     }
 
-    private Record<String, CommandProcessorOutput> shardReport(
+    /**
+     * Queues the latest report for each shard whose rate limit has elapsed. This runs on the worker
+     * thread; the resulting actions are still forwarded only by the Kafka Streams thread.
+     */
+    private void flushDueShardReports(PartitionJobContext<CommandProcessorOutput> ctx) throws InterruptedException {
+        Instant now = clock.get();
+        List<String> dueReports = shardProgress.keySet().stream()
+                .filter(key -> isReportDue(key, now))
+                .toList();
+
+        for (String key : dueReports) {
+            ctx.forward(toRecord(shardProgress.get(key)));
+        }
+        if (!dueReports.isEmpty()) {
+            ctx.submit();
+            dueReports.forEach(key -> lastReportAt.put(key, now));
+        }
+    }
+
+    /**
+     * Called by {@link CommandProcessor#close()} after the worker has stopped. Reports sent through
+     * the scheduler but not committed are discarded on revocation, so resend the latest state
+     * directly from the closing Streams thread.
+     */
+    void flushPendingReports(Consumer<Record<String, CommandProcessorOutput>> commandOutput) {
+        shardProgress.values().forEach(progress -> commandOutput.accept(toRecord(progress)));
+        shardProgress.clear();
+        lastReportAt.clear();
+    }
+
+    private boolean isReportDue(String key, Instant now) {
+        Instant lastReport = lastReportAt.get(key);
+        return lastReport == null || !now.isBefore(lastReport.plus(PROGRESS_REPORT_INTERVAL));
+    }
+
+    private void discardProgress(TenantIdModel tenantId, BulkJobIdModel bulkJobId) {
+        String progressKey = progressKey(tenantId, bulkJobId);
+        shardProgress.remove(progressKey);
+        lastReportAt.remove(progressKey);
+    }
+
+    private String progressKey(TenantIdModel tenantId, BulkJobIdModel bulkJobId) {
+        return tenantId.getId() + "/" + bulkJobId.getId();
+    }
+
+    private void recordShardProgress(
             PartitionJobContext<CommandProcessorOutput> ctx,
             BulkJobModel job,
             BulkJobShardCursorModel cursor,
             TenantIdModel tenantId) {
+        shardProgress.put(
+                progressKey(tenantId, job.getId()), new ShardProgress(tenantId, shardReport(ctx, job, cursor)));
+    }
+
+    private BulkJobShardReportModel shardReport(
+            PartitionJobContext<CommandProcessorOutput> ctx, BulkJobModel job, BulkJobShardCursorModel cursor) {
         BulkJobShardReportModel report = new BulkJobShardReportModel(
                 job.getId(),
                 ctx.partition(),
                 cursor.isScanCompleted(),
                 cursor.getLastKey(),
                 cursor.getLastSeenTimestamp());
+        return report;
+    }
+
+    private Record<String, CommandProcessorOutput> toRecord(ShardProgress progress) {
+        BulkJobShardReportModel report = progress.report();
         MetadataCommandModel command = new MetadataCommandModel(report);
         CommandProcessorOutput output =
                 new CommandProcessorOutput(config.getMetadataCmdTopicName(), command, command.getPartitionKey());
@@ -199,8 +277,11 @@ public class BulkJobScanJob implements PartitionBackgroundJob<CommandProcessorOu
                 output.partitionKey,
                 output,
                 System.currentTimeMillis(),
-                HeadersUtil.metadataHeadersFor(tenantId, new PrincipalIdModel(LHConstants.ANONYMOUS_PRINCIPAL)));
+                HeadersUtil.metadataHeadersFor(
+                        progress.tenantId(), new PrincipalIdModel(LHConstants.ANONYMOUS_PRINCIPAL)));
     }
+
+    private record ShardProgress(TenantIdModel tenantId, BulkJobShardReportModel report) {}
 
     /**
      * {@code BulkJobModel.tryToComplete} takes a raw {@code Consumer<Record>} for historical reasons;

--- a/server/src/main/java/io/littlehorse/server/streams/topology/core/processors/CommandProcessor.java
+++ b/server/src/main/java/io/littlehorse/server/streams/topology/core/processors/CommandProcessor.java
@@ -254,6 +254,9 @@ public class CommandProcessor implements Processor<String, Command, String, Comm
             backgroundScheduler.close();
             backgroundScheduler = null;
         }
+        if (bulkJobScanJob != null) {
+            bulkJobScanJob.flushPendingReports(ctx::forward);
+        }
         if (partitionIsClaimed) {
             this.partitionDrain.reset();
         }

--- a/server/src/test/java/e2e/WfRunBulkDeletion.java
+++ b/server/src/test/java/e2e/WfRunBulkDeletion.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 @Tag("slow")
 public class WfRunBulkDeletion {
 
+    private static final int BULK_JOB_COMPLETION_TIMEOUT_SECONDS = 90;
+
     private LittleHorseGrpc.LittleHorseBlockingStub client;
     private WorkflowVerifier verifier;
 
@@ -115,8 +117,8 @@ public class WfRunBulkDeletion {
     }
 
     private BulkJob waitForBulkJobCompletion(BulkJobId jobId) throws InterruptedException {
-        // The punctuator runs on a 1s schedule; poll until the job reaches a terminal state.
-        for (int i = 0; i < 40; i++) {
+        // The scan runs every second, but shard progress reaches metadata at most once per minute.
+        for (int i = 0; i < BULK_JOB_COMPLETION_TIMEOUT_SECONDS; i++) {
             BulkJob job = client.getBulkJob(
                     GetBulkJobRequest.newBuilder().setId(jobId).build());
             if (job.getStatus() != BulkJobStatus.BULK_JOB_RUNNING) {

--- a/server/src/test/java/io/littlehorse/server/streams/topology/core/processors/BulkJobScanJobTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/topology/core/processors/BulkJobScanJobTest.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
@@ -165,6 +166,36 @@ public class BulkJobScanJobTest {
             assertThat(report.isCompleted()).isTrue();
             assertThat(report.getPartition()).isEqualTo(TASK_ID.partition());
         });
+    }
+
+    @Test
+    void shouldRateLimitReportsAndFlushLatestProgressOnClose() throws Exception {
+        String jobId = LHUtil.generateGuid();
+        AtomicReference<Instant> now = new AtomicReference<>(Instant.parse("2026-01-01T00:00:00Z"));
+        BulkJobScanJob throttledJob = newJob(UNLIMITED_TIME_BUDGET, UNLIMITED_COMMAND_BUDGET, now::get);
+        seedRunningJob(jobId, emptyMatchDelete());
+
+        runAndApply(throttledJob);
+        assertThat(forwardedShardReports()).hasSize(1);
+
+        mockProcessorContext.resetForwards();
+        markCursorIncomplete(jobId);
+        now.set(now.get().plusSeconds(30));
+        runAndApply(throttledJob);
+        assertThat(forwardedShardReports()).isEmpty();
+
+        now.set(now.get().plusSeconds(30));
+        runAndApply(throttledJob);
+        assertThat(forwardedShardReports()).hasSize(1);
+
+        mockProcessorContext.resetForwards();
+        markCursorIncomplete(jobId);
+        now.set(now.get().plusSeconds(30));
+        runAndApply(throttledJob);
+        assertThat(forwardedShardReports()).isEmpty();
+
+        throttledJob.flushPendingReports(mockProcessorContext::forward);
+        assertThat(forwardedShardReports()).hasSize(1);
     }
 
     @Test
@@ -425,6 +456,13 @@ public class BulkJobScanJobTest {
         // Tags are co-partitioned with the WfRun in the tenant-scoped CORE store.
         tenantCoreStore.put(tag);
         return tag;
+    }
+
+    private void markCursorIncomplete(String jobId) {
+        BulkJobShardCursorModel cursor = tenantCoreStore.get(
+                new BulkJobShardCursorModel(new BulkJobIdModel(jobId)).getStoreKey(), BulkJobShardCursorModel.class);
+        cursor.setScanCompleted(false);
+        tenantCoreStore.put(cursor);
     }
 
     private List<String> forwardedDeletedWfRunIds() {

--- a/server/src/test/java/io/littlehorse/server/streams/topology/core/processors/CommandProcessorTest.java
+++ b/server/src/test/java/io/littlehorse/server/streams/topology/core/processors/CommandProcessorTest.java
@@ -184,6 +184,17 @@ public class CommandProcessorTest {
         assertThat(timer.topic).isEqualTo("core-cmd");
     }
 
+    @Test
+    void shouldFlushBulkJobProgressOnClose() throws Exception {
+        commandProcessor.init(mockProcessorContext);
+        BulkJobScanJob bulkJobScanJob = mock();
+        setField(commandProcessor, "bulkJobScanJob", bulkJobScanJob);
+
+        commandProcessor.close();
+
+        verify(bulkJobScanJob).flushPendingReports(any());
+    }
+
     @SuppressWarnings("unchecked")
     private PartitionLocalBuffer<PartitionMetricWindowModel> getMetricWindows() throws Exception {
         return (PartitionLocalBuffer<PartitionMetricWindowModel>) getField(commandProcessor, "metricWindows");


### PR DESCRIPTION
This fixes the root cause of several outages in my soak cluster with bulk jobs spamming the metadata processor with bulk shard updates. Instead, we push updates every 60 seconds.